### PR TITLE
Fix podspec errors

### DIFF
--- a/Sources/XMTP/Crypto.swift
+++ b/Sources/XMTP/Crypto.swift
@@ -81,7 +81,9 @@ enum Crypto {
 				info: info,
 				outputByteCount: 32
 		)
-		return Data(key.bytes)
+        return key.withUnsafeBytes { body in
+            Data(body)
+        }
 	}
 
 	static func secureRandomBytes(count: Int) throws -> Data {


### PR DESCRIPTION
I tried to pod trunk push so we could get the message and deduping fixes into react native but it failed with 2 errors

```
ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
ERROR | [iOS] xcodebuild:  XMTP/Sources/XMTP/Crypto.swift:84:19: error: value of type 'SymmetricKey' has no member 'bytes'
```

I think someone with more iOS knowledge might be better suited to debug this but I took a pass at fixing the SymmetricKey issue. cc @nakajima 