### PR TITLE
Fix lazy load of conversation class

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -182,6 +182,7 @@ public final class Client {
 		)
 
 		let client = try Client(address: account.address, privateKeyBundleV1: privateKeyBundleV1, apiClient: apiClient, v3Client: v3Client, dbPath: dbPath, installationID: v3Client?.installationId().toHex ?? "")
+		client.conversations
 		try await client.ensureUserContactPublished()
 
 		for codec in (options?.codecs ?? []) {
@@ -281,7 +282,7 @@ public final class Client {
 		)
 
 		let result = try Client(address: address, privateKeyBundleV1: v1Bundle, apiClient: apiClient, v3Client: v3Client, dbPath: dbPath, installationID: v3Client?.installationId().toHex ?? "")
-
+		result.conversations
 		for codec in options.codecs {
 			result.register(codec: codec)
 		}

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.9.4"
+  spec.version      = "0.9.5"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
We are seeing a bug in React Native outlined here: https://github.com/xmtp/xmtp-react-native/issues/343

It appears on call to conversations the promise can execute 10 times create a new conversations class each time before reusing the same one. I think this might be because of the lazy load of conversations which waits to create the class until it's first called. Seeing as the fix was to just call conversations once before calling the promise I think thats the case.

I'm not too familiar with how iOS works but it doesnt appear I can init the conversations class in the Client init because it takes a client as a parameter. I've opted to just calling conversations in the create function to short circuit the lazy and load it on create.