### PR TITLE
Improve error messages

### DIFF
--- a/Sources/XMTPiOS/ApiClient.swift
+++ b/Sources/XMTPiOS/ApiClient.swift
@@ -17,11 +17,24 @@ public typealias QueryRequest = Xmtp_MessageApi_V1_QueryRequest
 public typealias QueryResponse = Xmtp_MessageApi_V1_QueryResponse
 public typealias SubscribeRequest = Xmtp_MessageApi_V1_SubscribeRequest
 
-public enum ApiClientError: Error {
+public enum ApiClientError: Error, CustomStringConvertible {
 	case batchQueryError(String)
 	case queryError(String)
 	case publishError(String)
 	case subscribeError(String)
+
+	public var description: String {
+		switch self {
+		case .batchQueryError(let err):
+			return "ApiClientError.batchQueryError: \(err)"
+		case .queryError(let err):
+			return "ApiClientError.queryError: \(err)"
+		case .publishError(let err):
+			return "ApiClientError.publishError: \(err)"
+		case .subscribeError(let err):
+			return "ApiClientError.subscribeError: \(err)"
+		}
+	}
 }
 
 protocol ApiClient: Sendable {

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -11,8 +11,15 @@ import web3
 
 public typealias PreEventCallback = () async throws -> Void
 
-public enum ClientError: Error {
+public enum ClientError: Error, CustomStringConvertible {
 	case creationError(String)
+
+	public var description: String {
+		switch self {
+		case .creationError(let err):
+			return "ClientError.creationError: \(err)"
+		}
+	}
 }
 
 /// Specify configuration options for creating a ``Client``.

--- a/Sources/XMTPiOS/Codecs/RemoteAttachmentCodec.swift
+++ b/Sources/XMTPiOS/Codecs/RemoteAttachmentCodec.swift
@@ -11,8 +11,25 @@ import web3
 
 public let ContentTypeRemoteAttachment = ContentTypeID(authorityID: "xmtp.org", typeID: "remoteStaticAttachment", versionMajor: 1, versionMinor: 0)
 
-public enum RemoteAttachmentError: Error {
+public enum RemoteAttachmentError: Error, CustomStringConvertible {
 	case invalidURL, v1NotSupported, invalidParameters(String), invalidDigest(String), invalidScheme(String), payloadNotFound
+
+	public var description: String {
+		switch self {
+		case .invalidURL:
+			return "RemoteAttachmentError.invalidURL"
+		case .v1NotSupported:
+			return "RemoteAttachmentError.v1NotSupported"
+		case .invalidParameters(let string):
+			return "RemoteAttachmentError.invalidParameters: \(string)"
+		case .invalidDigest(let string):
+			return "RemoteAttachmentError.invalidDigest: \(string)"
+		case .invalidScheme(let string):
+			return "RemoteAttachmentError.invalidScheme: \(string)"
+		case .payloadNotFound:
+			return "RemoteAttachmentError.payloadNotFound"
+		}
+	}
 }
 
 protocol RemoteContentFetcher {

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -1,7 +1,18 @@
 import Foundation
 
-public enum ConversationError: Error {
+public enum ConversationError: Error, CustomStringConvertible {
 	case recipientNotOnNetwork, recipientIsSender, v1NotSupported(String)
+
+	public var description: String {
+		switch self {
+		case .recipientIsSender:
+			return "ConversationError.recipientIsSender: Recipient cannot be sender"
+		case .recipientNotOnNetwork:
+			return "ConversationError.recipientNotOnNetwork: Recipient is not on network"
+		case .v1NotSupported(let str):
+			return "ConversationError.v1NotSupported: V1 does not support: \(str)"
+		}
+	}
 }
 
 /// Handles listing and creating Conversations.

--- a/Sources/XMTPiOS/Messages/PrivateKey.swift
+++ b/Sources/XMTPiOS/Messages/PrivateKey.swift
@@ -13,8 +13,19 @@ import CryptoKit
 /// to create a ``Client``.
 public typealias PrivateKey = Xmtp_MessageContents_PrivateKey
 
-enum PrivateKeyError: Error {
+enum PrivateKeyError: Error, CustomStringConvertible {
 	case invalidSignatureText, invalidPrefix, invalidSignature
+
+	var description: String {
+		switch self {
+		case .invalidSignatureText:
+			return "PrivateKeyError.invalidSignatureText"
+		case .invalidPrefix:
+			return "PrivateKeyError.invalidPrefix"
+		case .invalidSignature:
+			return "PrivateKeyError.invalidSignature"
+		}
+	}
 }
 
 extension PrivateKey: SigningKey {

--- a/Sources/XMTPiOS/Messages/SealedInvitation.swift
+++ b/Sources/XMTPiOS/Messages/SealedInvitation.swift
@@ -10,8 +10,12 @@ import Foundation
 
 typealias SealedInvitation = Xmtp_MessageContents_SealedInvitation
 
-enum SealedInvitationError: Error {
+enum SealedInvitationError: Error, CustomStringConvertible {
 	case noSignature
+
+	var description: String {
+		"SealedInvitationError.noSignature"
+	}
 }
 
 extension SealedInvitation {

--- a/Sources/XMTPiOS/Messages/Signature.swift
+++ b/Sources/XMTPiOS/Messages/Signature.swift
@@ -11,8 +11,12 @@ import LibXMTP
 /// Represents a secp256k1 compact recoverable signature.
 public typealias Signature = Xmtp_MessageContents_Signature
 
-enum SignatureError: Error {
+enum SignatureError: Error, CustomStringConvertible {
 	case invalidMessage
+
+	var description: String {
+		return "SignatureError.invalidMessage"
+	}
 }
 
 public extension Signature {

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -34,6 +34,15 @@ class ConversationsTests: XCTestCase {
 		XCTAssertEqual(conversation.createdAt.description, created.description)
 	}
 
+	func testError() async throws {
+		let fixtures = await fixtures()
+		do {
+			try await fixtures.aliceClient.conversations.newConversation(with: fixtures.alice.address)
+		} catch {
+			print("ERRORohno: \(error)")
+		}
+	}
+
 	func testCanGetConversationFromInviteEnvelope() async throws {
 		let fixtures = await fixtures()
 		let client: Client = fixtures.aliceClient!

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -34,15 +34,6 @@ class ConversationsTests: XCTestCase {
 		XCTAssertEqual(conversation.createdAt.description, created.description)
 	}
 
-	func testError() async throws {
-		let fixtures = await fixtures()
-		do {
-			try await fixtures.aliceClient.conversations.newConversation(with: fixtures.alice.address)
-		} catch {
-			print("ERRORohno: \(error)")
-		}
-	}
-
 	func testCanGetConversationFromInviteEnvelope() async throws {
 		let fixtures = await fixtures()
 		let client: Client = fixtures.aliceClient!

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.8.0"
+  spec.version      = "0.8.1"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,7 +51,7 @@
       "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
       "state" : {
         "branch" : "master",
-        "revision" : "ecb18d8ce4d88277cc4fb103973352d91e18c535"
+        "revision" : "e0c7eebc5a4465a3c4680764f26b7a61f567cdaf"
       }
     },
     {
@@ -231,7 +231,7 @@
       "location" : "https://github.com/WalletConnect/WalletConnectSwiftV2",
       "state" : {
         "branch" : "main",
-        "revision" : "13446a81e678e8eddc6ab506e85c522df0163f1f"
+        "revision" : "f2db5e796976e6294b40da01c443f39a16b4732a"
       }
     },
     {


### PR DESCRIPTION
Should help out with https://github.com/xmtp/xmtp-react-native/issues/225.

Closes https://github.com/xmtp/xmtp-ios/issues/221.

Before:

> XMTPiOS.ConversationError error 2

After:

> Recipient cannot be sender
