### PR TITLE
Update pod spec arch types

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.6.4-alpha0"
+  spec.version      = "0.6.5-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -46,5 +46,5 @@ Pod::Spec.new do |spec|
   spec.dependency "Connect-Swift"
   spec.dependency 'XMTPRust', '= 0.3.6-beta0'
 
-  spec.xcconfig = {'VALID_ARCHS' =>  'arm64' }
+  spec.xcconfig = {'VALID_ARCHS' =>  'armv7 arm64 x86_64' }
 end


### PR DESCRIPTION
Should fix https://github.com/xmtp/xmtp-ios/issues/176

I think this was a just an oversight as the M1 macs when building cocoapods locally can error on these other types.
Should no longer be an issue for us as we build cocoapods on a docker image now.