### PR TITLE
fix: properly discard malformed messages during batch calls

### DIFF
--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -46,18 +46,18 @@ public class Conversations {
         for batch in batches {
             messages += try await client.apiClient.batchQuery(request: batch)
                 .responses.flatMap { (res) in
-                    try res.envelopes.compactMap { (envelope) in
+                    res.envelopes.compactMap { (envelope) in
                         let conversation = conversationsByTopic[envelope.contentTopic]
                         if conversation == nil {
                             print("discarding message, unknown conversation \(envelope)")
                             return nil
                         }
-                        let msg = try conversation?.decode(envelope)
-                        if msg == nil {
+                        do {
+                            return try conversation?.decode(envelope)
+                        } catch {
                             print("discarding message, unable to decode \(envelope)")
                             return nil
                         }
-                        return msg
                     }
                 }
         }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.4.9-alpha0"
+  spec.version      = "0.4.10-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This fixes a bug (reported via RN SDK) where malformed messages would prevent batch message listing on iOS. These malformed messages should be discarded instead of causing the entire listing request to fail.
