### PR TITLE
Only set app version on Client init

### DIFF
--- a/Sources/XMTP/ApiClient.swift
+++ b/Sources/XMTP/ApiClient.swift
@@ -73,6 +73,7 @@ class GRPCApiClient: ApiClient {
 		self.environment = environment
 		self.rustClient = rustClient
         self.appVersion = appVersion ?? "0.0.0"
+        rustClient.set_app_version(self.appVersion.intoRustString())
 	}
 
 	static func envToUrl(env: XMTPEnvironment) -> String {
@@ -89,7 +90,6 @@ class GRPCApiClient: ApiClient {
 
     func batchQuery(request: BatchQueryRequest) async throws -> BatchQueryResponse {
         do {
-            rustClient.set_app_version(appVersion.intoRustString())
             let req = RustVec<UInt8>(try request.serializedData())
             let res: RustVec<UInt8> = try await rustClient.batch_query(req)
             return try BatchQueryResponse(serializedData: Data(res))
@@ -100,7 +100,6 @@ class GRPCApiClient: ApiClient {
 
     func query(request: QueryRequest) async throws -> QueryResponse {
         do {
-            rustClient.set_app_version(appVersion.intoRustString())
             let req = RustVec<UInt8>(try request.serializedData())
             let res: RustVec<UInt8> = try await rustClient.query(req)
             return try QueryResponse(serializedData: Data(res))
@@ -142,7 +141,6 @@ class GRPCApiClient: ApiClient {
 	func subscribe(topics: [String]) -> AsyncThrowingStream<Envelope, Error> {
 		return AsyncThrowingStream { continuation in
 			Task {
-                rustClient.set_app_version(appVersion.intoRustString())
                 let request = SubscribeRequest.with { $0.contentTopics = topics }
                 let req = RustVec<UInt8>(try request.serializedData())
                 do {
@@ -166,7 +164,6 @@ class GRPCApiClient: ApiClient {
 
     func publish(request: PublishRequest) async throws -> PublishResponse {
         do {
-            rustClient.set_app_version(appVersion.intoRustString())
             let req = RustVec<UInt8>(try request.serializedData())
             let res: RustVec<UInt8> = try await rustClient.publish(authToken.intoRustString(), req)
             return try PublishResponse(serializedData: Data(res))


### PR DESCRIPTION
Possibly an issue with rust and swift allocation. Occasionally we are seeing errors around app version being set.