### PR TITLE
feat: Consent Proof Payload

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -373,7 +373,7 @@ public final class Client {
 			peerAddress: export.peerAddress,
 			client: self,
 			header: SealedInvitationHeaderV1(),
-            consentProof: try consentProof?.serializedData()
+            consentProof: consentProof
 		))
 	}
 

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -352,7 +352,7 @@ public final class Client {
 		guard let keyMaterial = Data(base64Encoded: Data(export.keyMaterial.utf8)) else {
 			throw ConversationImportError.invalidData
 		}
-        
+
         var consentProof: ConsentProofPayload? = nil
         if let exportConsentProof = export.consentProof {
             var proof = ConsentProofPayload()
@@ -361,7 +361,6 @@ public final class Client {
             proof.payloadVersion = ConsentProofPayloadVersion.consentProofPayloadVersion1
             consentProof = proof
         }
-        
 
 		return .v2(ConversationV2(
 			topic: export.topic,

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -352,6 +352,16 @@ public final class Client {
 		guard let keyMaterial = Data(base64Encoded: Data(export.keyMaterial.utf8)) else {
 			throw ConversationImportError.invalidData
 		}
+        
+        var consentProof: ConsentProofPayload? = nil
+        if let exportConsentProof = export.consentProof {
+            var proof = ConsentProofPayload()
+            proof.signature = exportConsentProof.signature
+            proof.timestamp = exportConsentProof.timestamp
+            proof.payloadVersion = ConsentProofPayloadVersion.consentProofPayloadVersion1
+            consentProof = proof
+        }
+        
 
 		return .v2(ConversationV2(
 			topic: export.topic,
@@ -362,7 +372,8 @@ public final class Client {
 			),
 			peerAddress: export.peerAddress,
 			client: self,
-			header: SealedInvitationHeaderV1()
+			header: SealedInvitationHeaderV1(),
+            consentProof: try consentProof?.serializedData()
 		))
 	}
 

--- a/Sources/XMTPiOS/Contacts.swift
+++ b/Sources/XMTPiOS/Contacts.swift
@@ -145,7 +145,6 @@ public class ConsentList {
 
     }
 
-
     let message = try LibXMTP.userPreferencesEncrypt(
         publicKey: publicKey,
         privateKey: privateKey,

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -324,6 +324,21 @@ public enum Conversation: Sendable {
 		}
 	}
 
+	public func consentProof() throws -> ConsentProofPayload? {
+		switch self {
+		case .v1(_):
+			return nil
+		case let .v2(conversationV2):
+			if let consentProof = conversationV2.consentProof {
+				let val = try ConsentProofPayload(serializedData: consentProof)
+				return val
+			}
+			return nil
+		case .group(_):
+			return nil
+		}
+	}
+
 	var client: Client {
 		switch self {
 		case let .v1(conversationV1):

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -324,16 +324,12 @@ public enum Conversation: Sendable {
 		}
 	}
 
-	public func consentProof() throws -> ConsentProofPayload? {
+    public var consentProof: ConsentProofPayload? {
 		switch self {
 		case .v1(_):
 			return nil
 		case let .v2(conversationV2):
-			if let consentProof = conversationV2.consentProof {
-				let val = try ConsentProofPayload(serializedData: consentProof)
-				return val
-			}
-			return nil
+			return conversationV2.consentProof
 		case .group(_):
 			return nil
 		}

--- a/Sources/XMTPiOS/ConversationExport.swift
+++ b/Sources/XMTPiOS/ConversationExport.swift
@@ -23,9 +23,15 @@ struct ConversationV2Export: Codable {
 	var peerAddress: String
 	var createdAt: String
 	var context: ConversationV2ContextExport?
+    var consentProof: ConsentProofPayloadExport?
 }
 
 struct ConversationV2ContextExport: Codable {
 	var conversationId: String
 	var metadata: [String: String]
+}
+
+struct ConsentProofPayloadExport: Codable {
+    var signature: String
+    var timestamp: UInt64
 }

--- a/Sources/XMTPiOS/ConversationV2.swift
+++ b/Sources/XMTPiOS/ConversationV2.swift
@@ -17,10 +17,11 @@ public struct ConversationV2Container: Codable {
 	var peerAddress: String
 	var createdAtNs: UInt64?
 	var header: SealedInvitationHeaderV1
+    var consentProof: Data?
 
 	public func decode(with client: Client) -> ConversationV2 {
 		let context = InvitationV1.Context(conversationID: conversationID ?? "", metadata: metadata)
-		return ConversationV2(topic: topic, keyMaterial: keyMaterial, context: context, peerAddress: peerAddress, client: client, createdAtNs: createdAtNs, header: header)
+        return ConversationV2(topic: topic, keyMaterial: keyMaterial, context: context, peerAddress: peerAddress, client: client, createdAtNs: createdAtNs, header: header, consentProof: consentProof)
 	}
 }
 
@@ -31,6 +32,7 @@ public struct ConversationV2 {
 	public var context: InvitationV1.Context
 	public var peerAddress: String
 	public var client: Client
+    public var consentProof: Data?
 	var createdAtNs: UInt64?
 	private var header: SealedInvitationHeaderV1
 
@@ -41,6 +43,7 @@ public struct ConversationV2 {
 		let peerAddress = try peer.walletAddress
 
 		let keyMaterial = Data(invitation.aes256GcmHkdfSha256.keyMaterial)
+        let consentProof = try invitation.consentProof.serializedData()
 
 		return ConversationV2(
 			topic: invitation.topic,
@@ -49,21 +52,23 @@ public struct ConversationV2 {
 			peerAddress: peerAddress,
 			client: client,
 			createdAtNs: header.createdNs,
-			header: header
+			header: header,
+      consentProof: consentProof
 		)
 	}
 
-	public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil) {
+  public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, consentProof: Data? = nil) {
 		self.topic = topic
 		self.keyMaterial = keyMaterial
 		self.context = context
 		self.peerAddress = peerAddress
 		self.client = client
 		self.createdAtNs = createdAtNs
+    self.consentProof = consentProof
 		header = SealedInvitationHeaderV1()
 	}
 
-	public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, header: SealedInvitationHeaderV1) {
+	public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, header: SealedInvitationHeaderV1, consentProof: Data? = nil) {
 		self.topic = topic
 		self.keyMaterial = keyMaterial
 		self.context = context
@@ -71,10 +76,11 @@ public struct ConversationV2 {
 		self.client = client
 		self.createdAtNs = createdAtNs
 		self.header = header
+        self.consentProof = consentProof
 	}
 
 	public var encodedContainer: ConversationV2Container {
-		ConversationV2Container(topic: topic, keyMaterial: keyMaterial, conversationID: context.conversationID, metadata: context.metadata, peerAddress: peerAddress, createdAtNs: createdAtNs, header: header)
+        ConversationV2Container(topic: topic, keyMaterial: keyMaterial, conversationID: context.conversationID, metadata: context.metadata, peerAddress: peerAddress, createdAtNs: createdAtNs, header: header, consentProof: consentProof)
 	}
 
 	func prepareMessage(encodedContent: EncodedContent, options: SendOptions?) async throws -> PreparedMessage {

--- a/Sources/XMTPiOS/ConversationV2.swift
+++ b/Sources/XMTPiOS/ConversationV2.swift
@@ -17,7 +17,7 @@ public struct ConversationV2Container: Codable {
 	var peerAddress: String
 	var createdAtNs: UInt64?
 	var header: SealedInvitationHeaderV1
-    var consentProof: Data?
+    var consentProof: ConsentProofPayload?
 
 	public func decode(with client: Client) -> ConversationV2 {
 		let context = InvitationV1.Context(conversationID: conversationID ?? "", metadata: metadata)
@@ -32,7 +32,7 @@ public struct ConversationV2 {
 	public var context: InvitationV1.Context
 	public var peerAddress: String
 	public var client: Client
-    public var consentProof: Data?
+    public var consentProof: ConsentProofPayload?
 	var createdAtNs: UInt64?
 	private var header: SealedInvitationHeaderV1
 
@@ -43,7 +43,6 @@ public struct ConversationV2 {
 		let peerAddress = try peer.walletAddress
 
 		let keyMaterial = Data(invitation.aes256GcmHkdfSha256.keyMaterial)
-        let consentProof = try invitation.consentProof.serializedData()
 
 		return ConversationV2(
 			topic: invitation.topic,
@@ -53,11 +52,11 @@ public struct ConversationV2 {
 			client: client,
 			createdAtNs: header.createdNs,
 			header: header,
-            consentProof: consentProof
+            consentProof: invitation.consentProof
 		)
 	}
 
-  public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, consentProof: Data? = nil) {
+  public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, consentProof: ConsentProofPayload? = nil) {
 		self.topic = topic
 		self.keyMaterial = keyMaterial
 		self.context = context
@@ -68,7 +67,7 @@ public struct ConversationV2 {
 		header = SealedInvitationHeaderV1()
 	}
 
-	public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, header: SealedInvitationHeaderV1, consentProof: Data? = nil) {
+	public init(topic: String, keyMaterial: Data, context: InvitationV1.Context, peerAddress: String, client: Client, createdAtNs: UInt64? = nil, header: SealedInvitationHeaderV1, consentProof: ConsentProofPayload? = nil) {
 		self.topic = topic
 		self.keyMaterial = keyMaterial
 		self.context = context

--- a/Sources/XMTPiOS/ConversationV2.swift
+++ b/Sources/XMTPiOS/ConversationV2.swift
@@ -53,7 +53,7 @@ public struct ConversationV2 {
 			client: client,
 			createdAtNs: header.createdNs,
 			header: header,
-      consentProof: consentProof
+            consentProof: consentProof
 		)
 	}
 
@@ -64,7 +64,7 @@ public struct ConversationV2 {
 		self.peerAddress = peerAddress
 		self.client = client
 		self.createdAtNs = createdAtNs
-    self.consentProof = consentProof
+        self.consentProof = consentProof
 		header = SealedInvitationHeaderV1()
 	}
 

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -447,7 +447,7 @@ public actor Conversations {
 		return Group(ffiGroup: group, client: client)
 	}
 
-	public func newConversation(with peerAddress: String, context: InvitationV1.Context? = nil) async throws -> Conversation {
+    public func newConversation(with peerAddress: String, context: InvitationV1.Context? = nil, consentProofSignature: String? = nil) async throws -> Conversation {
 		if peerAddress.lowercased() == client.address.lowercased() {
 			throw ConversationError.recipientIsSender
 		}
@@ -470,7 +470,8 @@ public actor Conversations {
 		let invitation = try InvitationV1.createDeterministic(
 			sender: client.keys,
 			recipient: recipient,
-			context: context
+			context: context,
+            consentProofSignature
 		)
 		let sealedInvitation = try await sendInvitation(recipient: recipient, invitation: invitation, created: Date())
 		let conversationV2 = try ConversationV2.create(client: client, invitation: invitation, header: sealedInvitation.v1.header)

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -582,7 +582,7 @@ public actor Conversations {
             return
         }
         let contacts = client.contacts
-        let _ = try await contacts.refreshConsentList()
+        _ = try await contacts.refreshConsentList()
         if await (contacts.consentList.state(address: peerAddress) == .unknown) {
             try await contacts.allow(addresses: [peerAddress])
         }
@@ -625,8 +625,7 @@ public actor Conversations {
 				newConversations.append(
                     newConversation
 				)
-                let consentProof = try newConversation.consentProof()
-                if let consentProof = consentProof {
+                if let consentProof = newConversation.consentProof {
                     try await self.handleConsentProof(consentProof: consentProof, peerAddress: newConversation.peerAddress)
                 
                 }

--- a/Sources/XMTPiOS/Frames/ProxyClient.swift
+++ b/Sources/XMTPiOS/Frames/ProxyClient.swift
@@ -13,7 +13,6 @@ struct Metadata: Codable {
     let imageUrl: String
 }
 
-
 class ProxyClient {
     var baseUrl: String
 
@@ -42,8 +41,7 @@ class ProxyClient {
         return metadataResponse
     }
 
-    func post(url: String, payload: Codable) async throws -> GetMetadataResponse {
-        
+    func post(url: String, payload: Codable) async throws -> GetMetadataResponse {        
         let encodedUrl = url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let fullUrl = "\(self.baseUrl)?url=\(encodedUrl)"
         guard let url = URL(string: fullUrl) else {
@@ -94,8 +92,6 @@ class ProxyClient {
     func mediaUrl(url: String) -> String {
         let encodedUrl = url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let result = "\(self.baseUrl)media?url=\(encodedUrl)"
-        return result;
+        return result
     }
 }
-
-

--- a/Sources/XMTPiOS/Messages/Invitation.swift
+++ b/Sources/XMTPiOS/Messages/Invitation.swift
@@ -96,7 +96,7 @@ extension ConsentProofPayloadVersion: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let rawValue = try container.decode(Int.self)
-        self.init(rawValue: rawValue)!
+        self = ConsentProofPayloadVersion(rawValue: rawValue) ?? ConsentProofPayloadVersion.UNRECOGNIZED(0)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/XMTPiOS/Messages/Invitation.swift
+++ b/Sources/XMTPiOS/Messages/Invitation.swift
@@ -16,7 +16,7 @@ extension InvitationV1 {
 			sender: PrivateKeyBundleV2,
 			recipient: SignedPublicKeyBundle,
 			context: InvitationV1.Context? = nil,
-            consentProofSignature: String? = nil
+            consentProofPayload: ConsentProofPayload? = nil
 	) throws -> InvitationV1 {
 		let context = context ?? InvitationV1.Context()
         let myAddress = try sender.toV1().walletAddress
@@ -38,18 +38,6 @@ extension InvitationV1 {
 
 		var aes256GcmHkdfSha256 = InvitationV1.Aes256gcmHkdfsha256()
 		aes256GcmHkdfSha256.keyMaterial = Data(keyMaterial)
-		// If consentProofSignature is not nil, create a ConsentProofPayload
-		// with the signature and add it to the InvitationV1
-        var consentProofPayload: ConsentProofPayload? = nil
-        
-		if let signature = consentProofSignature {
-			var consentProof = ConsentProofPayload()
-            consentProof.signature = signature
-            consentProof.timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
-            consentProof.payloadVersion = .consentProofPayloadVersion1
-            consentProofPayload = consentProof
-        }
-
 		return try InvitationV1(
 				topic: topic,
 				context: context,

--- a/Sources/XMTPiOS/Messages/Invitation.swift
+++ b/Sources/XMTPiOS/Messages/Invitation.swift
@@ -69,3 +69,38 @@ public extension InvitationV1.Context {
 		self.metadata = metadata
 	}
 }
+
+extension ConsentProofPayload: Codable {
+    enum CodingKeys: CodingKey {
+        case signature, timestamp, payloadVersion
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(signature, forKey: .signature)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(payloadVersion, forKey: .payloadVersion)
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        signature = try container.decode(String.self, forKey: .signature)
+        timestamp = try container.decode(UInt64.self, forKey: .timestamp)
+        payloadVersion = try container.decode(Xmtp_MessageContents_ConsentProofPayloadVersion.self, forKey: .payloadVersion)
+    }
+}
+
+extension ConsentProofPayloadVersion: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Int.self)
+        self.init(rawValue: rawValue)!
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}

--- a/Sources/XMTPiOS/Messages/Signature.swift
+++ b/Sources/XMTPiOS/Messages/Signature.swift
@@ -62,6 +62,17 @@ extension Signature {
 				"For more info: https://xmtp.org/signatures/"
 		)
 	}
+    
+    static func consentProofText(peerAddress: String, timestamp: UInt64) -> String {
+        return (
+            "XMTP : Grant inbox consent to sender\n" +
+            "\n" +
+            "Current Time: \(timestamp)\n" +
+            "From Address: \(peerAddress)\n" +
+            "\n" +
+            "For more info: https://xmtp.org/signatures/"
+        )
+    }
 
 	public init(bytes: Data, recovery: Int) {
 		self.init()

--- a/Sources/XMTPiOS/Proto/message_contents/invitation.pb.swift
+++ b/Sources/XMTPiOS/Proto/message_contents/invitation.pb.swift
@@ -24,6 +24,47 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
+/// Version of consent proof payload 
+public enum Xmtp_MessageContents_ConsentProofPayloadVersion: SwiftProtobuf.Enum {
+  public typealias RawValue = Int
+  case unspecified // = 0
+  case consentProofPayloadVersion1 // = 1
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .unspecified
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unspecified
+    case 1: self = .consentProofPayloadVersion1
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .unspecified: return 0
+    case .consentProofPayloadVersion1: return 1
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Xmtp_MessageContents_ConsentProofPayloadVersion: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static let allCases: [Xmtp_MessageContents_ConsentProofPayloadVersion] = [
+    .unspecified,
+    .consentProofPayloadVersion1,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
 /// Unsealed invitation V1
 public struct Xmtp_MessageContents_InvitationV1 {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -56,6 +97,16 @@ public struct Xmtp_MessageContents_InvitationV1 {
     }
     set {encryption = .aes256GcmHkdfSha256(newValue)}
   }
+
+  /// The user's consent proof
+  public var consentProof: Xmtp_MessageContents_ConsentProofPayload {
+    get {return _consentProof ?? Xmtp_MessageContents_ConsentProofPayload()}
+    set {_consentProof = newValue}
+  }
+  /// Returns true if `consentProof` has been explicitly set.
+  public var hasConsentProof: Bool {return self._consentProof != nil}
+  /// Clears the value of `consentProof`. Subsequent reads from it will return its default value.
+  public mutating func clearConsentProof() {self._consentProof = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -115,6 +166,7 @@ public struct Xmtp_MessageContents_InvitationV1 {
   public init() {}
 
   fileprivate var _context: Xmtp_MessageContents_InvitationV1.Context? = nil
+  fileprivate var _consentProof: Xmtp_MessageContents_ConsentProofPayload? = nil
 }
 
 /// Sealed Invitation V1 Header
@@ -222,7 +274,29 @@ public struct Xmtp_MessageContents_SealedInvitation {
   public init() {}
 }
 
+/// Payload for user's consent proof to be set in the invitation
+/// Signifying the conversation should be preapproved for the user on receipt
+public struct Xmtp_MessageContents_ConsentProofPayload {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// the user's signature in hex format
+  public var signature: String = String()
+
+  /// approximate time when the user signed
+  public var timestamp: UInt64 = 0
+
+  /// version of the payload
+  public var payloadVersion: Xmtp_MessageContents_ConsentProofPayloadVersion = .unspecified
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 #if swift(>=5.5) && canImport(_Concurrency)
+extension Xmtp_MessageContents_ConsentProofPayloadVersion: @unchecked Sendable {}
 extension Xmtp_MessageContents_InvitationV1: @unchecked Sendable {}
 extension Xmtp_MessageContents_InvitationV1.OneOf_Encryption: @unchecked Sendable {}
 extension Xmtp_MessageContents_InvitationV1.Aes256gcmHkdfsha256: @unchecked Sendable {}
@@ -231,11 +305,19 @@ extension Xmtp_MessageContents_SealedInvitationHeaderV1: @unchecked Sendable {}
 extension Xmtp_MessageContents_SealedInvitationV1: @unchecked Sendable {}
 extension Xmtp_MessageContents_SealedInvitation: @unchecked Sendable {}
 extension Xmtp_MessageContents_SealedInvitation.OneOf_Version: @unchecked Sendable {}
+extension Xmtp_MessageContents_ConsentProofPayload: @unchecked Sendable {}
 #endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "xmtp.message_contents"
+
+extension Xmtp_MessageContents_ConsentProofPayloadVersion: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "CONSENT_PROOF_PAYLOAD_VERSION_UNSPECIFIED"),
+    1: .same(proto: "CONSENT_PROOF_PAYLOAD_VERSION_1"),
+  ]
+}
 
 extension Xmtp_MessageContents_InvitationV1: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".InvitationV1"
@@ -243,6 +325,7 @@ extension Xmtp_MessageContents_InvitationV1: SwiftProtobuf.Message, SwiftProtobu
     1: .same(proto: "topic"),
     2: .same(proto: "context"),
     3: .standard(proto: "aes256_gcm_hkdf_sha256"),
+    4: .standard(proto: "consent_proof"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -266,6 +349,7 @@ extension Xmtp_MessageContents_InvitationV1: SwiftProtobuf.Message, SwiftProtobu
           self.encryption = .aes256GcmHkdfSha256(v)
         }
       }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._consentProof) }()
       default: break
       }
     }
@@ -285,6 +369,9 @@ extension Xmtp_MessageContents_InvitationV1: SwiftProtobuf.Message, SwiftProtobu
     try { if case .aes256GcmHkdfSha256(let v)? = self.encryption {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._consentProof {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -292,6 +379,7 @@ extension Xmtp_MessageContents_InvitationV1: SwiftProtobuf.Message, SwiftProtobu
     if lhs.topic != rhs.topic {return false}
     if lhs._context != rhs._context {return false}
     if lhs.encryption != rhs.encryption {return false}
+    if lhs._consentProof != rhs._consentProof {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -500,6 +588,50 @@ extension Xmtp_MessageContents_SealedInvitation: SwiftProtobuf.Message, SwiftPro
 
   public static func ==(lhs: Xmtp_MessageContents_SealedInvitation, rhs: Xmtp_MessageContents_SealedInvitation) -> Bool {
     if lhs.version != rhs.version {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Xmtp_MessageContents_ConsentProofPayload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ConsentProofPayload"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "signature"),
+    2: .same(proto: "timestamp"),
+    3: .standard(proto: "payload_version"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.signature) }()
+      case 2: try { try decoder.decodeSingularUInt64Field(value: &self.timestamp) }()
+      case 3: try { try decoder.decodeSingularEnumField(value: &self.payloadVersion) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.signature.isEmpty {
+      try visitor.visitSingularStringField(value: self.signature, fieldNumber: 1)
+    }
+    if self.timestamp != 0 {
+      try visitor.visitSingularUInt64Field(value: self.timestamp, fieldNumber: 2)
+    }
+    if self.payloadVersion != .unspecified {
+      try visitor.visitSingularEnumField(value: self.payloadVersion, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Xmtp_MessageContents_ConsentProofPayload, rhs: Xmtp_MessageContents_ConsentProofPayload) -> Bool {
+    if lhs.signature != rhs.signature {return false}
+    if lhs.timestamp != rhs.timestamp {return false}
+    if lhs.payloadVersion != rhs.payloadVersion {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/XMTPTests/ConversationsTest.swift
+++ b/Tests/XMTPTests/ConversationsTest.swift
@@ -202,19 +202,77 @@ class ConversationsTests: XCTestCase {
         let boClient = try await Client.create(account: bo, apiClient: fixtures.fakeApiClient)
         let alixClient = try await Client.create(account: alix, apiClient: fixtures.fakeApiClient)
 
-        let privateKeyBundle = alixClient.keys
-        let signedPrivateKey =  privateKeyBundle.identityKey
-        let privateKey = try PrivateKey(signedPrivateKey)
-        let signature = try await privateKey.sign(Data([1,2,3]))
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let signatureText = Signature.consentProofText(peerAddress: boClient.address, timestamp: timestamp)
+        let digest = Data(signatureText.utf8)
+        let signature = try await alix.sign(Util.keccak256(digest))
         let hex = Data(try signature.serializedData()).toHex
+        var consentProofPayload = ConsentProofPayload()
+        consentProofPayload.signature = hex
+        consentProofPayload.timestamp = timestamp
+        consentProofPayload.payloadVersion = .consentProofPayloadVersion1
         let boConversation =
-        try await boClient.conversations.newConversation(with: alixClient.address, context: nil, consentProofSignature: hex)
+        try await boClient.conversations.newConversation(with: alixClient.address, context: nil, consentProofPayload: consentProofPayload)
         let alixConversations = try await
             alixClient.conversations.list()
         let alixConversation = alixConversations.first(where: { $0.topic == boConversation.topic })
         XCTAssertNotNil(alixConversation)
         let consentStatus = await alixClient.contacts.isAllowed(boClient.address)
         XCTAssertTrue(consentStatus)
+    }
 
+    func testNetworkConsentOverConsentProof() async throws {
+        let fixtures = await fixtures()
+        let bo = try PrivateKey.generate()
+        let alix = try PrivateKey.generate()
+    
+        let boClient = try await Client.create(account: bo, apiClient: fixtures.fakeApiClient)
+        let alixClient = try await Client.create(account: alix, apiClient: fixtures.fakeApiClient)
+
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let signatureText = Signature.consentProofText(peerAddress: boClient.address, timestamp: timestamp)
+        let digest = Data(signatureText.utf8)
+        let signature = try await alix.sign(Util.keccak256(digest))
+        let hex = Data(try signature.serializedData()).toHex
+        var consentProofPayload = ConsentProofPayload()
+        consentProofPayload.signature = hex
+        consentProofPayload.timestamp = timestamp
+        consentProofPayload.payloadVersion = .consentProofPayloadVersion1
+        let boConversation =
+        try await boClient.conversations.newConversation(with: alixClient.address, context: nil, consentProofPayload: consentProofPayload)
+        try await alixClient.contacts.deny(addresses: [boClient.address])
+        let alixConversations = try await
+            alixClient.conversations.list()
+        let alixConversation = alixConversations.first(where: { $0.topic == boConversation.topic })
+        XCTAssertNotNil(alixConversation)
+        let isDenied = await alixClient.contacts.isDenied(boClient.address)
+        XCTAssertTrue(isDenied)
+    }
+    
+    func testConsentProofInvalidSignature() async throws {
+        let fixtures = await fixtures()
+        let bo = try PrivateKey.generate()
+        let alix = try PrivateKey.generate()
+    
+        let boClient = try await Client.create(account: bo, apiClient: fixtures.fakeApiClient)
+        let alixClient = try await Client.create(account: alix, apiClient: fixtures.fakeApiClient)
+
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let signatureText = Signature.consentProofText(peerAddress: boClient.address, timestamp: timestamp + 1)
+        let digest = Data(signatureText.utf8)
+        let signature = try await alix.sign(Util.keccak256(digest))
+        let hex = Data(try signature.serializedData()).toHex
+        var consentProofPayload = ConsentProofPayload()
+        consentProofPayload.signature = hex
+        consentProofPayload.timestamp = timestamp
+        consentProofPayload.payloadVersion = .consentProofPayloadVersion1
+        let boConversation =
+        try await boClient.conversations.newConversation(with: alixClient.address, context: nil, consentProofPayload: consentProofPayload)
+        let alixConversations = try await
+            alixClient.conversations.list()
+        let alixConversation = alixConversations.first(where: { $0.topic == boConversation.topic })
+        XCTAssertNotNil(alixConversation)
+        let isAllowed = await alixClient.contacts.isAllowed(boClient.address)
+        XCTAssertFalse(isAllowed)
     }
 }


### PR DESCRIPTION

## Introduction 📟
Updated invitiation protos
Added handling for consent proof signature on conversation creation

- [x]  Update Proto
- [x]  Send signature in invitation
- [x]  Verify signature when loading invitations
- [x]  Approve contact

## Purpose ℹ️ 
[XIP](https://community.xmtp.org/t/xip-43-consent-proofs/552)
Tracking issue: https://github.com/xmtp/xmtp-ios/issues/309 

## Scope 🔭
<!-- What is the technical scope of the changes? -->

<!-- Beginning of comment block
From this point on, all the following titles are optional.
Move the ones you need out of the comment block and delete the rest of the template.
There is a table example included for screenshots

## Out of Scope ⚔️

## Testing 🧪

## TODOs ☑️
- [ ] [Change log] updated or ignored

## Discussion 🎙

End of comment block -->
