### PR TITLE
fix: update the invitation to create topics without direction

### DIFF
--- a/Sources/XMTP/Messages/Invitation.swift
+++ b/Sources/XMTP/Messages/Invitation.swift
@@ -14,15 +14,14 @@ extension InvitationV1 {
 			context: InvitationV1.Context? = nil
 	) throws -> InvitationV1 {
 		let context = context ?? InvitationV1.Context()
-
+        let myAddress = try sender.toV1().walletAddress
+        let theirAddress = try recipient.walletAddress
+        
 		let secret = try sender.sharedSecret(
 				peer: recipient,
 				myPreKey: sender.preKeys[0].publicKey,
-				isRecipient: false)
-		let addresses = [
-			try sender.toV1().walletAddress,
-			try recipient.walletAddress,
-		].sorted()
+				isRecipient: myAddress < theirAddress)
+		let addresses = [myAddress, theirAddress].sorted()
 		let msg = "\(context.conversationID)\(addresses.joined(separator: ","))"
 		let topicId = try Crypto.calculateMac(Data(msg.utf8), secret).toHex
 		let topic = Topic.directMessageV2(topicId)

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.4.10-alpha0"
+  spec.version      = "0.5.0-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-js/pull/449

Lets make topics deterministic in either invite direction