### PR TITLE
Remove multiple topic queries

### DIFF
--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -125,8 +125,10 @@ public class Client {
 	}
 
 	static func loadPrivateKeys(for account: SigningKey, apiClient: ApiClient) async throws -> PrivateKeyBundleV1? {
-		let topics: [Topic] = [.userPrivateStoreKeyBundle(account.address)]
-		let res = try await apiClient.query(topics: topics, pagination: nil)
+		let res = try await apiClient.query(
+			topic: .userPrivateStoreKeyBundle(account.address),
+			pagination: nil
+		)
 
 		for envelope in res.envelopes {
 			let encryptedBundle = try EncryptedPrivateKeyBundle(serializedData: envelope.message)
@@ -174,7 +176,7 @@ public class Client {
 	}
 
 	public func canMessage(_ peerAddress: String) async throws -> Bool {
-		return try await query(topics: [.contact(peerAddress)]).envelopes.count > 0
+		return try await query(topic: .contact(peerAddress)).envelopes.count > 0
 	}
 
 	public func importConversation(from conversationData: Data) throws -> Conversation? {
@@ -265,8 +267,11 @@ public class Client {
 		_ = try await publish(envelopes: envelopes)
 	}
 
-	func query(topics: [Topic], pagination: Pagination? = nil) async throws -> QueryResponse {
-		return try await apiClient.query(topics: topics, pagination: pagination)
+	func query(topic: Topic, pagination: Pagination? = nil) async throws -> QueryResponse {
+		return try await apiClient.query(
+			topic: topic,
+			pagination: pagination
+		)
 	}
 
 	@discardableResult func publish(envelopes: [Envelope]) async throws -> PublishResponse {

--- a/Sources/XMTP/Contacts.swift
+++ b/Sources/XMTP/Contacts.swift
@@ -30,7 +30,7 @@ public struct Contacts {
 			return knownBundle
 		}
 
-		let response = try await client.query(topics: [.contact(peerAddress)])
+		let response = try await client.query(topic: .contact(peerAddress))
 
 		for envelope in response.envelopes {
 			// swiftlint:disable no_optional_try

--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -136,9 +136,10 @@ public struct ConversationV1 {
 	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, startTime: before, endTime: after)
 
-		let envelopes = try await client.apiClient.query(topics: [
-			.directMessageV1(client.address, peerAddress),
-		], pagination: pagination).envelopes
+		let envelopes = try await client.apiClient.query(
+			topic: Topic.directMessageV1(client.address, peerAddress),
+			pagination: pagination
+		).envelopes
 
 		return envelopes.compactMap { envelope in
 			do {

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -76,7 +76,7 @@ public struct ConversationV2 {
 	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, startTime: before, endTime: after)
 
-		let envelopes = try await client.apiClient.query(topics: [topic], pagination: pagination, cursor: nil).envelopes
+		let envelopes = try await client.apiClient.query(topic: topic, pagination: pagination, cursor: nil).envelopes
 
 		return envelopes.compactMap { envelope in
 			do {

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -216,9 +216,10 @@ public class Conversations {
 	}
 
 	func listIntroductionPeers() async throws -> [String: Date] {
-		let envelopes = try await client.apiClient.query(topics: [
-			.userIntro(client.address),
-		], pagination: nil).envelopes
+		let envelopes = try await client.apiClient.query(
+			topic: .userIntro(client.address),
+			pagination: nil
+		).envelopes
 
 		let messages = envelopes.compactMap { envelope in
 			do {
@@ -259,7 +260,7 @@ public class Conversations {
 
 	func listInvitations() async throws -> [SealedInvitation] {
 		let envelopes = try await client.apiClient.envelopes(
-			topics: [Topic.userInvite(client.address).description],
+			topic: Topic.userInvite(client.address).description,
 			pagination: nil
 		)
 

--- a/Tests/XMTPTests/IntegrationTests.swift
+++ b/Tests/XMTPTests/IntegrationTests.swift
@@ -38,7 +38,7 @@ final class IntegrationTests: XCTestCase {
 
 		try await Task.sleep(nanoseconds: 2_000_000_000)
 
-		let result = try await api.query(topics: [.userPrivateStoreKeyBundle(authorized.address)])
+		let result = try await api.query(topic: .userPrivateStoreKeyBundle(authorized.address))
 		XCTAssert(result.envelopes.count == 1)
 	}
 


### PR DESCRIPTION
In a move towards decentralization we need to remove the ability to query multiple topics as we can't guarantee topics will be on the same node.

See also https://github.com/xmtp/xmtp-android/pull/52.