### PR TITLE
Don't update to WalletConnectSwiftV2 until we resolve errors

### DIFF
--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -231,7 +231,7 @@
       "location" : "https://github.com/WalletConnect/WalletConnectSwiftV2",
       "state" : {
         "branch" : "main",
-        "revision" : "f2db5e796976e6294b40da01c443f39a16b4732a"
+        "revision" : "13446a81e678e8eddc6ab506e85c522df0163f1f"
       }
     },
     {


### PR DESCRIPTION
WalletConnectSwiftV2 was updated in Example project Package.resolved in [this PR](https://github.com/xmtp/xmtp-ios/pull/240/files) and it broke the example project. 

We should not update this until we fix errors from the WalletConnectSwiftV2 update. 

