### PR TITLE
Paginate per batched query

### DIFF
--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -33,9 +33,8 @@ public class Conversations {
         return conversation
     }
     
-    public typealias Query = (topic: String, pagination: Pagination?)
 
-    public func listBatchMessages(topics: [Query]) async throws -> [DecodedMessage] {
+    public func listBatchMessages(topics: [String: Pagination?]) async throws -> [DecodedMessage] {
         let requests = topics.map { (topic, page) in
             makeQueryRequest(topic: topic, pagination: page)
         }

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -32,7 +32,6 @@ public class Conversations {
         conversationsByTopic[conversation.topic] = conversation
         return conversation
     }
-    
 
     public func listBatchMessages(topics: [String: Pagination?]) async throws -> [DecodedMessage] {
         let requests = topics.map { (topic, page) in

--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -32,11 +32,12 @@ public class Conversations {
         conversationsByTopic[conversation.topic] = conversation
         return conversation
     }
+    
+    public typealias Query = (topic: String, pagination: Pagination?)
 
-    public func listBatchMessages(topics: [String], limit: Int? = nil, before: Date? = nil, after: Date? = nil) async throws -> [DecodedMessage] {
-        let pagination = Pagination(limit: limit, before: before, after: after)
-        let requests = topics.map { (topic) in
-            makeQueryRequest(topic: topic, pagination: pagination)
+    public func listBatchMessages(topics: [Query]) async throws -> [DecodedMessage] {
+        let requests = topics.map { (topic, page) in
+            makeQueryRequest(topic: topic, pagination: page)
         }
         /// The maximum number of requests permitted in a single batch call.
         let maxQueryRequestsPerBatch = 50

--- a/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -216,7 +216,12 @@ public class FakeApiClient: ApiClient {
 	}
 
     public func batchQuery(request: XMTP.BatchQueryRequest) async throws -> XMTP.BatchQueryResponse {
-        abort() // Not supported on Fake
+        let request1 = request.requests[0]
+        let responses = try await query(topic: request1.contentTopics[0], pagination: Pagination(after: Date(timeIntervalSince1970: Double(request1.startTimeNs / 1_000_000) / 1000)))
+
+        var queryResponse = XMTP.BatchQueryResponse()
+        queryResponse.responses = [responses]
+        return queryResponse
     }
 
     public func query(request: XMTP.QueryRequest) async throws -> XMTP.QueryResponse {

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -403,8 +403,31 @@ class ConversationTests: XCTestCase {
 		}
 
 		let messages = try await aliceConversation.messages()
-		XCTAssertEqual(100, messages.count)
+		XCTAssertEqual(110, messages.count)
 	}
+    
+    func testCanRetrieveBatchMessages() async throws {
+
+        guard case let .v2(bobConversation) = try await aliceClient.conversations.newConversation(with: bob.address, context: InvitationV1.Context(conversationID: "hi")) else {
+            XCTFail("did not get a v2 conversation for bob")
+            return
+        }
+
+        for i in 0..<3 {
+            do {
+                let content = "hey alice \(i)"
+                let sentAt = Date().addingTimeInterval(-1000)
+                try await bobConversation.send(content: content, sentAt: sentAt)
+            } catch {
+                print("Error sending message:", error)
+            }
+        }
+
+        let messages = try await aliceClient.conversations.listBatchMessages(
+            topics: [bobConversation.topic : Pagination(limit:1)]
+        )
+        XCTAssertEqual(3, messages.count)
+    }
 
 	func testImportV1ConversationFromJS() async throws {
 		let jsExportJSONData = Data("""

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -424,7 +424,7 @@ class ConversationTests: XCTestCase {
         }
 
         let messages = try await aliceClient.conversations.listBatchMessages(
-            topics: [bobConversation.topic : Pagination(limit:1)]
+            topics: [bobConversation.topic : Pagination(limit:3)]
         )
         XCTAssertEqual(3, messages.count)
     }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.3.6-alpha0"
+  spec.version      = "0.3.7-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-react-native/issues/68 and https://github.com/xmtp/xmtp-react-native/pull/77

This adds the ability to paginate per topic in a batch query.

Note: This is a breaking change