### PR TITLE
Introduce Conversation.prepareMessage

### DIFF
--- a/Sources/XMTP/Conversation.swift
+++ b/Sources/XMTP/Conversation.swift
@@ -97,6 +97,15 @@ public enum Conversation {
 		}
 	}
 
+	public func prepareMessage<T>(content: T, options: SendOptions? = nil) async throws -> PreparedMessage {
+		switch self {
+		case let .v1(conversationV1):
+			return try await conversationV1.prepareMessage(content: content, options: options ?? .init())
+		case let .v2(conversationV2):
+			return try await conversationV2.prepareMessage(content: content, options: options ?? .init())
+		}
+	}
+
 	@discardableResult public func send<T>(content: T, options: SendOptions? = nil, fallback _: String? = nil) async throws -> String {
 		switch self {
 		case let .v1(conversationV1):

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -9,7 +9,7 @@ import Foundation
 import XMTPProto
 
 public enum ConversationError: Error {
-	case recipientNotOnNetwork, recipientIsSender
+	case recipientNotOnNetwork, recipientIsSender, v1NotSupported(String)
 }
 
 /// Handles listing and creating Conversations.

--- a/Sources/XMTP/PreparedMessage.swift
+++ b/Sources/XMTP/PreparedMessage.swift
@@ -1,0 +1,27 @@
+//
+//  PreparedMessage.swift
+//
+//
+//  Created by Pat Nakajima on 3/9/23.
+//
+
+import CryptoKit
+import Foundation
+
+public struct PreparedMessage {
+	var messageEnvelope: Envelope
+	var conversation: Conversation
+	var onSend: () async throws -> Void
+
+	public func decodedMessage() throws -> DecodedMessage {
+		return try conversation.decode(messageEnvelope)
+	}
+
+	public func send() async throws {
+		try await onSend()
+	}
+
+	var messageID: String {
+		Data(SHA256.hash(data: messageEnvelope.message)).toHex
+	}
+}


### PR DESCRIPTION
This gives back a PreparedMessage that has a messageID on it. Clients can use this for optimistic sending purposes. Clients can then call `send()` on the prepared message to publish it to the network.