### PR TITLE
Revert latest rust bump

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.2-beta5"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.2-beta4"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -432,7 +432,7 @@ class GroupTests: XCTestCase {
 		let fixtures = try await localFixtures()
 
 		let expectation1 = expectation(description: "got a conversation")
-		expectation1.expectedFulfillmentCount = 4
+		expectation1.expectedFulfillmentCount = 2
 		let convo = try await fixtures.bobClient.conversations.newConversation(with: fixtures.alice.address)
 		let group = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address])
 		try await fixtures.aliceClient.conversations.sync()
@@ -444,11 +444,6 @@ class GroupTests: XCTestCase {
 
 		_ = try await group.send(content: "hi")
 		_ = try await convo.send(content: "hi")
-		let group2 = try await fixtures.fredClient.conversations.newGroup(with: [fixtures.alice.address])
-		let convo2 = try await fixtures.fredClient.conversations.newConversation(with: fixtures.alice.address)
-
-		_ = try await group2.send(content: "hi")
-		_ = try await convo2.send(content: "hi")
 
 		await waitForExpectations(timeout: 3)
 	}

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -452,7 +452,7 @@ class GroupTests: XCTestCase {
 		let fixtures = try await localFixtures()
 
 		let expectation1 = expectation(description: "got a conversation")
-		expectation1.expectedFulfillmentCount = 4
+		expectation1.expectedFulfillmentCount = 2
 		let convo = try await fixtures.bobClient.conversations.newConversation(with: fixtures.alice.address)
 		let group = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address])
 		try await fixtures.aliceClient.conversations.sync()
@@ -464,12 +464,6 @@ class GroupTests: XCTestCase {
 
 		_ = try await group.send(content: "hi")
 		_ = try await convo.send(content: "hi")
-		
-		let group2 = try await fixtures.fredClient.conversations.newGroup(with: [fixtures.alice.address])
-		let convo2 = try await fixtures.fredClient.conversations.newConversation(with: fixtures.alice.address)
-
-		_ = try await group2.send(content: "hi")
-		_ = try await convo2.send(content: "hi")
 
 		await waitForExpectations(timeout: 3)
 	}

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.8.16"
+  spec.version      = "0.8.17"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.3.0"
-  spec.dependency 'LibXMTP', '= 0.4.2-beta5'
+  spec.dependency 'LibXMTP', '= 0.4.2-beta4'
 end

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "a4111b1bb5485e7cd0d1606d8e6fde1a4b6a1783",
-        "version" : "0.4.2-beta5"
+        "revision" : "28ee27a4ded8b996a74850e366247e9fe51d782a",
+        "version" : "0.4.2-beta4"
       }
     },
     {


### PR DESCRIPTION
We've had several reports of issues with list conversations and streaming. Until we can isolate exactly where the issue is lets revert this change.

Reverts this PR https://github.com/xmtp/xmtp-ios/pull/270