### PR TITLE
Expose message pagination to XMTP.Conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ for conversation in client.conversations.list() {
 It may be helpful to retrieve and process the messages in a conversation page by page. You can do this by calling `conversation.messages(limit: Int, before: Date)` which will return the specified number of messages sent before that time.
 
 ```swift
-let conversation = try await clienet.conversations.newConversation(with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+let conversation = try await client.conversations.newConversation(with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
 
-let messages = conversation.messages(limit: 25)
-let nextPage = conversation.messages(limit: 25, before: messages[0].sent)
+let messages = try await conversation.messages(limit: 25)
+let nextPage = try await conversation.messages(limit: 25, before: messages[0].sent)
 ```
 
 ### Listen for new messages in a conversation

--- a/Sources/XMTP/Conversation.swift
+++ b/Sources/XMTP/Conversation.swift
@@ -78,12 +78,12 @@ public enum Conversation {
 	}
 
 	/// List messages in the conversation
-	public func messages() async throws -> [DecodedMessage] {
+	public func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		switch self {
 		case let .v1(conversationV1):
-			return try await conversationV1.messages()
+			return try await conversationV1.messages(limit: limit, before: before, after: after)
 		case let .v2(conversationV2):
-			return try await conversationV2.messages()
+			return try await conversationV2.messages(limit: limit, before: before, after: after)
 		}
 	}
 


### PR DESCRIPTION
I noticed the new pagination APIs were only available in `ConversationV1` & `ConversationV2` and not `XMTP.Conversation`. This PR adds pagination functionality to the top-level Conversation abstraction.