### PR TITLE
Fix conversationsByTopic concurrency issues

### DIFF
--- a/Sources/XMTP/Conversations.swift
+++ b/Sources/XMTP/Conversations.swift
@@ -7,7 +7,7 @@ public enum ConversationError: Error {
 /// Handles listing and creating Conversations.
 public class Conversations {
     var client: Client
-    var conversationsByTopic: [String: Conversation] = [:]
+    @MainActor var conversationsByTopic: [String: Conversation] = [:]
 
     init(client: Client) {
         self.client = client

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.5.7-alpha0"
+  spec.version      = "0.5.8-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-ios/issues/159

Use async and await to fix concurrency issues around `conversationsByTopic` that was causing crashes.