### PR TITLE
feat: improve PreparedMessage handling

### DIFF
--- a/Sources/XMTP/ApiClient.swift
+++ b/Sources/XMTP/ApiClient.swift
@@ -9,14 +9,14 @@ import Foundation
 import XMTPRust
 import XMTPRustSwift
 
-typealias PublishRequest = Xmtp_MessageApi_V1_PublishRequest
-typealias PublishResponse = Xmtp_MessageApi_V1_PublishResponse
-typealias BatchQueryRequest = Xmtp_MessageApi_V1_BatchQueryRequest
-typealias BatchQueryResponse = Xmtp_MessageApi_V1_BatchQueryResponse
-typealias Cursor = Xmtp_MessageApi_V1_Cursor
-typealias QueryRequest = Xmtp_MessageApi_V1_QueryRequest
-typealias QueryResponse = Xmtp_MessageApi_V1_QueryResponse
-typealias SubscribeRequest = Xmtp_MessageApi_V1_SubscribeRequest
+public typealias PublishRequest = Xmtp_MessageApi_V1_PublishRequest
+public typealias PublishResponse = Xmtp_MessageApi_V1_PublishResponse
+public typealias BatchQueryRequest = Xmtp_MessageApi_V1_BatchQueryRequest
+public typealias BatchQueryResponse = Xmtp_MessageApi_V1_BatchQueryResponse
+public typealias Cursor = Xmtp_MessageApi_V1_Cursor
+public typealias QueryRequest = Xmtp_MessageApi_V1_QueryRequest
+public typealias QueryResponse = Xmtp_MessageApi_V1_QueryResponse
+public typealias SubscribeRequest = Xmtp_MessageApi_V1_SubscribeRequest
 
 public enum ApiClientError: Error {
     case batchQueryError(String)

--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -285,18 +285,18 @@ public class Client {
 		_ = try await publish(envelopes: envelopes)
 	}
 
-	func query(topic: Topic, pagination: Pagination? = nil) async throws -> QueryResponse {
+	public func query(topic: Topic, pagination: Pagination? = nil) async throws -> QueryResponse {
 		return try await apiClient.query(
 			topic: topic,
 			pagination: pagination
 		)
 	}
 
-    func batchQuery(request: BatchQueryRequest) async throws -> BatchQueryResponse {
+    public func batchQuery(request: BatchQueryRequest) async throws -> BatchQueryResponse {
         return try await apiClient.batchQuery(request: request)
     }
 
-	@discardableResult func publish(envelopes: [Envelope]) async throws -> PublishResponse {
+	@discardableResult public func publish(envelopes: [Envelope]) async throws -> PublishResponse {
 		let authorized = AuthorizedIdentity(address: address, authorized: privateKeyBundleV1.identityKey.publicKey, identity: privateKeyBundleV1.identityKey)
 		let authToken = try await authorized.createAuthToken()
 
@@ -305,11 +305,11 @@ public class Client {
 		return try await apiClient.publish(envelopes: envelopes)
 	}
 
-	func subscribe(topics: [String]) -> AsyncThrowingStream<Envelope, Error> {
+	public func subscribe(topics: [String]) -> AsyncThrowingStream<Envelope, Error> {
 		return apiClient.subscribe(topics: topics)
 	}
 
-	func subscribe(topics: [Topic]) -> AsyncThrowingStream<Envelope, Error> {
+	public func subscribe(topics: [Topic]) -> AsyncThrowingStream<Envelope, Error> {
 		return subscribe(topics: topics.map(\.description))
 	}
 

--- a/Sources/XMTP/Conversation.swift
+++ b/Sources/XMTP/Conversation.swift
@@ -123,6 +123,17 @@ public enum Conversation: Sendable {
 		}
 	}
 
+    // This is a convenience for invoking the underlying `client.publish(prepared.envelopes)`
+    // If a caller has a `Client` handy, they may opt to do that directly instead.
+    @discardableResult public func send(prepared: PreparedMessage) async throws -> String {
+        switch self {
+        case let .v1(conversationV1):
+            return try await conversationV1.send(prepared: prepared)
+        case let .v2(conversationV2):
+            return try await conversationV2.send(prepared: prepared)
+        }
+    }
+
 	@discardableResult public func send<T>(content: T, options: SendOptions? = nil, fallback _: String? = nil) async throws -> String {
 		switch self {
 		case let .v1(conversationV1):

--- a/Sources/XMTP/PreparedMessage.swift
+++ b/Sources/XMTP/PreparedMessage.swift
@@ -1,27 +1,36 @@
-//
-//  PreparedMessage.swift
-//
-//
-//  Created by Pat Nakajima on 3/9/23.
-//
-
 import CryptoKit
 import Foundation
 
+// This houses a fully prepared message that can be published
+// as soon as the API client has connectivity.
+//
+// To support persistance layers that queue pending messages (e.g. while offline)
+// this struct supports serializing to/from bytes that can be written to disk or elsewhere.
+// See serializedData() and fromSerializedData()
 public struct PreparedMessage {
-	var messageEnvelope: Envelope
-	var conversation: Conversation
-	var onSend: () async throws -> Void
+    
+    // The first envelope should send the message to the conversation itself.
+    // Any more are for required intros/invites etc.
+    // A client can just publish these when it has connectivity.
+    public let envelopes: [Envelope]
 
-	public func decodedMessage() throws -> DecodedMessage {
-		return try conversation.decode(messageEnvelope)
-	}
+    // Note: we serialize as a PublishRequest as a convenient `envelopes` wrapper.
+    public static func fromSerializedData(_ serializedData: Data) throws -> PreparedMessage {
+        let req = try Xmtp_MessageApi_V1_PublishRequest(serializedData: serializedData)
+        return PreparedMessage(envelopes: req.envelopes)
+    }
 
-	public func send() async throws {
-		try await onSend()
-	}
+    // Note: we serialize as a PublishRequest as a convenient `envelopes` wrapper.
+    public func serializedData() throws -> Data {
+        let req = Xmtp_MessageApi_V1_PublishRequest.with { $0.envelopes = envelopes }
+        return try req.serializedData()
+    }
 
-	var messageID: String {
-		Data(SHA256.hash(data: messageEnvelope.message)).toHex
-	}
+	public var messageID: String {
+        Data(SHA256.hash(data: envelopes[0].message)).toHex
+    }
+
+    public var conversationTopic: String {
+        envelopes[0].contentTopic
+    }
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.5.1-alpha0"
+  spec.version      = "0.5.2-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This refactors `PreparedMessage` to better support apps with robust pending queue architectures:
- the `PreparedMessage` now contains the fully prepared `envelopes`
- this adds reliable serialization methods to the `PreparedMessage` for persistence
- it also makes `public` a bunch of handy methods on the `Client` (e.g. so it can `.publish(...)` the envelopes)

This is the iOS portion of https://github.com/xmtp/xmtp-react-native/issues/82