### PR TITLE
Make Client's signedPublicKeyBundle public and make signing public

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-rust-swift",
       "state" : {
-        "revision" : "41a1161cf06a86bab0aa886e450584a1191429b1",
-        "version" : "0.3.0-beta0"
+        "revision" : "4a76e5401fa780c40610e2f0d248f695261d08dd",
+        "version" : "0.3.1-beta0"
       }
     }
   ],

--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -188,6 +188,10 @@ public class Client {
 		PrivateKeyBundle(v1: privateKeyBundleV1)
 	}
 
+	public var publicKeyBundle: SignedPublicKeyBundle {
+		privateKeyBundleV1.toV2().getPublicKeyBundle()
+	}
+
 	public var v1keys: PrivateKeyBundleV1 {
 		privateKeyBundleV1
 	}

--- a/Sources/XMTP/Messages/SignedPrivateKey.swift
+++ b/Sources/XMTP/Messages/SignedPrivateKey.swift
@@ -22,7 +22,7 @@ extension SignedPrivateKey {
 		return signedPrivateKey
 	}
 
-	func sign(_ data: Data) async throws -> Signature {
+	public func sign(_ data: Data) async throws -> Signature {
 		let key = try PrivateKey(secp256K1.bytes)
 		return try await key.sign(data)
 	}

--- a/Sources/XMTP/Messages/SignedPublicKeyBundle.swift
+++ b/Sources/XMTP/Messages/SignedPublicKeyBundle.swift
@@ -7,7 +7,7 @@
 
 
 
-typealias SignedPublicKeyBundle = Xmtp_MessageContents_SignedPublicKeyBundle
+public typealias SignedPublicKeyBundle = Xmtp_MessageContents_SignedPublicKeyBundle
 
 extension SignedPublicKeyBundle {
 	init(_ publicKeyBundle: PublicKeyBundle) throws {


### PR DESCRIPTION
Lets folks get more information about the client as well as exposes signing functionality for those who need it.