### PR TITLE
Decode single message for a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ let keysData = try keys.serializedData()
 Once you have those keys, you can create a new client with `Client.from`:
 
 ```swift
+let keys = try PrivateKeyBundleV1(serializedData: keysData)
 let client = try Client.from(bundle: keys, options: .init(api: .init(env: .production)))
 ```
 
@@ -251,6 +252,30 @@ let myAppConversations = conversations.filter {
 
   return conversationID.hasPrefix("mydomain.xyz/")
 }
+```
+
+### Serialize/Deserialize conversations
+
+You can save a conversation object locally using its `encodedContainer` property. This returns a `ConversationContainer` object which conforms to `Codable`.
+
+```swift
+// Get a conversation
+let conversation = try await client.conversations.newConversation(with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+// Get a container.
+let container = conversation.encodedContainer
+
+// Dump it to JSON
+let encoder = JSONEncoder()
+let data = try encoder.encode(container)
+
+// Get it back from JSON
+let decoder = JSONDecoder()
+let containerAgain = try decoder.decode(ConversationContainer.self, from: data)
+
+// Get an actual Conversation object like we had above
+let decodedConversation = containerAgain.decode(with: client)
+try await decodedConversation.send(text: "hi")
 ```
 
 ## Compression

--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ let myAppConversations = conversations.filter {
 }
 ```
 
+### Decoding a single message
+
+You can decode a single `Envelope` from XMTP using the `decode` method:
+
+```swift
+let conversation = try await client.conversations.newConversation(with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+// Assume this method returns an Envelope that contains a message for the above conversation
+let envelope = getEnvelopeFromXMTP()
+
+let decodedMessage = try conversation.decode(envelope)
+```
+
 ### Serialize/Deserialize conversations
 
 You can save a conversation object locally using its `encodedContainer` property. This returns a `ConversationContainer` object which conforms to `Codable`.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ You can decode a single `Envelope` from XMTP using the `decode` method:
 ```swift
 let conversation = try await client.conversations.newConversation(with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
 
-// Assume this method returns an Envelope that contains a message for the above conversation
+// Assume this function returns an Envelope that contains a message for the above conversation
 let envelope = getEnvelopeFromXMTP()
 
 let decodedMessage = try conversation.decode(envelope)

--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -7,11 +7,25 @@
 
 import Foundation
 
+// Save the non-client parts for a v1 conversation
+public struct ConversationV1Container: Codable {
+	var peerAddress: String
+	var sentAt: Date
+
+	func decode(with client: Client) -> ConversationV1 {
+		ConversationV1(client: client, peerAddress: peerAddress, sentAt: sentAt)
+	}
+}
+
 /// Handles legacy message conversations.
 public struct ConversationV1 {
 	var client: Client
 	var peerAddress: String
 	var sentAt: Date
+
+	public var encodedContainer: ConversationV1Container {
+		ConversationV1Container(peerAddress: peerAddress, sentAt: sentAt)
+	}
 
 	var topic: Topic {
 		Topic.directMessageV1(client.address, peerAddress)
@@ -110,7 +124,7 @@ public struct ConversationV1 {
 		}
 	}
 
-	private func decode(envelope: Envelope) throws -> DecodedMessage {
+	public func decode(envelope: Envelope) throws -> DecodedMessage {
 		let message = try Message(serializedData: envelope.message)
 		let decrypted = try message.v1.decrypt(with: client.privateKeyBundleV1)
 

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -11,6 +11,21 @@ import XMTPProto
 
 struct SendOptions {}
 
+// Save the non-client parts for a v2 conversation
+public struct ConversationV2Container: Codable {
+	var topic: String
+	var keyMaterial: Data
+	var conversationID: String?
+	var metadata: [String: String] = [:]
+	var peerAddress: String
+	var header: SealedInvitationHeaderV1
+
+	public func decode(with client: Client) -> ConversationV2 {
+		let context = InvitationV1.Context(conversationID: conversationID ?? "", metadata: metadata)
+		return ConversationV2(topic: topic, keyMaterial: keyMaterial, context: context, peerAddress: peerAddress, client: client, header: header)
+	}
+}
+
 /// Handles V2 Message conversations.
 public struct ConversationV2 {
 	var topic: String
@@ -47,6 +62,10 @@ public struct ConversationV2 {
 		self.header = header
 	}
 
+	public var encodedContainer: ConversationV2Container {
+		ConversationV2Container(topic: topic, keyMaterial: keyMaterial, conversationID: context.conversationID, metadata: context.metadata, peerAddress: peerAddress, header: header)
+	}
+
 	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, startTime: before, endTime: after)
 
@@ -75,6 +94,11 @@ public struct ConversationV2 {
 				}
 			}
 		}
+	}
+
+	public func decode(envelope: Envelope) throws -> DecodedMessage {
+		let message = try Message(serializedData: envelope.message)
+		return try decode(message.v2)
 	}
 
 	private func decode(_ message: MessageV2) throws -> DecodedMessage {

--- a/Sources/XMTP/Messages/Envelope.swift
+++ b/Sources/XMTP/Messages/Envelope.swift
@@ -8,7 +8,7 @@
 import Foundation
 import XMTPProto
 
-typealias Envelope = Xmtp_MessageApi_V1_Envelope
+public typealias Envelope = Xmtp_MessageApi_V1_Envelope
 
 extension Envelope {
 	init(topic: Topic, timestamp: Date, message: Data) {

--- a/Sources/XMTP/Messages/SealedInvitationHeaderV1.swift
+++ b/Sources/XMTP/Messages/SealedInvitationHeaderV1.swift
@@ -5,6 +5,7 @@
 //  Created by Pat Nakajima on 11/26/22.
 //
 
+import Foundation
 import XMTPProto
 
 typealias SealedInvitationHeaderV1 = Xmtp_MessageContents_SealedInvitationHeaderV1
@@ -15,5 +16,28 @@ extension SealedInvitationHeaderV1 {
 		self.sender = sender
 		self.recipient = recipient
 		self.createdNs = createdNs
+	}
+}
+
+extension SealedInvitationHeaderV1: Codable {
+	enum CodingKeys: CodingKey {
+		case sender, recipient, createdNs
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+
+		try container.encode(sender, forKey: .sender)
+		try container.encode(recipient, forKey: .recipient)
+		try container.encode(createdNs, forKey: .createdNs)
+	}
+
+	public init(from decoder: Decoder) throws {
+		self.init()
+
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		sender = try container.decode(SignedPublicKeyBundle.self, forKey: .sender)
+		recipient = try container.decode(SignedPublicKeyBundle.self, forKey: .recipient)
+		createdNs = try container.decode(UInt64.self, forKey: .createdNs)
 	}
 }

--- a/Sources/XMTP/Messages/Signature.swift
+++ b/Sources/XMTP/Messages/Signature.swift
@@ -118,3 +118,25 @@ extension Signature {
 		return signingKey.ecdsa.isValidSignature(ecdsaSignature, for: digest)
 	}
 }
+
+extension Signature: Codable {
+	enum CodingKeys: CodingKey {
+		case rawData
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+
+		try container.encode(rawData, forKey: .rawData)
+	}
+
+	public init(from decoder: Decoder) throws {
+		self.init()
+
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		let rawData = try container.decode(Data.self, forKey: .rawData)
+
+		ecdsaCompact.bytes = rawData[0 ..< 64]
+		ecdsaCompact.recovery = UInt32(rawData[64])
+	}
+}

--- a/Sources/XMTP/Messages/SignedPublicKey.swift
+++ b/Sources/XMTP/Messages/SignedPublicKey.swift
@@ -76,3 +76,25 @@ extension SignedPublicKey {
 		return try PublicKey(pubKeyData)
 	}
 }
+
+extension SignedPublicKey: Codable {
+	enum CodingKeys: CodingKey {
+		case keyBytes, signature
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+
+		try container.encode(keyBytes, forKey: .keyBytes)
+		try container.encode(signature, forKey: .signature)
+	}
+
+	public init(from decoder: Decoder) throws {
+		self.init()
+
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+
+		keyBytes = try container.decode(Data.self, forKey: .keyBytes)
+		signature = try container.decode(Signature.self, forKey: .signature)
+	}
+}

--- a/Sources/XMTP/Messages/SignedPublicKeyBundle.swift
+++ b/Sources/XMTP/Messages/SignedPublicKeyBundle.swift
@@ -29,3 +29,24 @@ extension SignedPublicKeyBundle {
 		}
 	}
 }
+
+extension SignedPublicKeyBundle: Codable {
+	enum CodingKeys: CodingKey {
+		case identityKey, preKey
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+
+		try container.encode(identityKey, forKey: .identityKey)
+		try container.encode(preKey, forKey: .preKey)
+	}
+
+	public init(from decoder: Decoder) throws {
+		self.init()
+
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		identityKey = try container.decode(SignedPublicKey.self, forKey: .identityKey)
+		preKey = try container.decode(SignedPublicKey.self, forKey: .preKey)
+	}
+}

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -414,4 +414,74 @@ class ConversationTests: XCTestCase {
 		XCTAssertEqual(1, messages2.count)
 		XCTAssertEqual("hey alice 2", messages2[0].body)
 	}
+
+	func testV1ConversationCodable() async throws {
+		// Overwrite contact as legacy
+		try await publishLegacyContact(client: bobClient)
+		try await publishLegacyContact(client: aliceClient)
+
+		guard case let .v1(conversation) = try await aliceClient.conversations.newConversation(with: bob.walletAddress) else {
+			XCTFail("Did not have a v1 convo with bob")
+			return
+		}
+		try await conversation.send(content: "hi")
+		let envelope = fakeApiClient.published.first(where: { $0.contentTopic.hasPrefix("/xmtp/0/dm-") })!
+
+		let container = Conversation.v1(conversation).encodedContainer
+		let decodedConversation = container.decode(with: aliceClient)
+		let decodedMessage = try decodedConversation.decode(envelope)
+		XCTAssertEqual(decodedMessage.body, "hi")
+	}
+
+	func testV2ConversationCodable() async throws {
+		guard case let .v2(conversation) = try await aliceClient.conversations.newConversation(with: bob.walletAddress) else {
+			XCTFail("Did not have a v2 convo with bob")
+			return
+		}
+		try await conversation.send(content: "hi")
+		let envelope = fakeApiClient.published.first(where: { $0.contentTopic.hasPrefix("/xmtp/0/m-") })!
+
+		let container = Conversation.v2(conversation).encodedContainer
+		let decodedConversation = container.decode(with: aliceClient)
+		let decodedMessage = try decodedConversation.decode(envelope)
+		XCTAssertEqual(decodedMessage.body, "hi")
+	}
+
+	func testDecodeSingleV1Message() async throws {
+		// Overwrite contact as legacy
+		try await publishLegacyContact(client: bobClient)
+		try await publishLegacyContact(client: aliceClient)
+
+		guard case let .v1(conversation) = try await aliceClient.conversations.newConversation(with: bob.walletAddress) else {
+			XCTFail("Did not have a convo with bob")
+			return
+		}
+
+		try await conversation.send(content: "hi")
+
+		let message = fakeApiClient.published.first(where: { $0.contentTopic.hasPrefix("/xmtp/0/dm-") })!
+
+		let decodedMessage = try conversation.decode(envelope: message)
+		XCTAssertEqual("hi", decodedMessage.body)
+
+		let decodedMessage2 = try Conversation.v1(conversation).decode(message)
+		XCTAssertEqual("hi", decodedMessage2.body)
+	}
+
+	func testDecodeSingleV2Message() async throws {
+		guard case let .v2(conversation) = try await aliceClient.conversations.newConversation(with: bob.walletAddress) else {
+			XCTFail("Did not have a convo with bob")
+			return
+		}
+
+		try await conversation.send(content: "hi")
+
+		let message = fakeApiClient.published.first(where: { $0.contentTopic.hasPrefix("/xmtp/0/m-") })!
+
+		let decodedMessage = try conversation.decode(envelope: message)
+		XCTAssertEqual("hi", decodedMessage.body)
+
+		let decodedMessage2 = try Conversation.v2(conversation).decode(message)
+		XCTAssertEqual("hi", decodedMessage2.body)
+	}
 }

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -428,9 +428,12 @@ class ConversationTests: XCTestCase {
 		let envelope = fakeApiClient.published.first(where: { $0.contentTopic.hasPrefix("/xmtp/0/dm-") })!
 
 		let container = Conversation.v1(conversation).encodedContainer
-		let decodedConversation = container.decode(with: aliceClient)
-		let decodedMessage = try decodedConversation.decode(envelope)
-		XCTAssertEqual(decodedMessage.body, "hi")
+
+		try await fakeApiClient.assertNoQuery {
+			let decodedConversation = container.decode(with: aliceClient)
+			let decodedMessage = try decodedConversation.decode(envelope)
+			XCTAssertEqual(decodedMessage.body, "hi")
+		}
 	}
 
 	func testV2ConversationCodable() async throws {
@@ -442,9 +445,12 @@ class ConversationTests: XCTestCase {
 		let envelope = fakeApiClient.published.first(where: { $0.contentTopic.hasPrefix("/xmtp/0/m-") })!
 
 		let container = Conversation.v2(conversation).encodedContainer
-		let decodedConversation = container.decode(with: aliceClient)
-		let decodedMessage = try decodedConversation.decode(envelope)
-		XCTAssertEqual(decodedMessage.body, "hi")
+
+		try await fakeApiClient.assertNoQuery {
+			let decodedConversation = container.decode(with: aliceClient)
+			let decodedMessage = try decodedConversation.decode(envelope)
+			XCTAssertEqual(decodedMessage.body, "hi")
+		}
 	}
 
 	func testDecodeSingleV1Message() async throws {


### PR DESCRIPTION
Also adds the ability to serialize a `Conversation` via `Conversation.encodedContainer`.

See https://github.com/xmtp/xmtp-ios/issues/31.