### PR TITLE
Fix retrieve messages limit

### DIFF
--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -146,10 +146,10 @@ public struct ConversationV1 {
 	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, before: before, after: after)
 
-		let envelopes = try await client.apiClient.query(
-			topic: Topic.directMessageV1(client.address, peerAddress),
+		let envelopes = try await client.apiClient.envelopes(
+            topic: Topic.directMessageV1(client.address, peerAddress).description,
 			pagination: pagination
-		).envelopes
+		)
 
 		return envelopes.compactMap { envelope in
 			do {

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -110,14 +110,13 @@ public struct ConversationV2 {
 		return try await prepareMessage(encodedContent: encoded)
 	}
 
-	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
+	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil ) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, before: before, after: after)
-
-		let envelopes = try await client.apiClient.query(topic: topic, pagination: pagination, cursor: nil).envelopes
+		let envelopes = try await client.apiClient.envelopes(topic: topic.description, pagination: pagination)
 
 		return envelopes.compactMap { envelope in
 			do {
-				return try decode(envelope: envelope)
+            return try decode(envelope: envelope)
 			} catch {
 				print("Error decoding envelope \(error)")
 				return nil

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -110,7 +110,7 @@ public struct ConversationV2 {
 		return try await prepareMessage(encodedContent: encoded)
 	}
 
-	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil ) async throws -> [DecodedMessage] {
+	func messages(limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
 		let pagination = Pagination(limit: limit, before: before, after: after)
 		let envelopes = try await client.apiClient.envelopes(topic: topic.description, pagination: pagination)
 


### PR DESCRIPTION
**Description:** This PR aims to fix the default limit of 100 messages when fetching "all" messages.

**Unit tested**

- [x] YES
- [ ] NO
