### PR TITLE
Remove UserDefaults for the default encryption key

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -136,16 +136,7 @@ public final class Client {
 
 			var encryptionKey = options?.mlsEncryptionKey
 			if (encryptionKey == nil) {
-				let preferences = UserDefaults.standard
-				let key = "xmtp-key"
-				if preferences.data(forKey: key) == nil {
-					let data = Data(try Crypto.secureRandomBytes(count: 32))
-					preferences.set(data, forKey: key)
-					preferences.synchronize()
-					encryptionKey = data
-				} else {
-					encryptionKey = preferences.data(forKey: key)
-				}
+				throw ClientError.creationError("No encryption key passed for the database. Please store and provide a secure encryption key.")
 			}
 
 			let v3Client = try await LibXMTP.createClient(

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -21,8 +21,7 @@ class ClientTests: XCTestCase {
 	}
 
 	func testPassingSavedKeysWithNoSignerWithMLSErrors() async throws {
-		try TestConfig.skipIfNotRunningLocalNodeTests()
-
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 
 		do {
@@ -30,7 +29,8 @@ class ClientTests: XCTestCase {
 				account: bo,
 				options: .init(
 					api: .init(env: .local, isSecure: false),
-					mlsAlpha: true
+					mlsAlpha: true,
+					mlsEncryptionKey: key
 				)
 			)
 		} catch {
@@ -39,14 +39,14 @@ class ClientTests: XCTestCase {
 	}
 
 	func testPassingSavedKeysWithMLS() async throws {
-		try TestConfig.skipIfNotRunningLocalNodeTests()
-
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 		let client = try await Client.create(
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 
@@ -56,7 +56,8 @@ class ClientTests: XCTestCase {
 			options: .init(
 				api: .init(env: .local, isSecure: false),
 				// Should not need to pass the signer again
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 
@@ -64,8 +65,6 @@ class ClientTests: XCTestCase {
 	}
 
 	func testPassingMLSEncryptionKey() async throws {
-		try TestConfig.skipIfNotRunningLocalNodeTests()
-
 		let bo = try PrivateKey.generate()
 		let key = try Crypto.secureRandomBytes(count: 32)
 
@@ -94,9 +93,7 @@ class ClientTests: XCTestCase {
 		}
 	}
 	
-	func testPassingMLSEncryptionKeyAndDatabasePath() async throws {
-		try TestConfig.skipIfNotRunningLocalNodeTests()
-		
+	func testPassingMLSEncryptionKeyAndDatabasePath() async throws {		
 		let bo = try PrivateKey.generate()
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let documentsURL = try
@@ -158,13 +155,15 @@ class ClientTests: XCTestCase {
 	}
 	
 	func testCanDeleteDatabase() async throws {
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 		let alix = try PrivateKey.generate()
 		var boClient = try await Client.create(
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 	
@@ -172,7 +171,8 @@ class ClientTests: XCTestCase {
 			account: alix,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 
@@ -188,7 +188,8 @@ class ClientTests: XCTestCase {
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -45,13 +45,15 @@ class GroupTests: XCTestCase {
 	}
 
 	func localFixtures() async throws -> LocalFixtures {
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let alice = try PrivateKey.generate()
 		let aliceClient = try await Client.create(
 			account: alice,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
 				codecs: [GroupMembershipChangedCodec()],
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 		let bob = try PrivateKey.generate()
@@ -60,7 +62,8 @@ class GroupTests: XCTestCase {
 			options: .init(
 				api: .init(env: .local, isSecure: false),
 				codecs: [GroupMembershipChangedCodec()],
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 		let fred = try PrivateKey.generate()
@@ -69,7 +72,8 @@ class GroupTests: XCTestCase {
 			options: .init(
 				api: .init(env: .local, isSecure: false),
 				codecs: [GroupMembershipChangedCodec()],
-				mlsAlpha: true
+				mlsAlpha: true,
+				mlsEncryptionKey: key
 			)
 		)
 


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-ios/issues/291

This removes the user defaults that were added to avoid creating a database without an encryption key. The client creation will now error if an encryption key is not provided.

Note: This may break existing clients using group chat.
