### PR TITLE
fix: use exact 0.10 for secp library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
 		// .package(url: /* package url */, from: "1.0.0"),
 
 		.package(url: "https://github.com/xmtp/proto", branch: "main"),
-		.package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", from: "0.10.0"),
+		.package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", exact: "0.10.0"),
 		.package(url: "https://github.com/argentlabs/web3.swift", from: "1.1.0"),
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", from: "0.3.0"),


### PR DESCRIPTION
This PR fixes our sepc256k1 library to use version 0.10.0. Using `from` had updated the example app to use 0.10.0 prior to this, so the package refs are still the same there after resolving package versions.
