### PR TITLE
Add Key Material Function

### DIFF
--- a/Sources/XMTP/Conversation.swift
+++ b/Sources/XMTP/Conversation.swift
@@ -78,6 +78,15 @@ public enum Conversation: Sendable {
 			return conversationV2.peerAddress
 		}
 	}
+	
+	public var keyMaterial: Data? {
+		switch self {
+		case let .v1(conversationV1):
+			return nil
+		case let .v2(conversationV2):
+			return conversationV2.keyMaterial
+		}
+	}
 
 	/// An optional string that can specify a different context for a conversation with another account address.
 	///

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.7.6-alpha0"
+  spec.version      = "0.7.7-alpha0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
React Native is currently broken because we need a key material.

Because the latest changes to libxmtp broke the react native bridge I'm branching off the last working branch.
https://github.com/xmtp/xmtp-react-native/issues/221