### PR TITLE
Small typo fix

### DIFF
--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -60,7 +60,7 @@ public class Client {
 	}
 
 	static var codecRegistry = {
-		var registry = CodecRegsistry()
+		var registry = CodecRegistry()
 		registry.register(codec: TextCodec())
 		return registry
 	}()

--- a/Sources/XMTP/CodecRegistry.swift
+++ b/Sources/XMTP/CodecRegistry.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CodecRegsistry {
+struct CodecRegistry {
 	var codecs: [String: any ContentCodec] = [:]
 
 	mutating func register(codec: any ContentCodec) {


### PR DESCRIPTION
This just fixes a small typo in a class name.