### PR TITLE
Bump the pod

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.6.8-alpha0"
+  spec.version      = "0.6.9-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
The pod spec is failing with `[!] Unable to accept duplicate entry for: XMTP (0.6.8-alpha0)`

https://github.com/xmtp/xmtp-ios/actions/runs/6982329393

Needed so we can fix this https://github.com/xmtp/xmtp-react-native/issues/153