### PR TITLE
fix: normalize reaction encoding, support legacy form

### DIFF
--- a/Sources/XMTP/Codecs/ReactionCodec.swift
+++ b/Sources/XMTP/Codecs/ReactionCodec.swift
@@ -49,15 +49,19 @@ public struct ReactionCodec: ContentCodec {
 
     public func decode(content: EncodedContent) throws -> Reaction {
         // First try to decode it in the canonical form.
+        // swiftlint:disable no_optional_try
         if let reaction = try? JSONDecoder().decode(Reaction.self, from: content.content) {
             return reaction
         }
+        // swiftlint:disable no_optional_try
         // If that fails, try to decode it in the legacy form.
+        // swiftlint:disable force_unwrapping
         return Reaction(
             reference: content.parameters["reference"] ?? "",
             action: ReactionAction(rawValue: content.parameters["action"] ?? "")!,
             content: String(data: content.content, encoding: .utf8) ?? "",
             schema: ReactionSchema(rawValue: content.parameters["schema"] ?? "")!
         )
+        //swiftlint:disable force_unwrapping
     }
 }

--- a/Sources/XMTP/Codecs/ReactionCodec.swift
+++ b/Sources/XMTP/Codecs/ReactionCodec.swift
@@ -48,7 +48,16 @@ public struct ReactionCodec: ContentCodec {
     }
 
     public func decode(content: EncodedContent) throws -> Reaction {
-        let reaction = try JSONDecoder().decode(Reaction.self, from: content.content)
-        return reaction
+        // First try to decode it in the canonical form.
+        if let reaction = try? JSONDecoder().decode(Reaction.self, from: content.content) {
+            return reaction
+        }
+        // If that fails, try to decode it in the legacy form.
+        return Reaction(
+            reference: content.parameters["reference"] ?? "",
+            action: ReactionAction(rawValue: content.parameters["action"] ?? "")!,
+            content: String(data: content.content, encoding: .utf8) ?? "",
+            schema: ReactionSchema(rawValue: content.parameters["schema"] ?? "")!
+        )
     }
 }

--- a/Tests/XMTPTests/ReactionTests.swift
+++ b/Tests/XMTPTests/ReactionTests.swift
@@ -20,13 +20,13 @@ class ReactionTests: XCTestCase {
         let canonicalEncoded = EncodedContent.with {
             $0.type = ContentTypeReaction
             $0.content = Data("""
-{
-  "action": "added",
-  "content": "smile",
-  "reference": "abc123",
-  "schema": "shortcode"
-}
-""".utf8)
+            {
+              "action": "added",
+              "content": "smile",
+              "reference": "abc123",
+              "schema": "shortcode"
+            }
+            """.utf8)
         }
 
         // Previously, some clients sent reactions like this.

--- a/Tests/XMTPTests/ReactionTests.swift
+++ b/Tests/XMTPTests/ReactionTests.swift
@@ -12,6 +12,48 @@ import XCTest
 
 @available(iOS 15, *)
 class ReactionTests: XCTestCase {
+
+    func testCanDecodeLegacyForm() async throws {
+        let codec = ReactionCodec()
+
+        // This is how clients send reactions now.
+        let canonicalEncoded = EncodedContent.with {
+            $0.type = ContentTypeReaction
+            $0.content = Data("""
+{
+  "action": "added",
+  "content": "smile",
+  "reference": "abc123",
+  "schema": "shortcode"
+}
+""".utf8)
+        }
+
+        // Previously, some clients sent reactions like this.
+        // So we test here to make sure we can still decode them.
+        let legacyEncoded = EncodedContent.with {
+            $0.type = ContentTypeReaction
+            $0.parameters = [
+                "action": "added",
+                "reference": "abc123",
+                "schema": "shortcode",
+            ]
+            $0.content = Data("smile".utf8)
+        }
+
+        let canonical = try codec.decode(content: canonicalEncoded)
+        let legacy = try codec.decode(content: legacyEncoded)
+
+        XCTAssertEqual(ReactionAction.added, canonical.action)
+        XCTAssertEqual(ReactionAction.added, legacy.action)
+        XCTAssertEqual("smile", canonical.content)
+        XCTAssertEqual("smile", legacy.content)
+        XCTAssertEqual("abc123", canonical.reference)
+        XCTAssertEqual("abc123", legacy.reference)
+        XCTAssertEqual(ReactionSchema.shortcode, canonical.schema)
+        XCTAssertEqual(ReactionSchema.shortcode, legacy.schema)
+    }
+
     func testCanUseReactionCodec() async throws {
         Client.register(codec: ReactionCodec())
         

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.5.0-alpha0"
+  spec.version      = "0.5.1-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This fixes the iOS portion of how reactions are encoded across codec implementations.

See https://github.com/xmtp/xmtp-react-native/issues/93#issuecomment-1707220192
See also https://github.com/xmtp/xmtp-js-content-types/pull/26