### PR TITLE
fix: use type from the reply nested content directly

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.4.6-alpha0"
+  spec.version      = "0.4.7-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This gets the nested type of a reply from the deserialized `EncodedContent` instead of inspecting the parameter map.