### PR TITLE
feat: deterministic topic/keyMaterial for invites

### DIFF
--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -149,8 +149,10 @@ public class Conversations {
 
         // We don't have an existing conversation, make a v2 one
         let recipient = try contact.toSignedPublicKeyBundle()
-        let invitation = try InvitationV1.createRandom(context: context)
-
+        let invitation = try InvitationV1.createDeterministic(
+                sender: client.keys,
+                recipient: recipient,
+                context: context)
         let sealedInvitation = try await sendInvitation(recipient: recipient, invitation: invitation, created: Date())
         let conversationV2 = try ConversationV2.create(client: client, invitation: invitation, header: sealedInvitation.v1.header)
 

--- a/Sources/XMTP/Crypto.swift
+++ b/Sources/XMTP/Crypto.swift
@@ -1,9 +1,6 @@
 //
 //  Crypto.swift
 //
-//
-//  Created by Pat Nakajima on 11/17/22.
-//
 
 import CryptoKit
 import Foundation
@@ -70,6 +67,21 @@ enum Crypto {
 		} else {
 			return try AES.GCM.open(box, using: resultKey)
 		}
+	}
+
+	static func calculateMac(_ message: Data, _ secret: Data) throws -> Data {
+		let mac = HMAC<SHA256>.authenticationCode(for: message, using: SymmetricKey(data: secret))
+		return Data(mac)
+	}
+
+	static func deriveKey(secret: Data, nonce: Data, info: Data) throws -> Data {
+		let key = HKDF<SHA256>.deriveKey(
+				inputKeyMaterial: SymmetricKey(data: secret),
+				salt: nonce,
+				info: info,
+				outputByteCount: 32
+		)
+		return Data(key.bytes)
 	}
 
 	static func secureRandomBytes(count: Int) throws -> Data {

--- a/Sources/XMTP/Messages/Invitation.swift
+++ b/Sources/XMTP/Messages/Invitation.swift
@@ -1,9 +1,6 @@
 //
 //  Invitation.swift
 //
-//
-//  Created by Pat Nakajima on 11/26/22.
-//
 
 import Foundation
 
@@ -11,25 +8,37 @@ import Foundation
 public typealias InvitationV1 = Xmtp_MessageContents_InvitationV1
 
 extension InvitationV1 {
-	static func createRandom(context: InvitationV1.Context? = nil) throws -> InvitationV1 {
+	static func createDeterministic(
+			sender: PrivateKeyBundleV2,
+			recipient: SignedPublicKeyBundle,
+			context: InvitationV1.Context? = nil
+	) throws -> InvitationV1 {
 		let context = context ?? InvitationV1.Context()
-		let randomBytes = try Crypto.secureRandomBytes(count: 32)
-		let randomString = Data(randomBytes).base64EncodedString()
-			.replacingOccurrences(of: "=*$", with: "", options: .regularExpression)
-			.replacingOccurrences(of: "[^A-Za-z0-9]", with: "", options: .regularExpression)
 
-		let topic = Topic.directMessageV2(randomString)
+		let secret = try sender.sharedSecret(
+				peer: recipient,
+				myPreKey: sender.preKeys[0].publicKey,
+				isRecipient: false)
+		let addresses = [
+			try sender.toV1().walletAddress,
+			try recipient.walletAddress,
+		].sorted()
+		let msg = "\(context.conversationID)\(addresses.joined())"
+		let topicId = try Crypto.calculateMac(Data(msg.utf8), secret).toHex
+		let topic = Topic.directMessageV2(topicId)
 
-		let keyMaterial = try Crypto.secureRandomBytes(count: 32)
+		let keyMaterial = try Crypto.deriveKey(
+				secret: secret,
+				nonce: Data("__XMTP__INVITATION__SALT__XMTP__".utf8),
+				info: Data((["0"] + addresses).joined(separator: "|").utf8))
 
 		var aes256GcmHkdfSha256 = InvitationV1.Aes256gcmHkdfsha256()
 		aes256GcmHkdfSha256.keyMaterial = Data(keyMaterial)
 
 		return try InvitationV1(
-			topic: topic,
-			context: context,
-			aes256GcmHkdfSha256: aes256GcmHkdfSha256
-		)
+				topic: topic,
+				context: context,
+				aes256GcmHkdfSha256: aes256GcmHkdfSha256)
 	}
 
 	init(topic: Topic, context: InvitationV1.Context? = nil, aes256GcmHkdfSha256: InvitationV1.Aes256gcmHkdfsha256) throws {

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -85,32 +85,6 @@ class ConversationTests: XCTestCase {
 		wait(for: [expectation], timeout: 0.1)
 	}
 
-	func testDoesNotIncludeSelfConversationsInList() async throws {
-		let convos = try await aliceClient.conversations.list()
-		XCTAssert(convos.isEmpty, "setup is wrong")
-
-		let recipient = aliceClient.privateKeyBundleV1.toPublicKeyBundle()
-		let invitation = try InvitationV1.createRandom()
-		let created = Date()
-
-		let sealedInvitation = try SealedInvitation.createV1(
-			sender: aliceClient.keys,
-			recipient: SignedPublicKeyBundle(recipient),
-			created: created,
-			invitation: invitation
-		)
-
-		let peerAddress = recipient.walletAddress
-
-		try await aliceClient.publish(envelopes: [
-			Envelope(topic: .userInvite(aliceClient.address), timestamp: created, message: try sealedInvitation.serializedData()),
-			Envelope(topic: .userInvite(peerAddress), timestamp: created, message: try sealedInvitation.serializedData()),
-		])
-
-		let newConvos = try await aliceClient.conversations.list()
-		XCTAssert(newConvos.isEmpty, "did not filter out self conversations")
-	}
-
 	func testCanStreamConversationsV2() async throws {
 		let expectation1 = expectation(description: "got a conversation")
 		expectation1.expectedFulfillmentCount = 2

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -36,13 +36,15 @@ class ConversationsTests: XCTestCase {
 
 	func testCanGetConversationFromInviteEnvelope() async throws {
 		let fixtures = await fixtures()
-		let client = fixtures.aliceClient!
+		let client: Client = fixtures.aliceClient!
 
 		let created = Date()
 		let newWallet = try PrivateKey.generate()
 		let newClient = try await Client.create(account: newWallet, apiClient: fixtures.fakeApiClient)
 
-		let invitation = try InvitationV1.createRandom(context: nil)
+		let invitation = try InvitationV1.createDeterministic(
+				sender: newClient.keys,
+				recipient: client.keys.getPublicKeyBundle())
 		let sealed = try SealedInvitation.createV1(
 			sender: newClient.keys,
 			recipient: client.keys.getPublicKeyBundle(),

--- a/Tests/XMTPTests/MessageTests.swift
+++ b/Tests/XMTPTests/MessageTests.swift
@@ -55,7 +55,11 @@ class MessageTests: XCTestCase {
 		var invitationContext = InvitationV1.Context()
 		invitationContext.conversationID = "https://example.com/1"
 
-		let invitationv1 = try InvitationV1.createRandom(context: invitationContext)
+		let invitationv1 = try InvitationV1.createDeterministic(
+				sender: alice.toV2(),
+				recipient: bob.toV2().getPublicKeyBundle(),
+				context: invitationContext
+		)
 		let sealedInvitation = try SealedInvitation.createV1(sender: alice.toV2(), recipient: bob.toV2().getPublicKeyBundle(), created: Date(), invitation: invitationv1)
 		let encoder = TextCodec()
 		let encodedContent = try encoder.encode(content: "Yo!")


### PR DESCRIPTION
This produces consistent `topic` and `keyMaterial` for invites created to the same `peer` and `conversationId`.

This implements #86 