### PR TITLE
fix: local tests failing due to improper mem copying, .bytes extension not available in pods

### DIFF
--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -38,7 +38,7 @@ public struct ConversationV2 {
 		let peer = try myKeys.walletAddress == (try header.sender.walletAddress) ? header.recipient : header.sender
 		let peerAddress = try peer.walletAddress
 
-        let keyMaterial = Data(invitation.aes256GcmHkdfSha256.keyMaterial.bytes)
+		let keyMaterial = Data(invitation.aes256GcmHkdfSha256.keyMaterial)
 
 		return ConversationV2(
 			topic: invitation.topic,

--- a/Sources/XMTP/Crypto.swift
+++ b/Sources/XMTP/Crypto.swift
@@ -35,8 +35,14 @@ enum Crypto {
 		}
 
 		var ciphertext = CipherText()
-
-		ciphertext.aes256GcmHkdfSha256.payload = payload.ciphertext + payload.tag
+		// Copy the ciphertext data out, otherwise it's a region sliced from a combined Data (nonce, ciphertext, tag)
+		// with offsets like lowerBound=12, upperBound=224. Without copying, trying to index like payload[0] crashes
+		// up until payload[12]. This is mostly a problem for unit tests where we decrypt what we encrypt in memory, as
+		// serialization/deserialization acts as copying and avoids this issue.
+		var payloadData = Data(payload.ciphertext.subdata(in: 12 ..< payload.ciphertext.count+12))
+		let startTag = 12 + payload.ciphertext.count
+		payloadData.append(payload.tag.subdata(in: startTag ..< startTag + payload.tag.count))
+		ciphertext.aes256GcmHkdfSha256.payload = payloadData
 		ciphertext.aes256GcmHkdfSha256.hkdfSalt = salt
 		ciphertext.aes256GcmHkdfSha256.gcmNonce = nonceData
 
@@ -47,7 +53,7 @@ enum Crypto {
 		let salt = ciphertext.aes256GcmHkdfSha256.hkdfSalt
 		let nonceData = ciphertext.aes256GcmHkdfSha256.gcmNonce
 		let nonce = try AES.GCM.Nonce(data: nonceData)
-        let payload = ciphertext.aes256GcmHkdfSha256.payload.bytes
+		let payload = ciphertext.aes256GcmHkdfSha256.payload
 
 		let ciphertextBytes = payload[0 ..< payload.count - 16]
 		let tag = payload[payload.count - 16 ..< payload.count]

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -47,11 +47,11 @@ Pod::Spec.new do |spec|
   spec.dependency 'XMTPRust', '= 0.2.0-beta0'
 
   spec.xcconfig = {'VALID_ARCHS' =>  'arm64' }
-#  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
-#  def spec.post_install(target)
-#    target.build_configurations.each do |config|
-#      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
-#    end
-#  end
+  def spec.post_install(target)
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+    end
+  end
 end

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -47,11 +47,11 @@ Pod::Spec.new do |spec|
   spec.dependency 'XMTPRust', '= 0.2.0-beta0'
 
   spec.xcconfig = {'VALID_ARCHS' =>  'arm64' }
-  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
-  def spec.post_install(target)
-    target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
-    end
-  end
+#  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+#
+#  def spec.post_install(target)
+#    target.build_configurations.each do |config|
+#      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+#    end
+#  end
 end


### PR DESCRIPTION
## Overview

Two issues were preventing the cocoapods-integration branch from passing `pod lib lint XMTP.podspec  --allow-warnings`, the precursor to actually shipping the cocoapod again.

1) Indirect problem: we were utilizing subranges of Data when storing the result of Swift AES.GCM.Seal, this meant in a subsequent index like `payload[0]` we would hit a crash. Specifically, let `output = AES.GCM.Seal(...)` then `output.ciphertext` is actually a (12, ...) range of a shared underlying Data instance (`.combined`). We use `subdata` to create a copy to allow for safer indexing going forward.

NOTE: it seems possible to create a new Data representation over the same memory location with different offset, but that can be an optimization. Copying memory here isn't the worst as it's outweighed by the encryption operation and the eventual serialization.

2) Direct problem: We worked around this by using `.bytes` Data extension, which returned an unsafe pointer over the Data (see Note above). This works but was an extension provided by the `sec256k1` Swift package that is excluded from our podspec because it's not Cocoapods compliant.

## Test Plan

- Unit tests pass
- Passes pod lint