### PR TITLE
feat: add batch message listing, use updated libxmtp

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-rust-swift",
       "state" : {
-        "revision" : "eccfc16bb8f866857ecbb1604c1dab855b1960f7",
-        "version" : "0.2.2-beta0"
+        "revision" : "41a1161cf06a86bab0aa886e450584a1191429b1",
+        "version" : "0.3.0-beta0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", from: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/xmtp-rust-swift", from: "0.2.2-beta0"),
+		.package(url: "https://github.com/xmtp/xmtp-rust-swift", from: "0.3.0-beta0"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -132,7 +132,10 @@ public class Client {
 		for envelope in res.envelopes {
 			let encryptedBundle = try EncryptedPrivateKeyBundle(serializedData: envelope.message)
 			let bundle = try await encryptedBundle.decrypted(with: account)
-			return bundle.v1
+            if case .v1 = bundle.version {
+                return bundle.v1
+            }
+            print("discarding unsupported stored key bundle")
 		}
 
 		return nil
@@ -274,6 +277,10 @@ public class Client {
 			pagination: pagination
 		)
 	}
+
+    func batchQuery(request: BatchQueryRequest) async throws -> BatchQueryResponse {
+        return try await apiClient.batchQuery(request: request)
+    }
 
 	@discardableResult func publish(envelopes: [Envelope]) async throws -> PublishResponse {
 		let authorized = AuthorizedIdentity(address: address, authorized: privateKeyBundleV1.identityKey.publicKey, identity: privateKeyBundleV1.identityKey)

--- a/Sources/XMTP/Util.swift
+++ b/Sources/XMTP/Util.swift
@@ -13,3 +13,11 @@ enum Util {
 		return data.web3.keccak256
 	}
 }
+
+extension Array {
+    func chunks(_ chunkSize: Int) -> [[Element]] {
+        return stride(from: 0, to: self.count, by: chunkSize).map {
+            Array(self[$0..<Swift.min($0 + chunkSize, self.count)])
+        }
+    }
+}

--- a/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -193,6 +193,19 @@ public class FakeApiClient: ApiClient {
 
 		return PublishResponse()
 	}
+
+    public func batchQuery(request: XMTP.BatchQueryRequest) async throws -> XMTP.BatchQueryResponse {
+        abort() // Not supported on Fake
+    }
+
+    public func query(request: XMTP.QueryRequest) async throws -> XMTP.QueryResponse {
+        abort() // Not supported on Fake
+    }
+
+    public func publish(request: XMTP.PublishRequest) async throws -> XMTP.PublishResponse {
+        abort() // Not supported on Fake
+    }
+
 }
 
 @available(iOS 15, *)

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.2.2-alpha0"
+  spec.version      = "0.3.0-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,7 +44,7 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift"
-  spec.dependency 'XMTPRust', '= 0.2.2-beta0'
+  spec.dependency 'XMTPRust', '= 0.3.0-beta0'
 
   spec.xcconfig = {'VALID_ARCHS' =>  'arm64' }
 end

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-rust-swift",
       "state" : {
-        "revision" : "eccfc16bb8f866857ecbb1604c1dab855b1960f7",
-        "version" : "0.2.2-beta0"
+         "revision" : "41a1161cf06a86bab0aa886e450584a1191429b1",
+         "version" : "0.3.0-beta0"
       }
     }
   ],


### PR DESCRIPTION
This implements batch listing of messages for use as part of https://github.com/xmtp/xmtp-react-native/issues/34.

And uses the proto encoding bridge to `bindings_swift` to delete a bunch of glue code. https://github.com/xmtp/libxmtp/pull/131

This depends on an updated cocoapod resulting from https://github.com/xmtp/xmtp-rust-swift/pull/10.