### PR TITLE
Bump SDK Version to 0.8.16

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.8.15"
+  spec.version      = "0.8.16"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
## Purpose ℹ️ 
Bump SDK Version to 0.8.16

Release Tag will follow once the PR is approved and merged.

## Scope 🔭
- `XMTP.podspec`