### PR TITLE
Update libxmtp-swift to 0.4.2-beta2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "db13df1fef0e4a11880a889640a3df2998e4abac",
-        "version" : "0.4.2-beta1"
+        "revision" : "de859c86a5854bdc2cfd54e8f98b6088a38a2f3c",
+        "version" : "0.4.2-beta2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.2-beta1"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.2-beta2"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
`libxmtp-swift 0.4.2-beta2` contains an update to `Package.swift` that fixes linker errors when running tests. This update has no impact upon clients that consume `libxmtp-swift` via CocoaPods as `Package.swift` is only a Swift Package Manager implementation.

With this update it is now possible to run tests from the CLI using `swift test`.

A prettier version of the test suite can be run by piping the output accordingly:

```
swift test --parallel | grep -E "Test Case|XCTAssert|❌|✅"
```