### PR TITLE
fix: add visible initializers to some of the codec types

### DIFF
--- a/Sources/XMTP/Codecs/ContentTypeID.swift
+++ b/Sources/XMTP/Codecs/ContentTypeID.swift
@@ -17,7 +17,7 @@ public extension ContentTypeID {
 	}
 }
 
-extension ContentTypeID {
+public extension ContentTypeID {
 	var id: String {
 		"\(authorityID):\(typeID)"
 	}

--- a/Sources/XMTP/Codecs/ReactionCodec.swift
+++ b/Sources/XMTP/Codecs/ReactionCodec.swift
@@ -15,6 +15,13 @@ public struct Reaction: Codable {
     public var action: ReactionAction
     public var content: String
     public var schema: ReactionSchema
+    
+    public init(reference: String, action: ReactionAction, content: String, schema: ReactionSchema) {
+        self.reference = reference
+        self.action = action
+        self.content = content
+        self.schema = schema
+    }
 }
 
 public enum ReactionAction: String, Codable {

--- a/Sources/XMTP/Codecs/ReplyCodec.swift
+++ b/Sources/XMTP/Codecs/ReplyCodec.swift
@@ -13,6 +13,12 @@ public struct Reply {
 	public var reference: String
 	public var content: Any
 	public var contentType: ContentTypeID
+    
+    public init(reference: String, content: Any, contentType: ContentTypeID) {
+        self.reference = reference
+        self.content = content
+        self.contentType = contentType
+    }
 }
 
 public struct ReplyCodec: ContentCodec {


### PR DESCRIPTION
This is part of adding content types in https://github.com/xmtp/xmtp-react-native/pull/81