### PR TITLE
Bring Client key export in line with JS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ let client = try await Client.create(account: account, options: .init(api: .init
 
 ### Creating a client from saved keys
 
-You can save your keys from the client via the `v1keys` property:
+You can save your keys from the client via the `privateKeyBundle` property:
 
 ```swift
 // Create the client with a `SigningKey` from your app
 let client = try await Client.create(account: account, options: .init(api: .init(env: .production)))
 
 // Get the key bundle
-let keys = client.v1keys
+let keys = client.privateKeyBundle
 
 // Serialize the key bundle and store it somewhere safe
 let keysData = try keys.serializedData()
@@ -97,7 +97,7 @@ let keysData = try keys.serializedData()
 Once you have those keys, you can create a new client with `Client.from`:
 
 ```swift
-let keys = try PrivateKeyBundleV1(serializedData: keysData)
+let keys = try PrivateKeyBundle(serializedData: keysData)
 let client = try Client.from(bundle: keys, options: .init(api: .init(env: .production)))
 ```
 

--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -136,8 +136,12 @@ public class Client {
 		return nil
 	}
 
+	public static func from(bundle: PrivateKeyBundle, options: ClientOptions? = nil) throws -> Client {
+		return try from(v1Bundle: bundle.v1, options: options)
+	}
+
 	/// Create a Client from saved v1 key bundle.
-	public static func from(bundle v1Bundle: PrivateKeyBundleV1, options: ClientOptions? = nil) throws -> Client {
+	public static func from(v1Bundle: PrivateKeyBundleV1, options: ClientOptions? = nil) throws -> Client {
 		let address = try v1Bundle.identityKey.publicKey.recoverWalletSignerPublicKey().walletAddress
 
 		let options = options ?? ClientOptions()
@@ -154,6 +158,10 @@ public class Client {
 		self.address = address
 		self.privateKeyBundleV1 = privateKeyBundleV1
 		self.apiClient = apiClient
+	}
+
+	public var privateKeyBundle: PrivateKeyBundle {
+		PrivateKeyBundle(v1: privateKeyBundleV1)
 	}
 
 	public var v1keys: PrivateKeyBundleV1 {

--- a/Sources/XMTP/Messages/PrivateKeyBundle.swift
+++ b/Sources/XMTP/Messages/PrivateKeyBundle.swift
@@ -8,7 +8,7 @@
 import Foundation
 import XMTPProto
 
-typealias PrivateKeyBundle = Xmtp_MessageContents_PrivateKeyBundle
+public typealias PrivateKeyBundle = Xmtp_MessageContents_PrivateKeyBundle
 
 enum PrivateKeyBundleError: Error {
 	case noPreKeyFound

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -27,12 +27,24 @@ class ClientTests: XCTestCase {
 		XCTAssert(preKey.publicKey.hasSignature, "prekey not signed")
 	}
 
+	func testCanBeCreatedWithBundle() async throws {
+		let fakeWallet = try PrivateKey.generate()
+		let client = try await Client.create(account: fakeWallet)
+
+		let bundle = client.privateKeyBundle
+		let clientFromV1Bundle = try Client.from(bundle: bundle)
+
+		XCTAssertEqual(client.address, clientFromV1Bundle.address)
+		XCTAssertEqual(client.privateKeyBundleV1.identityKey, clientFromV1Bundle.privateKeyBundleV1.identityKey)
+		XCTAssertEqual(client.privateKeyBundleV1.preKeys, clientFromV1Bundle.privateKeyBundleV1.preKeys)
+	}
+
 	func testCanBeCreatedWithV1Bundle() async throws {
 		let fakeWallet = try PrivateKey.generate()
 		let client = try await Client.create(account: fakeWallet)
 
 		let bundleV1 = client.v1keys
-		let clientFromV1Bundle = try Client.from(bundle: bundleV1)
+		let clientFromV1Bundle = try Client.from(v1Bundle: bundleV1)
 
 		XCTAssertEqual(client.address, clientFromV1Bundle.address)
 		XCTAssertEqual(client.privateKeyBundleV1.identityKey, clientFromV1Bundle.privateKeyBundleV1.identityKey)


### PR DESCRIPTION
The JS SDK exports a `PrivateKeyBundle`, not a `PrivateKeyBundleV1`. This PR makes that work for iOS as well.