### PR TITLE
make canMessage method accessible on the Client class

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
 		.package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", exact: "0.10.0"),
 		.package(url: "https://github.com/argentlabs/web3.swift", from: "1.1.0"),
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
-		.package(url: "https://github.com/bufbuild/connect-swift", from: "0.3.0"),
+		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
 		.package(url: "https://github.com/xmtp/xmtp-rust-swift", branch: "main"),
 	],

--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -192,6 +192,18 @@ public final class Client: Sendable {
 	public func canMessage(_ peerAddress: String) async throws -> Bool {
 		return try await query(topic: .contact(peerAddress)).envelopes.count > 0
 	}
+  
+  public static func canMessage(_ peerAddress: String, options: ClientOptions? = nil) async throws -> Bool {
+    let options = options ?? ClientOptions()
+
+    let client = try await XMTPRust.create_client(GRPCApiClient.envToUrl(env: options.api.env), options.api.env != .local)
+    let apiClient = try GRPCApiClient(
+      environment: options.api.env,
+      secure: options.api.isSecure,
+      rustClient: client
+    )
+    return try await apiClient.query(topic: .contact(peerAddress)).envelopes.count > 0
+  }
 
 	public func importConversation(from conversationData: Data) throws -> Conversation? {
 		let jsonDecoder = JSONDecoder()

--- a/Sources/XMTP/Client.swift
+++ b/Sources/XMTP/Client.swift
@@ -193,17 +193,17 @@ public final class Client: Sendable {
 		return try await query(topic: .contact(peerAddress)).envelopes.count > 0
 	}
   
-  public static func canMessage(_ peerAddress: String, options: ClientOptions? = nil) async throws -> Bool {
-    let options = options ?? ClientOptions()
+    public static func canMessage(_ peerAddress: String, options: ClientOptions? = nil) async throws -> Bool {
+        let options = options ?? ClientOptions()
 
-    let client = try await XMTPRust.create_client(GRPCApiClient.envToUrl(env: options.api.env), options.api.env != .local)
-    let apiClient = try GRPCApiClient(
-      environment: options.api.env,
-      secure: options.api.isSecure,
-      rustClient: client
-    )
-    return try await apiClient.query(topic: .contact(peerAddress)).envelopes.count > 0
-  }
+        let client = try await XMTPRust.create_client(GRPCApiClient.envToUrl(env: options.api.env), options.api.env != .local)
+        let apiClient = try GRPCApiClient(
+          environment: options.api.env,
+          secure: options.api.isSecure,
+          rustClient: client
+        )
+        return try await apiClient.query(topic: .contact(peerAddress)).envelopes.count > 0
+    }
 
 	public func importConversation(from conversationData: Data) throws -> Conversation? {
 		let jsonDecoder = JSONDecoder()

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -30,20 +30,20 @@ class ClientTests: XCTestCase {
 		XCTAssertFalse(cannotMessage)
 	}
 
-  func testStaticCanMessage() async throws {
-      try TestConfig.skip(because: "run manually against dev")
-    let opts = ClientOptions(api: ClientOptions.Api(env: .local, isSecure: false))
+    func testStaticCanMessage() async throws {
+        try TestConfig.skip(because: "run manually against local")
+        let opts = ClientOptions(api: ClientOptions.Api(env: .local, isSecure: false))
 
-    let aliceWallet = try PrivateKey.generate()
-    let notOnNetwork = try PrivateKey.generate()
-    let alice = try await Client.create(account: aliceWallet, options: opts)
+        let aliceWallet = try PrivateKey.generate()
+        let notOnNetwork = try PrivateKey.generate()
+        let alice = try await Client.create(account: aliceWallet, options: opts)
 
-    let canMessage = try await Client.canMessage(alice.address, options: opts)
-    let cannotMessage = try await Client.canMessage(notOnNetwork.address, options: opts)
-    XCTAssertTrue(canMessage)
-    XCTAssertFalse(cannotMessage)
-  }
-  
+        let canMessage = try await Client.canMessage(alice.address, options: opts)
+        let cannotMessage = try await Client.canMessage(notOnNetwork.address, options: opts)
+        XCTAssertTrue(canMessage)
+        XCTAssertFalse(cannotMessage)
+    }
+
 	func testHasPrivateKeyBundleV1() async throws {
 		let fakeWallet = try PrivateKey.generate()
 		let client = try await Client.create(account: fakeWallet, apiClient: FakeApiClient())

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -30,6 +30,18 @@ class ClientTests: XCTestCase {
 		XCTAssertFalse(cannotMessage)
 	}
 
+  func testStaticCanMessage() async throws {
+    try TestConfig.skip(because: "run manually against dev")
+    let fixtures = await fixtures()
+    let notOnNetwork = try PrivateKey.generate()
+    let opts = ClientOptions(api: .init(env: .local, isSecure: false))
+
+    let canMessage = try await Client.canMessage(fixtures.bobClient.address, options: opts)
+    let cannotMessage = try await Client.canMessage(notOnNetwork.address, options: opts)
+    XCTAssertTrue(canMessage)
+    XCTAssertFalse(cannotMessage)
+  }
+  
 	func testHasPrivateKeyBundleV1() async throws {
 		let fakeWallet = try PrivateKey.generate()
 		let client = try await Client.create(account: fakeWallet, apiClient: FakeApiClient())

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -37,7 +37,6 @@ class ClientTests: XCTestCase {
     let aliceWallet = try PrivateKey.generate()
     let notOnNetwork = try PrivateKey.generate()
     let alice = try await Client.create(account: aliceWallet, options: opts)
-    _ = try await alice.getUserContact(peerAddress: alice.address)
 
     let canMessage = try await Client.canMessage(alice.address, options: opts)
     let cannotMessage = try await Client.canMessage(notOnNetwork.address, options: opts)

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -31,6 +31,7 @@ class ClientTests: XCTestCase {
 	}
 
   func testStaticCanMessage() async throws {
+      try TestConfig.skip(because: "run manually against dev")
     let opts = ClientOptions(api: ClientOptions.Api(env: .local, isSecure: false))
 
     let aliceWallet = try PrivateKey.generate()

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -31,12 +31,14 @@ class ClientTests: XCTestCase {
 	}
 
   func testStaticCanMessage() async throws {
-    try TestConfig.skip(because: "run manually against dev")
-    let fixtures = await fixtures()
-    let notOnNetwork = try PrivateKey.generate()
-    let opts = ClientOptions(api: .init(env: .local, isSecure: false))
+    let opts = ClientOptions(api: ClientOptions.Api(env: .local, isSecure: false))
 
-    let canMessage = try await Client.canMessage(fixtures.bobClient.address, options: opts)
+    let aliceWallet = try PrivateKey.generate()
+    let notOnNetwork = try PrivateKey.generate()
+    let alice = try await Client.create(account: aliceWallet, options: opts)
+    _ = try await alice.getUserContact(peerAddress: alice.address)
+
+    let canMessage = try await Client.canMessage(alice.address, options: opts)
     let cannotMessage = try await Client.canMessage(notOnNetwork.address, options: opts)
     XCTAssertTrue(canMessage)
     XCTAssertFalse(cannotMessage)

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.6.8-alpha0"
+  spec.version      = "0.6.9-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -43,6 +43,6 @@ Pod::Spec.new do |spec|
 
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
-  spec.dependency "Connect-Swift"
+  spec.dependency "Connect-Swift", "= 0.3.0"
   spec.dependency 'XMTPRust', '= 0.3.6-beta0'
 end


### PR DESCRIPTION
This PR exposes the `canMessage` method as requested in this [comment](https://github.com/xmtp/xmtp-react-native/issues/109#issuecomment-1719252634)