### PR TITLE
Bump Rust Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", from: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/xmtp-rust-swift", from: "0.3.1-beta0"),
+		.package(url: "https://github.com/xmtp/xmtp-rust-swift", from: "0.3.5-beta0"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
+++ b/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
@@ -174,7 +174,7 @@ public struct RemoteAttachmentCodec: ContentCodec {
 			throw RemoteAttachmentError.invalidScheme("no scheme parameter")
 		}
 
-        if (!schemeString.starts(with: "https")) {
+        if (!schemeString.hasPrefix(RemoteAttachment.Scheme.https.rawValue)) {
 			throw RemoteAttachmentError.invalidScheme("invalid scheme value. must start with https")
 		}
 

--- a/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
+++ b/Sources/XMTP/Codecs/RemoteAttachmentCodec.swift
@@ -74,7 +74,7 @@ public struct RemoteAttachment {
 
 	func ensureSchemeMatches() throws {
 		if !url.hasPrefix(scheme.rawValue) {
-			throw RemoteAttachmentError.invalidScheme("scheme must be https://")
+			throw RemoteAttachmentError.invalidScheme("scheme must be https")
 		}
 	}
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.5.14-alpha0"
+  spec.version      = "0.6.0-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,7 +44,7 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift"
-  spec.dependency 'XMTPRust', '= 0.3.4-beta0'
+  spec.dependency 'XMTPRust', '= 0.3.5-beta0'
 
   spec.xcconfig = {'VALID_ARCHS' =>  'arm64' }
 end

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-rust-swift",
       "state" : {
-        "revision" : "4a76e5401fa780c40610e2f0d248f695261d08dd",
-        "version" : "0.3.1-beta0"
+        "revision" : "d1aaac47fc7c57645a6fe9e06972b957b3efa33c",
+        "version" : "0.3.5-beta0"
       }
     }
   ],


### PR DESCRIPTION
This bumps to the latest Rust version which drops the timeouts lower so they aren't noticeable.

I was not able to reproduce `Remote attachments don’t work between the xmtp.chat and iOS XMTP.RemoteAttachmentError.invalidScheme("invalid scheme value. must be https://")` But I modified some of the error messages to confirm that the latest version of swift is getting run.