### PR TITLE
Add Pagination to Consent Query

### DIFF
--- a/Sources/XMTP/Contacts.swift
+++ b/Sources/XMTP/Contacts.swift
@@ -59,14 +59,13 @@ public class ConsentList {
             throw ContactError.invalidIdentifier
         }        
         
-        let envelopes = try await client.query(topic: .preferenceList(identifier), pagination: Pagination(direction: .ascending))
+        let envelopes = try await client.apiClient.envelopes(topic: Topic.preferenceList(identifier).description, pagination: Pagination(direction: .ascending))
 
 		let consentList = ConsentList(client: client)
         
         var preferences: [PrivatePreferencesAction] = []
 
-		for envelope in envelopes.envelopes {
-
+		for envelope in envelopes {
 
 			let payload = try XMTPRust.user_preferences_decrypt(
 				RustVec(publicKey),

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.7.4-alpha0"
+  spec.version      = "0.7.5-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-react-native/issues/197

Consent was erroring because it was only returning the first 100 entries from the network. Now we use the envelopes method that paginations all of the envelopes.