### PR TITLE
Remove CryptoSwift dependency and resolve warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
 		// Dependencies declare other packages that this package depends on.
 		// .package(url: /* package url */, from: "1.0.0"),
 
-		.package(url: "https://github.com/krzyzanowskim/CryptoSwift", branch: "main"),
-		.package(url: "https://github.com/xmtp/proto", branch: "main"),
+        .package(url: "https://github.com/xmtp/proto", branch: "main"),
 		.package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", branch: "main"),
 		.package(url: "https://github.com/argentlabs/web3.swift", from: "1.1.0"),
 		.package(url: "https://github.com/WalletConnect/WalletConnectSwift.git", revision: "9e4dfba34fb35336fd5da551285d7986ff536cb8"),

--- a/Sources/XMTP/DecodedMessage.swift
+++ b/Sources/XMTP/DecodedMessage.swift
@@ -43,7 +43,7 @@ public struct DecodedMessage {
 public extension DecodedMessage {
 	static func preview(body: String, senderAddress: String, sent: Date) -> DecodedMessage {
 		// swiftlint:disable force_try
-		var encoded = try! TextCodec().encode(content: body)
+		let encoded = try! TextCodec().encode(content: body)
 		// swiftlint:enable force_try
 		return DecodedMessage(encodedContent: encoded, senderAddress: senderAddress, sent: sent)
 	}

--- a/Sources/XMTP/Messages/MessageV2.swift
+++ b/Sources/XMTP/Messages/MessageV2.swift
@@ -47,7 +47,7 @@ extension MessageV2 {
 		let preKey = client.keys.preKeys[0]
 		let signature = try await preKey.sign(Data(digest))
 
-		let bundle = try client.privateKeyBundleV1.toV2().getPublicKeyBundle()
+		let bundle = client.privateKeyBundleV1.toV2().getPublicKeyBundle()
 
 		let signedContent = SignedContent(payload: payload, sender: bundle, signature: signature)
 		let signedBytes = try signedContent.serializedData()

--- a/Sources/XMTP/Messages/SignedPublicKeyBundle.swift
+++ b/Sources/XMTP/Messages/SignedPublicKeyBundle.swift
@@ -13,9 +13,9 @@ extension SignedPublicKeyBundle {
 	init(_ publicKeyBundle: PublicKeyBundle) throws {
 		self.init()
 
-		identityKey = try SignedPublicKey.fromLegacy(publicKeyBundle.identityKey)
+		identityKey = SignedPublicKey.fromLegacy(publicKeyBundle.identityKey)
 		identityKey.signature = publicKeyBundle.identityKey.signature
-		preKey = try SignedPublicKey.fromLegacy(publicKeyBundle.preKey)
+		preKey = SignedPublicKey.fromLegacy(publicKeyBundle.preKey)
 		preKey.signature = publicKeyBundle.preKey.signature
 	}
 

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -98,7 +98,7 @@ class CodecTests: XCTestCase {
 		let textContent = try TextCodec().encode(content: "sup")
 		let numberContent = try NumberCodec().encode(content: 3.14)
 
-		var source = DecodedComposite(parts: [
+		let source = DecodedComposite(parts: [
 			DecodedComposite(encodedContent: textContent),
 			DecodedComposite(parts: [
 				DecodedComposite(encodedContent: numberContent),


### PR DESCRIPTION
I noticed an unused dependency warning for `CryptoSwift`. This PR removes the `CryptoSwift` dependency and cleans up the warnings in the library package! Let me know if the warnings should be ignored instead of resolved anywhere of course.