### PR TITLE
Fix Broken Test Scheme

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/XMTP.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/XMTP.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XMTP"
-               BuildableName = "XMTP"
-               BlueprintName = "XMTP"
+               BlueprintIdentifier = "XMTPiOS"
+               BuildableName = "XMTPiOS"
+               BlueprintName = "XMTPiOS"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -98,9 +98,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "XMTP"
-            BuildableName = "XMTP"
-            BlueprintName = "XMTP"
+            BlueprintIdentifier = "XMTPiOS"
+            BuildableName = "XMTPiOS"
+            BlueprintName = "XMTPiOS"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>


### PR DESCRIPTION
This change fixes a broken Xcode scheme that was used for running tests using `xcodebuild` as well as interactively within Xcode itself.

**These changes now address the following**:

- It is now possible to run tests interactively by selecting the `XMTP` target in Xcode and then `CMD + U`. Interactive debugging will make it easier to fix broken tests going forward.
- This scheme can now be used in a forthcoming GitHub workflow
- This scheme can now be used locally by issuing the following command from the CLI:
```
xcodebuild test -scheme XMTP -destination "platform=iOS Simulator,name=iPhone 15"
```


