### PR TITLE
thirtyDayPeriodsSinceEpoch fix

### DIFF
--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -587,7 +587,9 @@ public actor Conversations {
 	}
 	
 	public func getHmacKeys(request: Xmtp_KeystoreApi_V1_GetConversationHmacKeysRequest? = nil) -> Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse {
-		let thirtyDayPeriodsSinceEpoch = Int(Date().timeIntervalSince1970) / (60 * 60 * 24 * 30)
+		let daysSinceEpoch = Date().timeIntervalSince1970 / (60 * 60 * 24)
+		let thirtyDayPeriodsSinceEpoch = Int(floor(daysSinceEpoch / 30))
+		
 		var hmacKeysResponse = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse()
 		
 		var topics = conversationsByTopic

--- a/Sources/XMTPiOS/Messages/MessageV2.swift
+++ b/Sources/XMTPiOS/Messages/MessageV2.swift
@@ -98,7 +98,8 @@ extension MessageV2 {
 
 		let ciphertext = try Crypto.encrypt(keyMaterial, signedBytes, additionalData: headerBytes)
 
-		let thirtyDayPeriodsSinceEpoch = Int(date.timeIntervalSince1970 / 60 / 60 / 24 / 30)
+		let daysSinceEpoch = Date().timeIntervalSince1970 / (60 * 60 * 24)
+		let thirtyDayPeriodsSinceEpoch = Int(floor(daysSinceEpoch / 30))
 		let info = "\(thirtyDayPeriodsSinceEpoch)-\(client.address)"
 		guard let infoEncoded = info.data(using: .utf8) else {
 			throw MessageV2Error.invalidData


### PR DESCRIPTION
In JS they do this

```js
const thirtyDayPeriodsSinceEpoch = Math.floor(
          Date.now() / 1000 / 60 / 60 / 24 / 30
        )
```

I think this brings the code closer inline with that.
