### PR TITLE
feat: Move fallback content definition to content codecs 

### DIFF
--- a/Sources/XMTP/Codecs/AttachmentCodec.swift
+++ b/Sources/XMTP/Codecs/AttachmentCodec.swift
@@ -57,6 +57,6 @@ public struct AttachmentCodec: ContentCodec {
 	}
     
     public func fallback(content: Attachment) throws -> String? {
-        return "Error: Sorry, this app cannot display attachments"
+        return "Can’t display “\(content.filename)”. This app doesn’t support attachments."
     }
 }

--- a/Sources/XMTP/Codecs/AttachmentCodec.swift
+++ b/Sources/XMTP/Codecs/AttachmentCodec.swift
@@ -55,4 +55,8 @@ public struct AttachmentCodec: ContentCodec {
 
 		return attachment
 	}
+    
+    public func fallback(content: Attachment) throws -> String? {
+        return "Error: Sorry, this app cannot display attachments"
+    }
 }

--- a/Sources/XMTP/Codecs/Composite.swift
+++ b/Sources/XMTP/Codecs/Composite.swift
@@ -41,6 +41,10 @@ struct CompositeCodec: ContentCodec {
 		let decodedComposite = fromComposite(composite: composite)
 		return decodedComposite
 	}
+    
+    public func fallback(content: DecodedComposite) throws -> String? {
+        return nil
+    }
 
 	func toComposite(content decodedComposite: DecodedComposite) -> Composite {
 		var composite = Composite()

--- a/Sources/XMTP/Codecs/ContentCodec.swift
+++ b/Sources/XMTP/Codecs/ContentCodec.swift
@@ -71,6 +71,7 @@ public protocol ContentCodec: Hashable, Equatable {
 	var contentType: ContentTypeID { get }
 	func encode(content: T) throws -> EncodedContent
 	func decode(content: EncodedContent) throws -> T
+    func fallback(content: T) throws -> String?
 }
 
 public extension ContentCodec {

--- a/Sources/XMTP/Codecs/ReactionCodec.swift
+++ b/Sources/XMTP/Codecs/ReactionCodec.swift
@@ -64,4 +64,8 @@ public struct ReactionCodec: ContentCodec {
         )
         //swiftlint:disable force_unwrapping
     }
+    
+    public func fallback(content: Reaction) throws -> String? {
+        return "Error: Sorry, this app cannot display reactions"
+    }
 }

--- a/Sources/XMTP/Codecs/ReactionCodec.swift
+++ b/Sources/XMTP/Codecs/ReactionCodec.swift
@@ -66,6 +66,11 @@ public struct ReactionCodec: ContentCodec {
     }
     
     public func fallback(content: Reaction) throws -> String? {
-        return "Error: Sorry, this app cannot display reactions"
+        switch content.action {
+        case .added:
+            return "Reacted “\(content.content)” to an earlier message"
+        case .removed:
+            return "Removed “\(content.content)” from an earlier message"
+        }
     }
 }

--- a/Sources/XMTP/Codecs/ReadReceiptCodec.swift
+++ b/Sources/XMTP/Codecs/ReadReceiptCodec.swift
@@ -41,4 +41,8 @@ public struct ReadReceiptCodec: ContentCodec {
 
         return ReadReceipt(timestamp: timestamp)
     }
+    
+    public func fallback(content: ReadReceipt) throws -> String? {
+        return nil
+    }
 }

--- a/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
+++ b/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
@@ -132,6 +132,7 @@ public struct RemoteAttachment {
 }
 
 public struct RemoteAttachmentCodec: ContentCodec {
+    
 	public typealias T = RemoteAttachment
 
 	public init() {}
@@ -189,6 +190,10 @@ public struct RemoteAttachmentCodec: ContentCodec {
 
 		return attachment
 	}
+    
+    public func fallback(content: RemoteAttachment) throws -> String? {
+        return "Error: Sorry, this app cannot display attachments"
+    }
 
 	private func getHexParameter(_ name: String, from parameters: [String: String]) throws -> Data {
 		guard let parameterHex = parameters[name] else {

--- a/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
+++ b/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
@@ -192,7 +192,7 @@ public struct RemoteAttachmentCodec: ContentCodec {
 	}
     
     public func fallback(content: RemoteAttachment) throws -> String? {
-        return "Error: Sorry, this app cannot display attachments"
+        return "Can’t display “\(String(describing: content.filename))”. This app doesn’t support attachments."
     }
 
 	private func getHexParameter(_ name: String, from parameters: [String: String]) throws -> Data {

--- a/Sources/XMTP/Codecs/ReplyCodec.swift
+++ b/Sources/XMTP/Codecs/ReplyCodec.swift
@@ -62,4 +62,8 @@ public struct ReplyCodec: ContentCodec {
 			throw CodecError.invalidContent
 		}
 	}
+    
+    public func fallback(content: Reply) throws -> String? {
+        return "Error: Sorry, this app cannot display quote replies"
+    }
 }

--- a/Sources/XMTP/Codecs/ReplyCodec.swift
+++ b/Sources/XMTP/Codecs/ReplyCodec.swift
@@ -64,6 +64,6 @@ public struct ReplyCodec: ContentCodec {
 	}
     
     public func fallback(content: Reply) throws -> String? {
-        return "Error: Sorry, this app cannot display quote replies"
+        return "Replied with “\(content.content)” to an earlier message"
     }
 }

--- a/Sources/XMTP/Codecs/TextCodec.swift
+++ b/Sources/XMTP/Codecs/TextCodec.swift
@@ -14,6 +14,7 @@ enum TextCodecError: Error {
 }
 
 public struct TextCodec: ContentCodec {
+    
 	public typealias T = String
 
 	public init() {}
@@ -41,4 +42,8 @@ public struct TextCodec: ContentCodec {
 			throw TextCodecError.unknownDecodingError
 		}
 	}
+    
+    public func fallback(content: String) throws -> String? {
+        return nil
+    }
 }

