### PR TITLE
Remove timestamp from read receipts

### DIFF
--- a/Sources/XMTP/Codecs/ReadReceiptCodec.swift
+++ b/Sources/XMTP/Codecs/ReadReceiptCodec.swift
@@ -9,13 +9,7 @@ import Foundation
 
 public let ContentTypeReadReceipt = ContentTypeID(authorityID: "xmtp.org", typeID: "readReceipt", versionMajor: 1, versionMinor: 0)
 
-public struct ReadReceipt {
-    public var timestamp: String
-    
-    public init(timestamp: String) {
-        self.timestamp = timestamp
-    }
-}
+public struct ReadReceipt {}
 
 public struct ReadReceiptCodec: ContentCodec {
     public typealias T = ReadReceipt
@@ -28,18 +22,13 @@ public struct ReadReceiptCodec: ContentCodec {
         var encodedContent = EncodedContent()
 
         encodedContent.type = ContentTypeReadReceipt
-        encodedContent.parameters = ["timestamp": content.timestamp]
         encodedContent.content = Data()
 
         return encodedContent
     }
 
     public func decode(content: EncodedContent) throws -> ReadReceipt {
-        guard let timestamp = content.parameters["timestamp"] else {
-            throw CodecError.invalidContent
-        }
-
-        return ReadReceipt(timestamp: timestamp)
+        return ReadReceipt()
     }
     
     public func fallback(content: ReadReceipt) throws -> String? {

--- a/Tests/XMTPTests/ReadReceiptTests.swift
+++ b/Tests/XMTPTests/ReadReceiptTests.swift
@@ -20,7 +20,7 @@ class ReadReceiptTests: XCTestCase {
 
         try await conversation.send(text: "hey alice 2 bob")
 
-        let read = ReadReceipt(timestamp: "2019-09-26T07:58:30.996+0200")
+        let read = ReadReceipt()
 
         try await conversation.send(
             content: read,
@@ -30,7 +30,7 @@ class ReadReceiptTests: XCTestCase {
         let updatedMessages = try await conversation.messages()
         
         let message = try await conversation.messages()[0]
-        let content: ReadReceipt = try message.content()
-        XCTAssertEqual("2019-09-26T07:58:30.996+0200", content.timestamp)
+        let contentType: String = message.encodedContent.type.typeID
+        XCTAssertEqual("readReceipt", contentType)
     }
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.5.4-alpha0"
+  spec.version      = "0.5.6-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Implements https://github.com/orgs/xmtp/discussions/43#discussioncomment-6972516

This removes the timestamp from the read receipt content type in favor of the timestamp already on the message.