### PR TITLE
Fix SQL App Group Crash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.12.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.4-beta5"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.4.4-beta6"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/XMTPiOS/ApiClient.swift
+++ b/Sources/XMTPiOS/ApiClient.swift
@@ -37,6 +37,8 @@ extension GenericErrorDescribing {
 			let .GroupMetadata(message),
 			let .Generic(message):
 			return message
+		case .GroupMutablePermissions(message: let message):
+			return message
 		}
 	}
 }

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -462,6 +462,21 @@ public final class Client {
 		let fm = FileManager.default
 		try fm.removeItem(atPath: dbPath)
 	}
+	
+	@available(*, deprecated, message: "This function is delicate and should be used with caution. App will error if database not properly reconnected. See: reconnectLocalDatabase()")
+	public func dropLocalDatabaseConnection() throws {
+		guard let client = v3Client else {
+			throw ClientError.noV3Client("Error no V3 client initialized")
+		}
+		try client.releaseDbConnection()
+	}
+	
+	public func reconnectLocalDatabase() async throws {
+		guard let client = v3Client else {
+			throw ClientError.noV3Client("Error no V3 client initialized")
+		}
+		try await client.dbReconnect()
+	}
 
 	func getUserContact(peerAddress: String) async throws -> ContactBundle? {
 		let peerAddress = EthereumAddress(peerAddress).toChecksumAddress()

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -71,9 +71,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 		return try metadata().creatorAccountAddress().lowercased() == client.address.lowercased()
 	}
 
-	public func permissionLevel() throws -> GroupPermissions {
-		return try metadata().policyType()
-	}
+//	public func permissionLevel() throws -> GroupPermissions {
+//		return try metadata().policyType()
+//	}
 
 	public func adminAddress() throws -> String {
 		return try metadata().creatorAccountAddress()

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -110,8 +110,8 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(aliceGroup.memberAddresses.count, 3)
 		XCTAssertEqual(bobGroup.memberAddresses.count, 3)
 		
-		XCTAssertEqual(try bobGroup.permissionLevel(), .everyoneIsAdmin)
-		XCTAssertEqual(try aliceGroup.permissionLevel(), .everyoneIsAdmin)
+//		XCTAssertEqual(try bobGroup.permissionLevel(), .everyoneIsAdmin)
+//		XCTAssertEqual(try aliceGroup.permissionLevel(), .everyoneIsAdmin)
 		XCTAssertEqual(try bobGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
 		XCTAssertEqual(try aliceGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
 		XCTAssert(try bobGroup.isAdmin())
@@ -156,8 +156,8 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(aliceGroup.memberAddresses.count, 2)
 		XCTAssertEqual(bobGroup.memberAddresses.count, 2)
 		
-		XCTAssertEqual(try bobGroup.permissionLevel(), .groupCreatorIsAdmin)
-		XCTAssertEqual(try aliceGroup.permissionLevel(), .groupCreatorIsAdmin)
+//		XCTAssertEqual(try bobGroup.permissionLevel(), .groupCreatorIsAdmin)
+//		XCTAssertEqual(try aliceGroup.permissionLevel(), .groupCreatorIsAdmin)
 		XCTAssertEqual(try bobGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
 		XCTAssertEqual(try aliceGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
 		XCTAssert(try bobGroup.isAdmin())

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.10.11"
+  spec.version      = "0.10.12"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.12.0"
-  spec.dependency 'LibXMTP', '= 0.4.4-beta5'
+  spec.dependency 'LibXMTP', '= 0.4.4-beta6'
 end

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "f2b73d14be21b64feecfa70c789b3302525975ab",
-        "version" : "0.4.4-beta5"
+        "revision" : "11ac13baf3b2d36571a8ad5b0d8bda3017635563",
+        "version" : "0.4.4-beta6"
       }
     },
     {


### PR DESCRIPTION
Should close https://github.com/xmtp/xmtp-ios/issues/336

This adds two new functions that should be called on background and foreground of the app when using app groups with the local database to disconnect and reconnect the database to avoid crashing.