--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -104,8 +104,19 @@ public struct ConversationV1 {
 
 		let content = content as T
 		var encoded = try encode(codec: codec, content: content)
-		encoded.fallback = options?.contentFallback ?? ""
-
+        
+        func fallback<Codec: ContentCodec>(codec: Codec, content: Any) throws -> String? {
+            if let content = content as? Codec.T {
+                return try codec.fallback(content: content)
+            } else {
+                throw CodecError.invalidContent
+            }
+        }
+        
+        if let fallback = try fallback(codec: codec, content: content) {
+            encoded.fallback = fallback
+        }
+        
 		if let compression = options?.compression {
 			encoded = try encoded.compress(compression)
 		}

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -98,9 +98,20 @@ public struct ConversationV2 {
 		}
 
 		var encoded = try encode(codec: codec, content: content)
-		encoded.fallback = options?.contentFallback ?? ""
-
-		if let compression = options?.compression {
+        
+        func fallback<Codec: ContentCodec>(codec: Codec, content: Any) throws -> String? {
+            if let content = content as? Codec.T {
+                return try codec.fallback(content: content)
+            } else {
+                throw CodecError.invalidContent
+            }
+        }
+        
+        if let fallback = try fallback(codec: codec, content: content) {
+            encoded.fallback = fallback
+        }
+		
+        if let compression = options?.compression {
 			encoded = try encoded.compress(compression)
 		}
 

--- a/Sources/XMTP/SendOptions.swift
+++ b/Sources/XMTP/SendOptions.swift
@@ -10,13 +10,11 @@ import Foundation
 public struct SendOptions {
 	public var compression: EncodedContentCompression?
 	public var contentType: ContentTypeID?
-	public var contentFallback: String?
 	public var ephemeral: Bool = false
 
-	public init(compression: EncodedContentCompression? = nil, contentType: ContentTypeID? = nil, contentFallback: String? = nil, ephemeral: Bool = false) {
+	public init(compression: EncodedContentCompression? = nil, contentType: ContentTypeID? = nil, ephemeral: Bool = false) {
 		self.compression = compression
 		self.contentType = contentType
-		self.contentFallback = contentFallback
 		self.ephemeral = ephemeral
 	}
 }

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -9,6 +9,10 @@ import XCTest
 @testable import XMTP
 
 struct NumberCodec: ContentCodec {
+    func fallback(content: Double) throws -> String? {
+        return "pi"
+    }
+    
 	typealias T = Double
 
 	var contentType: XMTP.ContentTypeID {
@@ -57,7 +61,7 @@ class CodecTests: XCTestCase {
 		let aliceClient = fixtures.aliceClient!
 		let aliceConversation = try await aliceClient.conversations.newConversation(with: fixtures.bob.address)
 
-		try await aliceConversation.send(content: 3.14, options: .init(contentType: NumberCodec().contentType, contentFallback: "pi"))
+		try await aliceConversation.send(content: 3.14, options: .init(contentType: NumberCodec().contentType))
 
 		// Remove number codec from registry
 		Client.codecRegistry.codecs.removeValue(forKey: NumberCodec().id)

--- a/Tests/XMTPTests/RemoteAttachmentTest.swift
+++ b/Tests/XMTPTests/RemoteAttachmentTest.swift
@@ -41,7 +41,7 @@ class RemoteAttachmentTests: XCTestCase {
 		remoteAttachmentContent.filename = "hello.txt"
 		remoteAttachmentContent.contentLength = 5
 
-		_ = try await conversation.send(content: remoteAttachmentContent, options: .init(contentType: ContentTypeRemoteAttachment, contentFallback: "hey"))
+		_ = try await conversation.send(content: remoteAttachmentContent, options: .init(contentType: ContentTypeRemoteAttachment))
 	}
 
 	func testCanUseAttachmentCodec() async throws {

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.5.2-alpha0"
+  spec.version      = "0.5.3-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
iOS side https://github.com/xmtp/xmtp-js/pull/426

Moves the content fallback for supported codecs into the codec itself.