### PR TITLE
feat: include topic in the DecodedMessage

### DIFF
--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -194,6 +194,7 @@ public struct ConversationV1 {
 		let header = try message.v1.header
 
 		var decoded = DecodedMessage(
+            topic: envelope.contentTopic,
 			encodedContent: encodedMessage,
 			senderAddress: header.sender.walletAddress,
 			sent: message.v1.sentAt

--- a/Sources/XMTP/DecodedMessage.swift
+++ b/Sources/XMTP/DecodedMessage.swift
@@ -9,6 +9,8 @@ import Foundation
 
 /// Decrypted messages from a conversation.
 public struct DecodedMessage: Sendable {
+    public var topic: String
+
 	public var id: String = ""
 
 	public var encodedContent: EncodedContent
@@ -19,7 +21,8 @@ public struct DecodedMessage: Sendable {
 	/// When the message was sent
 	public var sent: Date
 
-	public init(encodedContent: EncodedContent, senderAddress: String, sent: Date) {
+    public init(topic: String, encodedContent: EncodedContent, senderAddress: String, sent: Date) {
+        self.topic = topic
 		self.encodedContent = encodedContent
 		self.senderAddress = senderAddress
 		self.sent = sent
@@ -43,10 +46,10 @@ public struct DecodedMessage: Sendable {
 }
 
 public extension DecodedMessage {
-	static func preview(body: String, senderAddress: String, sent: Date) -> DecodedMessage {
+    static func preview(topic: String, body: String, senderAddress: String, sent: Date) -> DecodedMessage {
 		// swiftlint:disable force_try
 		let encoded = try! TextCodec().encode(content: body)
 		// swiftlint:enable force_try
-		return DecodedMessage(encodedContent: encoded, senderAddress: senderAddress, sent: sent)
+        return DecodedMessage(topic: topic, encodedContent: encoded, senderAddress: senderAddress, sent: sent)
 	}
 }

--- a/Sources/XMTP/Messages/MessageV2.swift
+++ b/Sources/XMTP/Messages/MessageV2.swift
@@ -53,6 +53,7 @@ extension MessageV2 {
 			let header = try MessageHeaderV2(serializedData: message.headerBytes)
 
 			return DecodedMessage(
+                topic: header.topic,
 				encodedContent: encodedMessage,
 				senderAddress: try signed.sender.walletAddress,
 				sent: Date(timeIntervalSince1970: Double(header.createdNs / 1_000_000) / 1000)

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -327,6 +327,7 @@ class ConversationTests: XCTestCase {
 		let messages = try await aliceConversation.messages(limit: 1)
 		XCTAssertEqual(1, messages.count)
 		XCTAssertEqual("hey alice 3", messages[0].body)
+        XCTAssertEqual(aliceConversation.topic.description, messages[0].topic)
 
 		let messages2 = try await aliceConversation.messages(limit: 1, before: messages[0].sent)
 		XCTAssertEqual(1, messages2.count)
@@ -368,6 +369,7 @@ class ConversationTests: XCTestCase {
 		let messages = try await aliceConversation.messages(limit: 1)
 		XCTAssertEqual(1, messages.count)
 		XCTAssertEqual("hey alice 3", messages[0].body)
+        XCTAssertEqual(aliceConversation.topic, messages[0].topic)
 
 		let messages2 = try await aliceConversation.messages(limit: 1, before: messages[0].sent)
 		XCTAssertEqual(1, messages2.count)
@@ -427,6 +429,9 @@ class ConversationTests: XCTestCase {
             topics: [bobConversation.topic : Pagination(limit:3)]
         )
         XCTAssertEqual(3, messages.count)
+        XCTAssertEqual(bobConversation.topic, messages[0].topic)
+        XCTAssertEqual(bobConversation.topic, messages[1].topic)
+        XCTAssertEqual(bobConversation.topic, messages[2].topic)
     }
 
 	func testImportV1ConversationFromJS() async throws {


### PR DESCRIPTION
This adds the conversation `topic` to the `DecodedMessage` so that it can be associated with the corresponding conversation.

This is part of fix for the leftover bits from https://github.com/xmtp/xmtp-react-native/pull/86

This mirrors the Android edition from https://github.com/xmtp/xmtp-android/pull/110