### PR TITLE
Fix bug that would lead to GRPCApiClient.envelopes hanging forever

### DIFF
--- a/Sources/XMTP/ApiClient.swift
+++ b/Sources/XMTP/ApiClient.swift
@@ -90,7 +90,7 @@ class GRPCApiClient: ApiClient {
 			envelopes.append(contentsOf: response.envelopes)
 
 			cursor = response.pagingInfo.cursor
-			hasNextPage = !response.envelopes.isEmpty
+			hasNextPage = !response.envelopes.isEmpty && response.pagingInfo.hasCursor
 		}
 
 		return envelopes


### PR DESCRIPTION
This would cause `conversations.list()` to never finish.