### PR TITLE
fix: set Connect-Swift version explicitly

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -43,6 +43,6 @@ Pod::Spec.new do |spec|
 
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
-  spec.dependency "Connect-Swift"
+  spec.dependency "Connect-Swift", '= 0.9.0'
   spec.dependency 'XMTPRust', '= 0.3.6-beta0'
 end


### PR DESCRIPTION
[Connect-Swift 0.10.0](
https://github.com/connectrpc/connect-swift/releases/tag/0.10.0) introduces a breaking change by adding another parameter in [unary api](https://github.com/connectrpc/connect-swift/commit/5ba072fdbad51a994e84656b6478c39ff470eb77)

In my case this causes React Native iOS builds to fail. [See discord message for logs](https://discord.com/channels/831836269558235136/1171532060482080910/1176983376499068948)

This PR fixes the package version to the last working version.

Not sure if you guys want to update [the generated code](https://github.com/xmtp/xmtp-ios/blob/3d5103e9372970ab5d2c58c0a7b467b2ec278b1b/XMTP.podspec) that is breaking but for at least for now this should be a temporary solution.