### PR TITLE
Access libxmtp-swift with static binaries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", revision: "e0cac80"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", revision: "58e80a6"),
 //		.package(path: "../libxmtp-swift")
 	],
 	targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", revision: "ccbf6ac"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", revision: "e0cac80"),
 //		.package(path: "../libxmtp-swift")
 	],
 	targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", revision: "58e80a6"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", revision: "e5d26a4"),
 //		.package(path: "../libxmtp-swift")
 	],
 	targets: [

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "branch" : "58e80a6",
-        "revision" : "58e80a641f45ed6b5033e220f982efeb5c3dbe86"
+        "branch" : "e5d26a4",
+        "revision" : "e5d26a45966f568829e71cd087952de30234de58"
       }
     },
     {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "branch" : "60b99d0",
-        "revision" : "60b99d04f642a7e2b15156d818dabc4aab65b1c0"
+        "branch" : "e0cac80",
+        "revision" : "e0cac80a44cde67ce229eceb2a01b98b537caf84"
       }
     },
     {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "branch" : "e0cac80",
-        "revision" : "e0cac80a44cde67ce229eceb2a01b98b537caf84"
+        "branch" : "58e80a6",
+        "revision" : "58e80a641f45ed6b5033e220f982efeb5c3dbe86"
       }
     },
     {


### PR DESCRIPTION
The only change in this PR is to test xmtp-ios via any tests and the example app against the "static library" or .a file version of our libxmtp swift bindings. See below PRs for more details.

Related PRs:

- https://github.com/xmtp/libxmtp/pull/433
- https://github.com/xmtp/libxmtp-swift/pull/4