### PR TITLE
feat: proposal encode should push

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "branch" : "92274fe",
-        "revision" : "92274fe0dde1fc7f8f716ebcffa3d252813be56d"
+        "branch" : "503086d",
+        "revision" : "503086d91ba6c3420aca118e4812d62a004d17ee"
       }
     },
     {

--- a/Sources/XMTPiOS/Messages/MessageV2.swift
+++ b/Sources/XMTPiOS/Messages/MessageV2.swift
@@ -80,9 +80,10 @@ extension MessageV2 {
 		}
 	}
 
-	static func encode<Codec: ContentCodec>(client: Client, content encodedContent: EncodedContent, topic: String, keyMaterial: Data, codec: Codec) async throws -> MessageV2 {
+	static func encode(client: Client, content encodedContent: EncodedContent, topic: String, keyMaterial: Data) async throws -> MessageV2 {
 		let payload = try encodedContent.serializedData()
-
+		let shouldPush = encodedContent.shouldPush
+		
 		let date = Date()
 		let header = MessageHeaderV2(topic: topic, created: date)
 		let headerBytes = try header.serializedData()
@@ -105,9 +106,6 @@ extension MessageV2 {
 		}
 
 		let senderHmac = try Crypto.generateHmacSignature(secret: keyMaterial, info: infoEncoded, message: headerBytes)
-		
-		let decoded = try codec.decode(content: encodedContent, client: client)
-		let shouldPush = try codec.shouldPush(content: decoded)
 		
 
 		return MessageV2(

--- a/Sources/XMTPiOS/Proto/message_contents/content.pb.swift
+++ b/Sources/XMTPiOS/Proto/message_contents/content.pb.swift
@@ -132,6 +132,9 @@ public struct Xmtp_MessageContents_EncodedContent {
 
   /// encoded content itself
   public var content: Data = Data()
+	
+  /// Indicates whether the content should be pushed.
+  public var shouldPush: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -256,6 +259,7 @@ extension Xmtp_MessageContents_EncodedContent: SwiftProtobuf.Message, SwiftProto
     3: .same(proto: "fallback"),
     5: .same(proto: "compression"),
     4: .same(proto: "content"),
+	6: .same(proto: "shouldPush"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -269,6 +273,7 @@ extension Xmtp_MessageContents_EncodedContent: SwiftProtobuf.Message, SwiftProto
       case 3: try { try decoder.decodeSingularStringField(value: &self._fallback) }()
       case 4: try { try decoder.decodeSingularBytesField(value: &self.content) }()
       case 5: try { try decoder.decodeSingularEnumField(value: &self._compression) }()
+	  case 6: try { try decoder.decodeSingularBoolField(value: &self.shouldPush) }()
       default: break
       }
     }
@@ -294,7 +299,10 @@ extension Xmtp_MessageContents_EncodedContent: SwiftProtobuf.Message, SwiftProto
     try { if let v = self._compression {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     } }()
-    try unknownFields.traverse(visitor: &visitor)
+	if self.shouldPush != false {
+	  try visitor.visitSingularBoolField(value: self.shouldPush, fieldNumber: 6)
+	}
+	try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Xmtp_MessageContents_EncodedContent, rhs: Xmtp_MessageContents_EncodedContent) -> Bool {
@@ -303,6 +311,7 @@ extension Xmtp_MessageContents_EncodedContent: SwiftProtobuf.Message, SwiftProto
     if lhs._fallback != rhs._fallback {return false}
     if lhs._compression != rhs._compression {return false}
     if lhs.content != rhs.content {return false}
+	if lhs.shouldPush != rhs.shouldPush {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -96,8 +96,7 @@ class CodecTests: XCTestCase {
 			client: aliceClient,
 			content: messages[0].encodedContent,
 			topic: aliceConversation.topic,
-			keyMaterial: Data(aliceConversation.keyMaterial!),
-			codec: NumberCodec()
+			keyMaterial: Data(aliceConversation.keyMaterial!)
 		)
 		
 		XCTAssertEqual(false, message.shouldPush)

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -230,8 +230,7 @@ class ConversationTests: XCTestCase {
 						client: bobClient,
 						content: encodedContent,
 						topic: conversation.topic,
-						keyMaterial: conversation.keyMaterial,
-						codec: encoder
+						keyMaterial: conversation.keyMaterial
 					)
 				).serializedData()
 			)

--- a/Tests/XMTPTests/MessageTests.swift
+++ b/Tests/XMTPTests/MessageTests.swift
@@ -63,7 +63,7 @@ class MessageTests: XCTestCase {
 		let sealedInvitation = try SealedInvitation.createV1(sender: alice.toV2(), recipient: bob.toV2().getPublicKeyBundle(), created: Date(), invitation: invitationv1)
 		let encoder = TextCodec()
 		let encodedContent = try encoder.encode(content: "Yo!", client: client)
-		let message1 = try await MessageV2.encode(client: client, content: encodedContent, topic: invitationv1.topic, keyMaterial: invitationv1.aes256GcmHkdfSha256.keyMaterial, codec: encoder)
+		let message1 = try await MessageV2.encode(client: client, content: encodedContent, topic: invitationv1.topic, keyMaterial: invitationv1.aes256GcmHkdfSha256.keyMaterial)
 
 		let decoded = try MessageV2.decode("", "", message1, keyMaterial: invitationv1.aes256GcmHkdfSha256.keyMaterial, client: client)
 		let result: String = try decoded.content()


### PR DESCRIPTION
**Description:**

This PR is a potential solution for sending the `shouldPush` flag as a part of the `EncodedContent`. By doing this the decode after encoding is no longer needed, the encode parameters remain the same and also it would be easy to send from the React Native side, using the same way as we currently send the fallback.