### PR TITLE
Allow Pagination to be Initialized

### DIFF
--- a/Sources/XMTP/Messages/PagingInfo.swift
+++ b/Sources/XMTP/Messages/PagingInfo.swift
@@ -12,10 +12,10 @@ typealias PagingInfoCursor = Xmtp_MessageApi_V1_Cursor
 typealias PagingInfoSortDirection = Xmtp_MessageApi_V1_SortDirection
 
 public struct Pagination {
-	var limit: Int?
+	public var limit: Int?
 	var direction: PagingInfoSortDirection?
-    var before: Date?
-    var after: Date?
+    public var before: Date?
+    public var after: Date?
 
 	var pagingInfo: PagingInfo {
 		var info = PagingInfo()

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.3.7-alpha0"
+  spec.version      = "0.3.8-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Was getting `'Pagination' initializer is inaccessible due to 'internal' protection level`

This should allow us to create a Pagination object.