### PR TITLE
Fix order of loading consent

### DIFF
--- a/Sources/XMTP/Contacts.swift
+++ b/Sources/XMTP/Contacts.swift
@@ -77,7 +77,7 @@ class ConsentList {
             preferences.append(try PrivatePreferencesAction(serializedData: Data(payload)))
 		}
         
-        preferences.forEach { preference in
+        preferences.reversed().forEach { preference in
             preference.allow.walletAddresses.forEach { address in
                 consentList.allow(address: address)
             }

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -612,6 +612,13 @@ class ConversationTests: XCTestCase {
 
 		// Conversations you start should start as allowed
 		XCTAssertTrue(isAllowed)
+        
+        try await bobClient.contacts.block(addresses: [alice.address])
+        try await bobClient.contacts.refreshConsentList()
+
+        let isBlocked = (await bobConversation.consentState()) == .blocked
+
+        XCTAssertTrue(isBlocked)
 
 		let aliceConversation = (try await aliceClient.conversations.list())[0]
 		let isUnknown = (await aliceConversation.consentState()) == .unknown

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.6.3-alpha0"
+  spec.version      = "0.6.4-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Turns out that consent will load the entries newest to oldest. This would make newer entries get overridden by older entries so if you allowed someone and then blocked them it would always show as allowed.
By reversing the iteration it will take the newest entries last and succeed.