### PR TITLE
Implement basic pagination

### DIFF
--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -86,7 +86,7 @@ public class Client {
 
 	static func loadPrivateKeys(for account: SigningKey, apiClient: ApiClient) async throws -> PrivateKeyBundleV1? {
 		let topics: [Topic] = [.userPrivateStoreKeyBundle(account.address)]
-		let res = try await apiClient.query(topics: topics)
+		let res = try await apiClient.query(topics: topics, pagination: nil)
 
 		for envelope in res.envelopes {
 			do {
@@ -156,8 +156,8 @@ public class Client {
 		_ = try await publish(envelopes: envelopes)
 	}
 
-	func query(topics: [Topic]) async throws -> QueryResponse {
-		return try await apiClient.query(topics: topics)
+	func query(topics: [Topic], pagination: Pagination? = nil) async throws -> QueryResponse {
+		return try await apiClient.query(topics: topics, pagination: pagination)
 	}
 
 	@discardableResult func publish(envelopes: [Envelope]) async throws -> PublishResponse {

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -46,10 +46,6 @@ public struct ConversationV2 {
 		self.header = header
 	}
 
-//	func messages(pageSize: Int) async throws -> AsyncThrowingStream<[DecodedMessage], Error> {
-//
-//	}
-
 	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, startTime: before, endTime: after)
 

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -46,8 +46,14 @@ public struct ConversationV2 {
 		self.header = header
 	}
 
-	func messages() async throws -> [DecodedMessage] {
-		let envelopes = try await client.apiClient.query(topics: [topic]).envelopes
+//	func messages(pageSize: Int) async throws -> AsyncThrowingStream<[DecodedMessage], Error> {
+//
+//	}
+
+	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
+		let pagination = Pagination(limit: limit, startTime: before, endTime: after)
+
+		let envelopes = try await client.apiClient.query(topics: [topic], pagination: pagination).envelopes
 
 		return envelopes.compactMap { envelope in
 			do {
@@ -78,8 +84,7 @@ public struct ConversationV2 {
 		try MessageV2.decode(message, keyMaterial: keyMaterial)
 	}
 
-	// TODO: more types of content
-	func send(content: String, options _: SendOptions? = nil) async throws {
+	internal func send(content: String, sentAt: Date) async throws {
 		guard try await client.getUserContact(peerAddress: peerAddress) != nil else {
 			throw ContactBundleError.notFound
 		}
@@ -92,7 +97,12 @@ public struct ConversationV2 {
 		)
 
 		try await client.publish(envelopes: [
-			Envelope(topic: topic, timestamp: Date(), message: try Message(v2: message).serializedData()),
+			Envelope(topic: topic, timestamp: sentAt, message: try Message(v2: message).serializedData()),
 		])
+	}
+
+	// TODO: more types of content
+	func send(content: String) async throws {
+		try await send(content: content, sentAt: Date())
 	}
 }

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -45,6 +45,7 @@ public struct Conversations {
 		// See if we have a v2 conversation
 		for sealedInvitation in try await listInvitations() {
 			if !sealedInvitation.involves(contact) {
+				print("does not involve me")
 				continue
 			}
 
@@ -153,7 +154,7 @@ public struct Conversations {
 	func listIntroductionPeers() async throws -> [String: Date] {
 		let envelopes = try await client.apiClient.query(topics: [
 			.userIntro(client.address),
-		]).envelopes
+		], pagination: nil).envelopes
 
 		let messages = envelopes.compactMap { envelope in
 			do {
@@ -195,7 +196,7 @@ public struct Conversations {
 	func listInvitations() async throws -> [SealedInvitation] {
 		let envelopes = try await client.apiClient.query(topics: [
 			.userInvite(client.address),
-		]).envelopes
+		], pagination: nil).envelopes
 
 		return envelopes.compactMap { envelope in
 			// swiftlint:disable no_optional_try

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -45,7 +45,6 @@ public struct Conversations {
 		// See if we have a v2 conversation
 		for sealedInvitation in try await listInvitations() {
 			if !sealedInvitation.involves(contact) {
-				print("does not involve me")
 				continue
 			}
 

--- a/Sources/XMTP/Messages/MessageV1.swift
+++ b/Sources/XMTP/Messages/MessageV1.swift
@@ -82,7 +82,7 @@ extension MessageV1 {
 
 	var sentAt: Date {
 		// swiftlint:disable force_try
-		try! Date(timeIntervalSince1970: Double(header.timestamp))
+		try! Date(timeIntervalSince1970: Double(header.timestamp / 1000))
 		// swiftlint:enable force_try
 	}
 

--- a/Sources/XMTP/Messages/MessageV2.swift
+++ b/Sources/XMTP/Messages/MessageV2.swift
@@ -31,7 +31,7 @@ extension MessageV2 {
 			return DecodedMessage(
 				body: decoded,
 				senderAddress: try signed.sender.walletAddress,
-				sent: Date(timeIntervalSince1970: Double(header.createdNs) / 1_000_000)
+				sent: Date(timeIntervalSince1970: Double(header.createdNs / 1_000_000) / 1000)
 			)
 		} catch {
 			print("ERROR DECODING: \(error)")

--- a/Sources/XMTP/Messages/PagingInfo.swift
+++ b/Sources/XMTP/Messages/PagingInfo.swift
@@ -1,0 +1,65 @@
+//
+//  PagingInfo.swift
+//
+//
+//  Created by Pat Nakajima on 12/15/22.
+//
+
+import Foundation
+import XMTPProto
+
+typealias PagingInfo = Xmtp_MessageApi_V1_PagingInfo
+typealias PagingInfoCursor = Xmtp_MessageApi_V1_Cursor
+typealias PagingInfoSortDirection = Xmtp_MessageApi_V1_SortDirection
+
+struct Pagination {
+	var limit: Int?
+	var direction: PagingInfoSortDirection?
+	var startTime: Date?
+	var endTime: Date?
+
+	var pagingInfo: PagingInfo {
+		var info = PagingInfo()
+
+		if let limit {
+			info.limit = UInt32(limit)
+		}
+
+		if let direction {
+			info.direction = direction
+		}
+
+		return info
+	}
+}
+
+extension PagingInfo {
+//	/// Note: this is a uint32, while go-waku's pageSize is a uint64
+//	public var limit: UInt32 = 0
+//
+//	public var cursor: Xmtp_MessageApi_V1_Cursor {
+//		get {return _cursor ?? Xmtp_MessageApi_V1_Cursor()}
+//		set {_cursor = newValue}
+//	}
+//	/// Returns true if `cursor` has been explicitly set.
+//	public var hasCursor: Bool {return self._cursor != nil}
+//	/// Clears the value of `cursor`. Subsequent reads from it will return its default value.
+//	public mutating func clearCursor() {self._cursor = nil}
+//
+//	public var direction: Xmtp_MessageApi_V1_SortDirection = .unspecified
+	init(limit: Int? = nil, cursor: PagingInfoCursor? = nil, direction: PagingInfoSortDirection? = nil) {
+		self.init()
+
+		if let limit {
+			self.limit = UInt32(limit)
+		}
+
+		if let cursor {
+			self.cursor = cursor
+		}
+
+		if let direction {
+			self.direction = direction
+		}
+	}
+}

--- a/Sources/XMTP/Messages/PagingInfo.swift
+++ b/Sources/XMTP/Messages/PagingInfo.swift
@@ -34,19 +34,6 @@ struct Pagination {
 }
 
 extension PagingInfo {
-//	/// Note: this is a uint32, while go-waku's pageSize is a uint64
-//	public var limit: UInt32 = 0
-//
-//	public var cursor: Xmtp_MessageApi_V1_Cursor {
-//		get {return _cursor ?? Xmtp_MessageApi_V1_Cursor()}
-//		set {_cursor = newValue}
-//	}
-//	/// Returns true if `cursor` has been explicitly set.
-//	public var hasCursor: Bool {return self._cursor != nil}
-//	/// Clears the value of `cursor`. Subsequent reads from it will return its default value.
-//	public mutating func clearCursor() {self._cursor = nil}
-//
-//	public var direction: Xmtp_MessageApi_V1_SortDirection = .unspecified
 	init(limit: Int? = nil, cursor: PagingInfoCursor? = nil, direction: PagingInfoSortDirection? = nil) {
 		self.init()
 

--- a/Sources/XMTP/Messages/SignedPublicKey.swift
+++ b/Sources/XMTP/Messages/SignedPublicKey.swift
@@ -13,7 +13,7 @@ import XMTPProto
 typealias SignedPublicKey = Xmtp_MessageContents_SignedPublicKey
 
 extension SignedPublicKey {
-	static func fromLegacy(_ legacyKey: PublicKey, signedByWallet: Bool? = false) throws -> SignedPublicKey {
+	static func fromLegacy(_ legacyKey: PublicKey, signedByWallet _: Bool? = false) throws -> SignedPublicKey {
 		var signedPublicKey = SignedPublicKey()
 
 		var publicKey = PublicKey()

--- a/Tests/XMTPTests/IntegrationTests.swift
+++ b/Tests/XMTPTests/IntegrationTests.swift
@@ -367,7 +367,6 @@ final class IntegrationTests: XCTestCase {
 		XCTAssertEqual(1, messages.count)
 		let nowMessage = messages[0]
 		XCTAssertEqual("now", nowMessage.body)
-		print("now message sent \(nowMessage.sent)")
 
 		let messages2 = try await convo.messages(limit: 1, before: nowMessage.sent)
 		XCTAssertEqual(1, messages2.count)
@@ -402,15 +401,10 @@ final class IntegrationTests: XCTestCase {
 		try await convo.send(content: "10 seconds ago", sentAt: tenSecondsAgo)
 		try await convo.send(content: "now")
 
-		let all = try await convo.messages()
-		print("all: \(all)")
-
 		let messages = try await convo.messages(limit: 1)
 		XCTAssertEqual(1, messages.count)
 		let nowMessage = messages[0]
 		XCTAssertEqual("now", nowMessage.body)
-
-		print("now message sent: \(nowMessage.sent)")
 
 		let messages2 = try await convo.messages(limit: 1, before: nowMessage.sent)
 		XCTAssertEqual(1, messages2.count)

--- a/Tests/XMTPTests/IntegrationTests.swift
+++ b/Tests/XMTPTests/IntegrationTests.swift
@@ -343,4 +343,83 @@ final class IntegrationTests: XCTestCase {
 
 		await waitForExpectations(timeout: 3)
 	}
+
+	func testCanPaginateV1Messages() async throws {
+		throw XCTSkip("integration only (requires local node)")
+
+		let bob = try FakeWallet.generate()
+		let alice = try FakeWallet.generate()
+
+		let options = ClientOptions(api: ClientOptions.Api(env: .local, isSecure: false))
+		let bobClient = try await Client.create(account: bob, options: options)
+
+		// Publish alice's contact
+		_ = try await Client.create(account: alice, options: options)
+
+		let convo = ConversationV1(client: bobClient, peerAddress: alice.address, sentAt: Date())
+
+		// Say this message is sent in the past
+		try await convo.send(content: "10 seconds ago", sentAt: Date().addingTimeInterval(-10))
+
+		try await convo.send(content: "now")
+
+		let messages = try await convo.messages(limit: 1)
+		XCTAssertEqual(1, messages.count)
+		let nowMessage = messages[0]
+		XCTAssertEqual("now", nowMessage.body)
+		print("now message sent \(nowMessage.sent)")
+
+		let messages2 = try await convo.messages(limit: 1, before: nowMessage.sent)
+		XCTAssertEqual(1, messages2.count)
+		let tenSecondsAgoMessage = messages2[0]
+		XCTAssertEqual("10 seconds ago", tenSecondsAgoMessage.body)
+
+		let messages3 = try await convo.messages(limit: 1, after: tenSecondsAgoMessage.sent)
+		XCTAssertEqual(1, messages3.count)
+		let nowMessage2 = messages3[0]
+		XCTAssertEqual("now", nowMessage2.body)
+	}
+
+	func testCanPaginateV2Messages() async throws {
+		throw XCTSkip("integration only (requires local node)")
+
+		let bob = try FakeWallet.generate()
+		let alice = try FakeWallet.generate()
+
+		let options = ClientOptions(api: ClientOptions.Api(env: .local, isSecure: false))
+		let bobClient = try await Client.create(account: bob, options: options)
+
+		// Publish alice's contact
+		_ = try await Client.create(account: alice, options: options)
+
+		guard case let .v2(convo) = try await bobClient.conversations.newConversation(with: alice.address) else {
+			XCTFail("Did not get a v2 convo")
+			return
+		}
+
+		// Say this message is sent in the past
+		let tenSecondsAgo = Date().addingTimeInterval(-10)
+		try await convo.send(content: "10 seconds ago", sentAt: tenSecondsAgo)
+		try await convo.send(content: "now")
+
+		let all = try await convo.messages()
+		print("all: \(all)")
+
+		let messages = try await convo.messages(limit: 1)
+		XCTAssertEqual(1, messages.count)
+		let nowMessage = messages[0]
+		XCTAssertEqual("now", nowMessage.body)
+
+		print("now message sent: \(nowMessage.sent)")
+
+		let messages2 = try await convo.messages(limit: 1, before: nowMessage.sent)
+		XCTAssertEqual(1, messages2.count)
+		let tenSecondsAgoMessage = messages2[0]
+		XCTAssertEqual("10 seconds ago", tenSecondsAgoMessage.body)
+
+		let messages3 = try await convo.messages(limit: 1, after: tenSecondsAgoMessage.sent)
+		XCTAssertEqual(1, messages3.count)
+		let nowMessage2 = messages3[0]
+		XCTAssertEqual("now", nowMessage2.body)
+	}
 }


### PR DESCRIPTION
This adds the ability to specify a `limit` when fetching messages as well as `before` and `after` date params.

I diverged a bit from how the JS SDK does things here, since I thought adding another async iterator felt like overkill for basic pagination needs. Happy to revisit this decision if anyone disagrees though. 

This PR also fixes a bug where message `sent` times were way in the future (E2E tests ftw).