### PR TITLE
Update block to deny and add implicit consent for sending messages

### DIFF
--- a/Sources/XMTP/Contacts.swift
+++ b/Sources/XMTP/Contacts.swift
@@ -59,7 +59,7 @@ class ConsentList {
             throw ContactError.invalidIdentifier
         }        
         
-        let envelopes = try await client.query(topic: .preferenceList(identifier))
+        let envelopes = try await client.query(topic: .preferenceList(identifier), pagination: Pagination(direction: .ascending))
 
 		let consentList = ConsentList(client: client)
         
@@ -77,7 +77,7 @@ class ConsentList {
             preferences.append(try PrivatePreferencesAction(serializedData: Data(payload)))
 		}
         
-        preferences.reversed().forEach { preference in
+        preferences.forEach { preference in
             preference.allow.walletAddresses.forEach { address in
                 consentList.allow(address: address)
             }

--- a/Sources/XMTP/ConversationV1.swift
+++ b/Sources/XMTP/ConversationV1.swift
@@ -140,6 +140,9 @@ public struct ConversationV1 {
 
     @discardableResult func send(prepared: PreparedMessage) async throws -> String {
         try await client.publish(envelopes: prepared.envelopes)
+        if((await client.contacts.consentList.state(address: peerAddress)) == .unknown) {
+            try await client.contacts.allow(addresses: [peerAddress])
+        }
         return prepared.messageID
     }
 

--- a/Sources/XMTP/ConversationV2.swift
+++ b/Sources/XMTP/ConversationV2.swift
@@ -196,6 +196,9 @@ public struct ConversationV2 {
 
     @discardableResult func send(prepared: PreparedMessage) async throws -> String {
         try await client.publish(envelopes: prepared.envelopes)
+        if((await client.contacts.consentList.state(address: peerAddress)) == .unknown) {
+            try await client.contacts.allow(addresses: [peerAddress])
+        }
         return prepared.messageID
     }
 

--- a/Sources/XMTP/Proto/message_contents/private_preferences.pb.swift
+++ b/Sources/XMTP/Proto/message_contents/private_preferences.pb.swift
@@ -67,7 +67,7 @@ public struct Xmtp_MessageContents_PrivatePreferencesAction {
         guard case .allow(let l) = lhs, case .allow(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.block, .block): return {
+      case (.deny, .deny): return {
         guard case .block(let l) = lhs, case .block(let r) = rhs else { preconditionFailure() }
         return l == r
       }()

--- a/Sources/XMTP/Proto/message_contents/private_preferences.pb.swift
+++ b/Sources/XMTP/Proto/message_contents/private_preferences.pb.swift
@@ -67,7 +67,7 @@ public struct Xmtp_MessageContents_PrivatePreferencesAction {
         guard case .allow(let l) = lhs, case .allow(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.deny, .deny): return {
+      case (.block, .block): return {
         guard case .block(let l) = lhs, case .block(let r) = rhs else { preconditionFailure() }
         return l == r
       }()

--- a/Tests/XMTPTests/ContactsTests.swift
+++ b/Tests/XMTPTests/ContactsTests.swift
@@ -76,9 +76,9 @@ class ContactsTests: XCTestCase {
 
 		XCTAssertFalse(result)
 
-		try await contacts.block(addresses: [fixtures.alice.address])
+		try await contacts.deny(addresses: [fixtures.alice.address])
 
-		result = await contacts.isBlocked(fixtures.alice.address)
+		result = await contacts.isDenied(fixtures.alice.address)
 		XCTAssertTrue(result)
 	}
 }

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -613,10 +613,10 @@ class ConversationTests: XCTestCase {
 		// Conversations you start should start as allowed
 		XCTAssertTrue(isAllowed)
         
-        try await bobClient.contacts.block(addresses: [alice.address])
+        try await bobClient.contacts.deny(addresses: [alice.address])
         try await bobClient.contacts.refreshConsentList()
 
-        let isBlocked = (await bobConversation.consentState()) == .blocked
+        let isBlocked = (await bobConversation.consentState()) == .denied
 
         XCTAssertTrue(isBlocked)
 

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -616,9 +616,9 @@ class ConversationTests: XCTestCase {
         try await bobClient.contacts.deny(addresses: [alice.address])
         try await bobClient.contacts.refreshConsentList()
 
-        let isBlocked = (await bobConversation.consentState()) == .denied
+        let isDenied = (await bobConversation.consentState()) == .denied
 
-        XCTAssertTrue(isBlocked)
+        XCTAssertTrue(isDenied)
 
 		let aliceConversation = (try await aliceClient.conversations.list())[0]
 		let isUnknown = (await aliceConversation.consentState()) == .unknown

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.6.5-alpha0"
+  spec.version      = "0.6.6-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This addresses the items outlined here: https://github.com/orgs/xmtp/discussions/49#discussioncomment-7429217

Changes the word blocked to denied and adds implicit consent for sending a message to a conversation with unknown consent.