### PR TITLE
Bump consent pagination

### DIFF
--- a/Sources/XMTPiOS/ApiClient.swift
+++ b/Sources/XMTPiOS/ApiClient.swift
@@ -141,7 +141,7 @@ final class GRPCApiClient: ApiClient {
 			cursor = response.pagingInfo.cursor
 			hasNextPage = !response.envelopes.isEmpty && response.pagingInfo.hasCursor
 
-			if let limit = pagination?.limit, envelopes.count >= limit {
+			if let limit = pagination?.limit, envelopes.count >= limit, limit <= 100 {
 				envelopes = Array(envelopes.prefix(limit))
 				break
 			}

--- a/Sources/XMTPiOS/Contacts.swift
+++ b/Sources/XMTPiOS/Contacts.swift
@@ -75,7 +75,8 @@ public class ConsentList {
 
 		let pagination = Pagination(
             after: lastFetched,
-            direction: .ascending
+            direction: .ascending,
+			limit = 500
         )
 		let envelopes = try await client.apiClient.envelopes(topic: Topic.preferenceList(identifier).description, pagination: pagination)
     lastFetched = newDate

--- a/Sources/XMTPiOS/Contacts.swift
+++ b/Sources/XMTPiOS/Contacts.swift
@@ -74,9 +74,9 @@ public class ConsentList {
 		let newDate = Date()
 
 		let pagination = Pagination(
+			limit: 500,
             after: lastFetched,
-            direction: .ascending,
-			limit = 500
+            direction: .ascending
         )
 		let envelopes = try await client.apiClient.envelopes(topic: Topic.preferenceList(identifier).description, pagination: pagination)
     lastFetched = newDate

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.10.4"
+  spec.version      = "0.10.3"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.10.3"
+  spec.version      = "0.10.4"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This bumps the consent record pagination size to 500 instead of the previous 100. Should help with performance of the subscribe feature.

Previously
```
Loaded 1102 consent entries in 10.089964032173157
Second time loaded 1102 consent entries in 0.1475890874862671
```

Now
```
Loaded 1102 consent entries in 5.456334948539734s
Second time loaded 1102 consent entries in 0.08725190162658691s
```
