### PR TITLE
Fix typo in groups file

### DIFF
--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -9,10 +9,10 @@ import Foundation
 import LibXMTP
 
 final class MessageCallback: FfiMessageCallback {
-	let client: XMTPiOS.Client
+	let client: Client
 	let callback: (DecodedMessage) -> Void
 
-	init(client: XMTPiOS.Client, _ callback: @escaping (DecodedMessage) -> Void) {
+	init(client: Client, _ callback: @escaping (DecodedMessage) -> Void) {
 		self.client = client
 		self.callback = callback
 	}


### PR DESCRIPTION
Cocoapods returning

```
    - ERROR | [iOS] xcodebuild:  /Users/runner/work/xmtp-ios/xmtp-ios/Sources/XMTPiOS/Group.swift:12:14: error: cannot find type 'XMTPiOS' in scope
    - ERROR | [iOS] xcodebuild:  /Users/runner/work/xmtp-ios/xmtp-ios/Sources/XMTPiOS/Group.swift:15:15: error: cannot find type 'XMTPiOS' in scope
```

We shouldn't need the name spacing on XMTPiOS here