### PR TITLE
Fix list conversation only listing first 100

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.3.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.2-beta4"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.3-beta1"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -194,7 +194,7 @@ class ConversationsTests: XCTestCase {
 		}
 	}
 	
-	func testLoadConvos() async throws {
+	func testLoadAllConvosForLargeWallet() async throws {
 		// Data from hex: 0836200ffafa17a3cb8b54f22d6afa60b13da48726543241adc5c250dbb0e0cd
 		// aka 2k many convo test wallet
 		let privateKeyData = Data([8,54,32,15,250,250,23,163,203,139,84,242,45,106,250,96,177,61,164,135,38,84,50,65,173,197,194,80,219,176,224,205])
@@ -207,5 +207,7 @@ class ConversationsTests: XCTestCase {
 		let conversations = try await client.conversations.list()
 		let end = Date()
 		print("Loaded \(conversations.count) conversations in \(end.timeIntervalSince(start))s")
+		XCTAssertTrue(conversations.count > 2000)
+		XCTAssertTrue(end.timeIntervalSince(start) < 30)
 	}
 }

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -193,4 +193,19 @@ class ConversationsTests: XCTestCase {
 			}
 		}
 	}
+	
+	func testLoadConvos() async throws {
+		// Data from hex: 0836200ffafa17a3cb8b54f22d6afa60b13da48726543241adc5c250dbb0e0cd
+		// aka 2k many convo test wallet
+		let privateKeyData = Data([8,54,32,15,250,250,23,163,203,139,84,242,45,106,250,96,177,61,164,135,38,84,50,65,173,197,194,80,219,176,224,205])
+		let privateKey = try PrivateKey(privateKeyData)
+		// Use hardcoded privateKey for testing
+		let options = ClientOptions(api: ClientOptions.Api(env: .dev, isSecure: true))
+		let client = try await Client.create(account: privateKey, options: options)
+
+		let start = Date()
+		let conversations = try await client.conversations.list()
+		let end = Date()
+		print("Loaded \(conversations.count) conversations in \(end.timeIntervalSince(start))s")
+	}
 }

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -193,21 +193,4 @@ class ConversationsTests: XCTestCase {
 			}
 		}
 	}
-	
-	func testLoadAllConvosForLargeWallet() async throws {
-		// Data from hex: 0836200ffafa17a3cb8b54f22d6afa60b13da48726543241adc5c250dbb0e0cd
-		// aka 2k many convo test wallet
-		let privateKeyData = Data([8,54,32,15,250,250,23,163,203,139,84,242,45,106,250,96,177,61,164,135,38,84,50,65,173,197,194,80,219,176,224,205])
-		let privateKey = try PrivateKey(privateKeyData)
-		// Use hardcoded privateKey for testing
-		let options = ClientOptions(api: ClientOptions.Api(env: .dev, isSecure: true))
-		let client = try await Client.create(account: privateKey, options: options)
-
-		let start = Date()
-		let conversations = try await client.conversations.list()
-		let end = Date()
-		print("Loaded \(conversations.count) conversations in \(end.timeIntervalSince(start))s")
-		XCTAssertTrue(conversations.count > 2000)
-		XCTAssertTrue(end.timeIntervalSince(start) < 30)
-	}
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.3.0"
-  spec.dependency 'LibXMTP', '= 0.4.2-beta3'
+  spec.dependency 'LibXMTP', '= 0.4.3-beta1'
 end

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.8.17"
+  spec.version      = "0.9.0"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "28ee27a4ded8b996a74850e366247e9fe51d782a",
-        "version" : "0.4.2-beta4"
+        "revision" : "f8c4be0d591671067c8e7772b7c402931f33ed54",
+        "version" : "0.4.3-beta1"
       }
     },
     {


### PR DESCRIPTION
This validates that the fixes in libxmtp now fix the pagination issue for listing all conversations

Also adds a test around performance. Benchmarks that conversation listing off a large wallet should take less than 30 seconds. A few results showed:
`Loaded 2015 conversations in 17.3847593298321s`
`Loaded 2015 conversations in 8.91787302494049s`
