### PR TITLE
Load all conversations

### DIFF
--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -5,8 +5,8 @@
 //  Created by Pat Nakajima on 11/28/22.
 //
 
-import Foundation
 import CryptoKit
+import Foundation
 
 // Save the non-client parts for a v1 conversation
 public struct ConversationV1Container: Codable {

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -67,7 +67,7 @@ public struct ConversationV2 {
 	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, startTime: before, endTime: after)
 
-		let envelopes = try await client.apiClient.query(topics: [topic], pagination: pagination).envelopes
+		let envelopes = try await client.apiClient.query(topics: [topic], pagination: pagination, cursor: nil).envelopes
 
 		return envelopes.compactMap { envelope in
 			do {

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -202,9 +202,10 @@ public struct Conversations {
 	}
 
 	func listInvitations() async throws -> [SealedInvitation] {
-		let envelopes = try await client.apiClient.query(topics: [
-			.userInvite(client.address),
-		], pagination: nil).envelopes
+		let envelopes = try await client.apiClient.envelopes(
+			topics: [Topic.userInvite(client.address).description],
+			pagination: nil
+		)
 
 		return envelopes.compactMap { envelope in
 			// swiftlint:disable no_optional_try

--- a/Sources/XMTP/Push/XMTPPush.swift
+++ b/Sources/XMTP/Push/XMTPPush.swift
@@ -83,7 +83,8 @@ public struct XMTPPush {
 			config: ProtocolClientConfig(
 				host: pushServer,
 				networkProtocol: .connect,
-				codec: ProtoCodec())
+				codec: ProtoCodec()
+			)
 		)
 
 		return Notifications_V1_NotificationsClient(client: protocolClient)

--- a/Tests/XMTPTests/IntegrationTests.swift
+++ b/Tests/XMTPTests/IntegrationTests.swift
@@ -477,4 +477,25 @@ final class IntegrationTests: XCTestCase {
 		// Check that we can send as well
 		try await convo.send(text: "hello deflate from swift again", options: .init(compression: .deflate))
 	}
+
+	func testCanLoadAllConversations() async throws {
+		throw XCTSkip("integration only (requires dev network)")
+
+		let keyBytes: [UInt8] = [
+			105, 207, 193, 11, 240, 115, 115, 204,
+			117, 134, 201, 10, 56, 59, 52, 90,
+			229, 103, 15, 66, 20, 113, 118, 137,
+			44, 62, 130, 90, 30, 158, 182, 178,
+		]
+
+		var key = PrivateKey()
+		key.secp256K1.bytes = Data(keyBytes)
+		key.publicKey.secp256K1Uncompressed.bytes = try KeyUtil.generatePublicKey(from: Data(keyBytes))
+
+		let client = try await XMTP.Client.create(account: key)
+
+		let conversations = try await client.conversations.list()
+
+		XCTAssertEqual(200, conversations.count)
+	}
 }

--- a/Tests/XMTPTests/MessageTests.swift
+++ b/Tests/XMTPTests/MessageTests.swift
@@ -5,8 +5,8 @@
 //  Created by Pat Nakajima on 11/27/22.
 //
 
-import XCTest
 import CryptoKit
+import XCTest
 @testable import XMTP
 
 // TODO: Make these match ConversationContainer
@@ -121,10 +121,10 @@ class MessageTests: XCTestCase {
 
 		let key = try PrivateKey.with { key in
 			key.secp256K1.bytes = Data([
-				80,  84,  15, 126,  14, 105, 216,  8,
-				61, 147, 153, 232, 103,  69, 219, 13,
-				99, 118,  68,  56, 160,  94,  58, 22,
-			 140, 247, 221, 172,  14, 188,  52, 88
+				80, 84, 15, 126, 14, 105, 216, 8,
+				61, 147, 153, 232, 103, 69, 219, 13,
+				99, 118, 68, 56, 160, 94, 58, 22,
+				140, 247, 221, 172, 14, 188, 52, 88,
 			])
 
 			key.publicKey.secp256K1Uncompressed.bytes = try KeyUtil.generatePublicKey(from: key.secp256K1.bytes)

--- a/Tests/XMTPTests/TestHelpers.swift
+++ b/Tests/XMTPTests/TestHelpers.swift
@@ -8,6 +8,7 @@
 import Combine
 import XCTest
 @testable import XMTP
+import XMTPProto
 
 struct FakeWallet: SigningKey {
 	static func generate() throws -> FakeWallet {
@@ -50,6 +51,10 @@ class FakeStreamHolder: ObservableObject {
 
 @available(iOS 15, *)
 class FakeApiClient: ApiClient {
+	func envelopes(topics: [String], pagination: XMTP.Pagination?) async throws -> [XMTP.Envelope] {
+		try await query(topics: topics, pagination: pagination).envelopes
+	}
+
 	var environment: XMTPEnvironment
 	var authToken: String = ""
 	private var responses: [String: [Envelope]] = [:]
@@ -122,7 +127,7 @@ class FakeApiClient: ApiClient {
 		authToken = token
 	}
 
-	func query(topics: [String], pagination: Pagination? = nil) async throws -> XMTP.QueryResponse {
+	func query(topics: [String], pagination: Pagination? = nil, cursor _: Xmtp_MessageApi_V1_Cursor? = nil) async throws -> XMTP.QueryResponse {
 		if forbiddingQueries {
 			XCTFail("Attempted to query \(topics)")
 			throw FakeApiClientError.queryAssertionFailure
@@ -169,7 +174,7 @@ class FakeApiClient: ApiClient {
 	}
 
 	func query(topics: [XMTP.Topic], pagination: Pagination? = nil) async throws -> XMTP.QueryResponse {
-		return try await query(topics: topics.map(\.description), pagination: pagination)
+		return try await query(topics: topics.map(\.description), pagination: pagination, cursor: nil)
 	}
 
 	func publish(envelopes: [XMTP.Envelope]) async throws -> XMTP.PublishResponse {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bufbuild/connect-swift",
       "state" : {
-        "revision" : "2dd21eec7ed7dfa657778a19abcbf4af4f450385",
-        "version" : "0.2.0"
+        "revision" : "6f5afc57f44a3ed15b9a01381ce73f84d15e43db",
+        "version" : "0.3.0"
       }
     },
     {


### PR DESCRIPTION
Prior to this change, we were only loading 200 conversations (100 from invites, 100 from intros). This PR fixes that.