### PR TITLE
Improve docs

### DIFF
--- a/Sources/XMTP/ApiClient.swift
+++ b/Sources/XMTP/ApiClient.swift
@@ -22,7 +22,7 @@ protocol ApiClient {
 	func subscribe(topics: [String]) -> AsyncThrowingStream<Envelope, Error>
 }
 
-public class GRPCApiClient: ApiClient {
+class GRPCApiClient: ApiClient {
 	let ClientVersionHeaderKey = "X-Client-Version"
 	let AppVersionHeaderKey = "X-App-Version"
 

--- a/Sources/XMTP/Contacts.swift
+++ b/Sources/XMTP/Contacts.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Provides access to contact bundles.
 public struct Contacts {
 	var client: Client
 

--- a/Sources/XMTP/Conversation.swift
+++ b/Sources/XMTP/Conversation.swift
@@ -8,10 +8,12 @@
 import Foundation
 import XMTPProto
 
+/// Wrapper that provides a common interface between ``ConversationV1`` and ``ConversationV2`` objects.
 public enum Conversation {
 	// TODO: It'd be nice to not have to expose these types as public, maybe we make this a struct with an enum prop instead of just an enum
 	case v1(ConversationV1), v2(ConversationV2)
 
+	/// The wallet address of the other person in this conversation.
 	public var peerAddress: String {
 		switch self {
 		case let .v1(conversationV1):
@@ -21,6 +23,9 @@ public enum Conversation {
 		}
 	}
 
+	/// An optional string that can specify a different context for a conversation with another account address.
+	///
+	/// > Note: ``conversationID`` is only available for ``ConversationV2`` conversations.
 	public var conversationID: String? {
 		switch self {
 		case .v1:
@@ -30,6 +35,7 @@ public enum Conversation {
 		}
 	}
 
+	/// Send a message to the conversation
 	public func send(text: String) async throws {
 		switch self {
 		case let .v1(conversationV1):
@@ -39,6 +45,7 @@ public enum Conversation {
 		}
 	}
 
+	/// The topic identifier for this conversation
 	public var topic: String {
 		switch self {
 		case let .v1(conversation):
@@ -48,6 +55,10 @@ public enum Conversation {
 		}
 	}
 
+	/// Returns a stream you can iterate through to receive new messages in this conversation.
+	///
+	/// > Note: All messages in the conversation are returned by this stream. If you want to filter out messages
+	/// by a sender, you can check the ``Client`` address against the message's ``peerAddress``.
 	public func streamMessages() -> AsyncThrowingStream<DecodedMessage, Error> {
 		switch self {
 		case let .v1(conversation):
@@ -57,6 +68,7 @@ public enum Conversation {
 		}
 	}
 
+	/// List messages in the conversation
 	public func messages() async throws -> [DecodedMessage] {
 		switch self {
 		case let .v1(conversationV1):
@@ -76,7 +88,7 @@ public enum Conversation {
 	}
 }
 
-extension Conversation: Hashable {
+extension Conversation: Hashable, Equatable {
 	public static func == (lhs: Conversation, rhs: Conversation) -> Bool {
 		lhs.topic == rhs.topic
 	}

--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Handles legacy message conversations.
 public struct ConversationV1 {
 	var client: Client
 	var peerAddress: String

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -11,6 +11,7 @@ import XMTPProto
 
 struct SendOptions {}
 
+/// Handles V2 Message conversations.
 public struct ConversationV2 {
 	var topic: String
 	var keyMaterial: Data // MUST be kept secret

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -12,6 +12,7 @@ public enum ConversationError: Error {
 	case recipientNotOnNetwork
 }
 
+/// Handles listing and creating Conversations.
 public struct Conversations {
 	var client: Client
 	var conversations: [Conversation] = []

--- a/Sources/XMTP/DecodedMessage.swift
+++ b/Sources/XMTP/DecodedMessage.swift
@@ -7,9 +7,15 @@
 
 import Foundation
 
+/// Decrypted messages from a conversation.
 public struct DecodedMessage {
+	/// The text of a message
 	public var body: String
+
+	/// The wallet address of the sender of the message
 	public var senderAddress: String
+
+	/// When the message was sent
 	public var sent: Date
 
 	public init(body: String, senderAddress: String, sent: Date) {

--- a/Sources/XMTP/Messages/Invitation.swift
+++ b/Sources/XMTP/Messages/Invitation.swift
@@ -8,6 +8,7 @@
 import Foundation
 import XMTPProto
 
+/// Handles topic generation for conversations.
 public typealias InvitationV1 = Xmtp_MessageContents_InvitationV1
 
 extension InvitationV1 {
@@ -45,6 +46,7 @@ extension InvitationV1 {
 	}
 }
 
+/// Allows for additional data to be attached to V2 conversations
 public extension InvitationV1.Context {
 	init(conversationID: String = "", metadata: [String: String] = [:]) {
 		self.init()

--- a/Sources/XMTP/Messages/Message.swift
+++ b/Sources/XMTP/Messages/Message.swift
@@ -7,6 +7,7 @@
 
 import XMTPProto
 
+/// Handles encryption/decryption for communicating data in conversations
 public typealias Message = Xmtp_MessageContents_Message
 
 public enum MessageVersion: String, RawRepresentable {

--- a/Sources/XMTP/Messages/PrivateKey.swift
+++ b/Sources/XMTP/Messages/PrivateKey.swift
@@ -9,6 +9,8 @@ import Foundation
 import secp256k1
 import XMTPProto
 
+/// Represents a secp256k1 private key.  ``PrivateKey`` conforms to ``SigningKey`` so you can use it
+/// to create a ``Client``.
 public typealias PrivateKey = Xmtp_MessageContents_PrivateKey
 
 enum PrivateKeyError: Error {

--- a/Sources/XMTP/Messages/Signature.swift
+++ b/Sources/XMTP/Messages/Signature.swift
@@ -9,13 +9,15 @@ import Foundation
 import secp256k1
 import XMTPProto
 
+/// Represents a secp256k1 compact recoverable signature.
 public typealias Signature = Xmtp_MessageContents_Signature
 
 enum SignatureError: Error {
 	case invalidMessage
 }
 
-extension Signature {
+public extension Signature {
+	/// Generate Ethereum personal signature text from a message
 	static func ethPersonalMessage(_ message: String) throws -> Data {
 		let prefix = "\u{19}Ethereum Signed Message:\n\(message.count)"
 
@@ -31,7 +33,9 @@ extension Signature {
 
 		return data
 	}
+}
 
+extension Signature {
 	static func ethHash(_ message: String) throws -> Data {
 		let data = try ethPersonalMessage(message)
 

--- a/Sources/XMTP/SigningKey.swift
+++ b/Sources/XMTP/SigningKey.swift
@@ -8,10 +8,22 @@
 import Foundation
 import secp256k1
 
-// Anything that can sign should be a SigningKey (like a private key or a wallet).
+/// Defines a type that is used by a ``Client`` to sign keys and messages.
+///
+/// You can use ``Account`` for an easier WalletConnect flow, or ``PrivateKey``
+/// for quick key generation.
+///
+/// > Tip: You can make your own object that conforms to ``SigningKey`` if you want to
+/// handle key management yourself.
 public protocol SigningKey {
+	/// A wallet address for this key
 	var address: String { get }
+
+	/// Sign the data and return a secp256k1 compact recoverable signature.
 	func sign(_ data: Data) async throws -> Signature
+
+	/// Pass a personal Ethereum signed message string text to be signed, returning
+	/// a secp256k1 compact recoverable signature. You can use ``Signature.ethPersonalMessage`` to generate this text.
 	func sign(message: String) async throws -> Signature
 }
 

--- a/Sources/XMTP/Wallet/Account.swift
+++ b/Sources/XMTP/Wallet/Account.swift
@@ -8,9 +8,12 @@
 import Foundation
 import UIKit
 
+/// Wrapper around a WalletConnect V1 wallet connection. Account conforms to ``SigningKey`` so
+/// you can use it to create a ``Client``.
+///
+/// > Warning: The WalletConnect V1 API will be deprecated soon.
 public struct Account {
-	public var connection: WalletConnection
-	var isConnected: Bool = false
+	var connection: WalletConnection
 
 	public static func create() throws -> Account {
 		let connection = WCWalletConnection()
@@ -19,6 +22,10 @@ public struct Account {
 
 	init(connection: WalletConnection) throws {
 		self.connection = connection
+	}
+
+	public var isConnected: Bool {
+		connection.isConnected
 	}
 
 	public var address: String {

--- a/Sources/XMTP/Wallet/WalletConnection.swift
+++ b/Sources/XMTP/Wallet/WalletConnection.swift
@@ -26,7 +26,7 @@ enum WalletConnectionError: String, Error {
 	case noSignature
 }
 
-public protocol WalletConnection {
+protocol WalletConnection {
 	var isConnected: Bool { get }
 	var walletAddress: String? { get }
 	func preferredConnectionMethod() throws -> WalletConnectionMethodType

--- a/Sources/XMTP/Wallet/WalletConnectionMethod.swift
+++ b/Sources/XMTP/Wallet/WalletConnectionMethod.swift
@@ -13,6 +13,7 @@ protocol WalletConnectionMethod {
 	var type: WalletConnectionMethodType { get }
 }
 
+/// Describes WalletConnect flows.
 public enum WalletConnectionMethodType {
 	case redirect(URL), qrCode(UIImage), manual(String)
 }

--- a/XMTPiOSExample/XMTPiOSExample/ContentView.swift
+++ b/XMTPiOSExample/XMTPiOSExample/ContentView.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
 					try await accountManager.account.connect()
 
 					for _ in 0 ... 30 {
-						if accountManager.account.connection.isConnected {
+						if accountManager.account.isConnected {
 							let client = try await Client.create(account: accountManager.account)
 
 							self.status = .connected(client)

--- a/XMTPiOSExample/XMTPiOSExample/Views/ConversationListView.swift
+++ b/XMTPiOSExample/XMTPiOSExample/Views/ConversationListView.swift
@@ -17,9 +17,13 @@ struct ConversationListView: View {
 
 	var body: some View {
 		List {
-			ForEach(conversations, id: \.peerAddress) { conversation in
+			ForEach(conversations, id: \.topic) { conversation in
 				NavigationLink(value: conversation) {
-					Text(conversation.peerAddress)
+					VStack {
+						Text(conversation.peerAddress)
+						Text(conversation.topic)
+							.font(.caption)
+					}
 				}
 			}
 		}
@@ -36,7 +40,9 @@ struct ConversationListView: View {
 		.task {
 			do {
 				for try await conversation in client.conversations.stream() {
-					conversations.insert(conversation, at: 0)
+					if !conversations.contains(conversation) {
+						conversations.insert(conversation, at: 0)
+					}
 				}
 			} catch {
 				print("Error streaming conversations: \(error)")

--- a/XMTPiOSExample/XMTPiOSExample/Views/ConversationListView.swift
+++ b/XMTPiOSExample/XMTPiOSExample/Views/ConversationListView.swift
@@ -17,13 +17,9 @@ struct ConversationListView: View {
 
 	var body: some View {
 		List {
-			ForEach(conversations, id: \.topic) { conversation in
+			ForEach(conversations, id: \.peerAddress) { conversation in
 				NavigationLink(value: conversation) {
-					VStack {
-						Text(conversation.peerAddress)
-						Text(conversation.topic)
-							.font(.caption)
-					}
+					Text(conversation.peerAddress)
 				}
 			}
 		}
@@ -40,9 +36,7 @@ struct ConversationListView: View {
 		.task {
 			do {
 				for try await conversation in client.conversations.stream() {
-					if !conversations.contains(conversation) {
-						conversations.insert(conversation, at: 0)
-					}
+					conversations.insert(conversation, at: 0)
 				}
 			} catch {
 				print("Error streaming conversations: \(error)")

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,1 @@
+xcodebuild docbuild -scheme XMTP -destination "platform=iOS Simulator,name=iPhone 14"


### PR DESCRIPTION
Adds typedocs to more things. This PR also makes a couple types private that didn't need to be public. These types weren't used by anything in the example app and shouldn't affect any users of the SDK. They were just cluttering the generated docs so I made them private.

Also I think these could all be fleshed out more, but at least now the generated docs won't be blank. I can also update this PR to try to get the package docs listed on https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/, unless we want to host them elsewhere in which case we can figure that out in a follow up PR.