### PR TITLE
Expose consent entries

### DIFF
--- a/Sources/XMTP/Contacts.swift
+++ b/Sources/XMTP/Contacts.swift
@@ -37,8 +37,8 @@ public enum ContactError: Error {
     case invalidIdentifier
 }
 
-class ConsentList {
-	var entries: [String: ConsentState] = [:]
+public class ConsentList {
+	public var entries: [String: ConsentState] = [:]
     var publicKey: Data
     var privateKey: Data
     var identifier: String?
@@ -148,7 +148,7 @@ public actor Contacts {
 	// Whether or not we have sent invite/intro to this contact
 	var hasIntroduced: [String: Bool] = [:]
 
-    var consentList: ConsentList
+    public var consentList: ConsentList
 	
     init(client: Client) {
 		self.client = client

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.7.0-alpha0"
+  spec.version      = "0.7.1-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -249,7 +249,7 @@
       "location" : "https://github.com/xmtp/xmtp-rust-swift",
       "state" : {
         "branch" : "main",
-        "revision" : "eb931c2f467c2a71a621f54d7ae22887b234c13a"
+        "revision" : "e08af6942841054ae02a6fe01d90d18e76d5f248"
       }
     }
   ],


### PR DESCRIPTION
Expose the map of consent entries so integrators can get all the consent items at once to populate their databases.