### PR TITLE
Adds admin list functionality

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "f2b73d14be21b64feecfa70c789b3302525975ab",
-        "version" : "0.4.4-beta5"
+        "revision" : "bfee6cde5cadf0e1842b77daf80e6e4a88830194",
+        "version" : "0.5.0-beta1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.12.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.5.0-beta0"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.5.0-beta1"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -113,7 +113,7 @@ public actor Conversations {
 		}
 	}
 
-	public func newGroup(with addresses: [String], permissions: GroupPermissions = .everyoneIsAdmin) async throws -> Group {
+    public func newGroup(with addresses: [String], permissions: GroupPermissions = .allMembers) async throws -> Group {
 		guard let v3Client = client.v3Client else {
 			throw GroupError.alphaMLSNotEnabled
 		}

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -42,6 +42,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 	func metadata() throws -> FfiGroupMetadata {
 		return try ffiGroup.groupMetadata()
 	}
+    
+    func permissions() throws -> FfiGroupPermissions {
+        return try ffiGroup.groupPermissions()
+    }
 
 	public func sync() async throws {
 		try await ffiGroup.sync()
@@ -59,15 +63,47 @@ public struct Group: Identifiable, Equatable, Hashable {
 		return try ffiGroup.isActive()
 	}
 
-	public func isAdmin() throws -> Bool {
+	public func isCreator() throws -> Bool {
 		return try metadata().creatorInboxId() == client.inboxID
 	}
+    
+    public func isAdmin(inboxId: String) throws -> Bool {
+        return try ffiGroup.isAdmin(inboxId: inboxId)
+    }
+    
+    public func isSuperAdmin(inboxId: String) throws -> Bool {
+        return try ffiGroup.isSuperAdmin(inboxId: inboxId)
+    }
+    
+    public func addAdmin(inboxId: String) async throws {
+        try await ffiGroup.addAdmin(inboxId: inboxId)
+    }
+    
+    public func removeAdmin(inboxId: String) async throws {
+        try await ffiGroup.removeAdmin(inboxId: inboxId)
+    }
+    
+    public func addSuperAdmin(inboxId: String) async throws {
+        try await ffiGroup.addSuperAdmin(inboxId: inboxId)
+    }
+    
+    public func removeSuperAdmin(inboxId: String) async throws {
+        try await ffiGroup.removeSuperAdmin(inboxId: inboxId)
+    }
+    
+    public func listAdmins() throws -> [String] {
+        try ffiGroup.adminList()
+    }
+    
+    public func listSuperAdmins() throws -> [String] {
+        try ffiGroup.superAdminList()
+    }
 
-//	public func permissionLevel() throws -> GroupPermissions {
-//		return try metadata().policyType()
-//	}
+	public func permissionLevel() throws -> GroupPermissions {
+		return try permissions().policyType()
+	}
 
-	public func adminInboxId() throws -> String {
+	public func creatorInboxId() throws -> String {
 		return try metadata().creatorInboxId()
 	}
 	

--- a/Sources/XMTPiOS/Mls/Member.swift
+++ b/Sources/XMTPiOS/Mls/Member.swift
@@ -8,19 +8,34 @@
 import Foundation
 import LibXMTP
 
-public struct Member {
-	var ffiGroupMember: FfiGroupMember
-	
-	init(ffiGroupMember: FfiGroupMember) {
-		self.ffiGroupMember = ffiGroupMember
-	}
+public enum PermissionLevel {
+    case Member, Admin, SuperAdmin
+}
 
-	public var inboxId: String {
-		ffiGroupMember.inboxId
-	}
-	
-	public var addresses: [String] {
-		ffiGroupMember.accountAddresses
+public struct Member {
+    var ffiGroupMember: FfiGroupMember
+    
+    init(ffiGroupMember: FfiGroupMember) {
+        self.ffiGroupMember = ffiGroupMember
+    }
+
+    public var inboxId: String {
+        ffiGroupMember.inboxId
+    }
+    
+    public var addresses: [String] {
+        ffiGroupMember.accountAddresses
+    }
+
+	public var permissionLevel: PermissionLevel {
+        switch ffiGroupMember.permissionLevel {
+        case .member:
+            return PermissionLevel.Member
+        case .admin:
+            return PermissionLevel.Admin
+        case .superAdmin:
+            return PermissionLevel.SuperAdmin
+        }
 	}
 }
 

--- a/Tests/XMTPTests/GroupPermissionsTests.swift
+++ b/Tests/XMTPTests/GroupPermissionsTests.swift
@@ -1,0 +1,232 @@
+//
+//  GroupPermissionTests.swift
+//
+//
+//  Created by Cameron Voell on 5/29/24.
+//
+
+import CryptoKit
+import XCTest
+@testable import XMTPiOS
+import LibXMTP
+import XMTPTestHelpers
+
+@available(iOS 16, *)
+class GroupPermissionTests: XCTestCase {
+    // Use these fixtures to talk to the local node
+    struct LocalFixtures {
+        var alice: PrivateKey!
+        var bob: PrivateKey!
+        var caro: PrivateKey!
+        var aliceClient: Client!
+        var bobClient: Client!
+        var caroClient: Client!
+    }
+    
+    func localFixtures() async throws -> LocalFixtures {
+        let key = try Crypto.secureRandomBytes(count: 32)
+        let alice = try PrivateKey.generate()
+        let aliceClient = try await Client.create(
+            account: alice,
+            options: .init(
+                api: .init(env: .local, isSecure: false),
+                codecs: [GroupUpdatedCodec()],
+                mlsAlpha: true,
+                mlsEncryptionKey: key
+            )
+        )
+        let bob = try PrivateKey.generate()
+        let bobClient = try await Client.create(
+            account: bob,
+            options: .init(
+                api: .init(env: .local, isSecure: false),
+                codecs: [GroupUpdatedCodec()],
+                mlsAlpha: true,
+                mlsEncryptionKey: key
+            )
+        )
+        let caro = try PrivateKey.generate()
+        let caroClient = try await Client.create(
+            account: caro,
+            options: .init(
+                api: .init(env: .local, isSecure: false),
+                codecs: [GroupUpdatedCodec()],
+                mlsAlpha: true,
+                mlsEncryptionKey: key
+            )
+        )
+        
+        return .init(
+            alice: alice,
+            bob: bob,
+            caro: caro,
+            aliceClient: aliceClient,
+            bobClient: bobClient,
+            caroClient: caroClient
+        )
+    }
+    
+    func testGroupCreatedWithCorrectAdminList() async throws {
+        let fixtures = try await localFixtures()
+        let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.walletAddress])
+        try await fixtures.aliceClient.conversations.sync()
+        let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
+        
+        XCTAssertTrue(try bobGroup.isAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssertTrue(try bobGroup.isSuperAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssertFalse(try aliceGroup.isCreator())
+        XCTAssertFalse(try aliceGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+        XCTAssertFalse(try aliceGroup.isSuperAdmin(inboxId: fixtures.aliceClient.inboxID))
+        
+        let adminList = try bobGroup.listAdmins()
+        let superAdminList = try bobGroup.listSuperAdmins()
+        
+        XCTAssertEqual(adminList.count, 1)
+        XCTAssertTrue(adminList.contains(fixtures.bobClient.inboxID))
+        XCTAssertEqual(superAdminList.count, 1)
+        XCTAssertTrue(superAdminList.contains(fixtures.bobClient.inboxID))
+    }
+    
+    func testGroupCanUpdateAdminList() async throws {
+        let fixtures = try await localFixtures()
+        let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.walletAddress, fixtures.caro.walletAddress], permissions: .adminOnly)
+        try await fixtures.aliceClient.conversations.sync()
+        let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
+        
+        XCTAssertTrue(try bobGroup.isAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssertTrue(try bobGroup.isSuperAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssertFalse(try aliceGroup.isCreator())
+        XCTAssertFalse(try aliceGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+        XCTAssertFalse(try aliceGroup.isSuperAdmin(inboxId: fixtures.aliceClient.inboxID))
+        
+        var adminList = try bobGroup.listAdmins()
+        var superAdminList = try bobGroup.listSuperAdmins()
+        XCTAssertEqual(adminList.count, 1)
+        XCTAssertTrue(adminList.contains(fixtures.bobClient.inboxID))
+        XCTAssertEqual(superAdminList.count, 1)
+        XCTAssertTrue(superAdminList.contains(fixtures.bobClient.inboxID))
+        
+        // Verify that alice can NOT update group name
+        XCTAssertEqual(try bobGroup.groupName(), "New Group")
+        await assertThrowsAsyncError(
+            try await aliceGroup.updateGroupName(groupName: "Alice group name")
+        )
+        
+        try await aliceGroup.sync()
+        try await bobGroup.sync()
+        XCTAssertEqual(try bobGroup.groupName(), "New Group")
+        XCTAssertEqual(try aliceGroup.groupName(), "New Group")
+        
+        try await bobGroup.addAdmin(inboxId: fixtures.aliceClient.inboxID)
+        try await bobGroup.sync()
+        try await aliceGroup.sync()
+        
+        adminList = try bobGroup.listAdmins()
+        superAdminList = try bobGroup.listSuperAdmins()
+        
+        XCTAssertTrue(try aliceGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+        XCTAssertEqual(adminList.count, 2)
+        XCTAssertTrue(adminList.contains(fixtures.aliceClient.inboxID))
+        XCTAssertEqual(superAdminList.count, 1)
+        
+        // Verify that alice can now update group name
+        try await aliceGroup.updateGroupName(groupName: "Alice group name")
+        try await aliceGroup.sync()
+        try await bobGroup.sync()
+        XCTAssertEqual(try bobGroup.groupName(), "Alice group name")
+        XCTAssertEqual(try aliceGroup.groupName(), "Alice group name")
+        
+        try await bobGroup.removeAdmin(inboxId: fixtures.aliceClient.inboxID)
+        try await bobGroup.sync()
+        try await aliceGroup.sync()
+        
+        adminList = try bobGroup.listAdmins()
+        superAdminList = try bobGroup.listSuperAdmins()
+        
+        XCTAssertFalse(try aliceGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+        XCTAssertEqual(adminList.count, 1)
+        XCTAssertFalse(adminList.contains(fixtures.aliceClient.inboxID))
+        XCTAssertEqual(superAdminList.count, 1)
+        
+        // Verify that alice can NOT update group name
+        await assertThrowsAsyncError(
+            try await aliceGroup.updateGroupName(groupName: "Alice group name 2")
+        )
+    }
+    
+    func testGroupCanUpdateSuperAdminList() async throws {
+        let fixtures = try await localFixtures()
+        let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.walletAddress, fixtures.caro.walletAddress], permissions: .adminOnly)
+        try await fixtures.aliceClient.conversations.sync()
+        let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
+
+        XCTAssertTrue(try bobGroup.isSuperAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssertFalse(try aliceGroup.isSuperAdmin(inboxId: fixtures.aliceClient.inboxID))
+
+        // Attempt to remove bob as a super admin by alice should fail since she is not a super admin
+        await assertThrowsAsyncError(
+            try await aliceGroup.removeSuperAdmin(inboxId: fixtures.bobClient.inboxID)
+        )
+
+        // Make alice a super admin
+        try await bobGroup.addSuperAdmin(inboxId: fixtures.aliceClient.inboxID)
+        try await bobGroup.sync()
+        try await aliceGroup.sync()
+        XCTAssertTrue(try aliceGroup.isSuperAdmin(inboxId: fixtures.aliceClient.inboxID))
+
+        // Now alice should be able to remove bob as a super admin
+        try await aliceGroup.removeSuperAdmin(inboxId: fixtures.bobClient.inboxID)
+        try await aliceGroup.sync()
+        try await bobGroup.sync()
+
+        let superAdminList = try bobGroup.listSuperAdmins()
+        XCTAssertFalse(superAdminList.contains(fixtures.bobClient.inboxID))
+        XCTAssertTrue(superAdminList.contains(fixtures.aliceClient.inboxID))
+    }
+    
+    func testGroupMembersAndPermissionLevel() async throws {
+        let fixtures = try await localFixtures()
+        let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.walletAddress, fixtures.caro.walletAddress], permissions: .adminOnly)
+        try await fixtures.aliceClient.conversations.sync()
+        let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
+
+        // Initial checks for group members and their permissions
+        var members = try bobGroup.members
+        var admins = members.filter { $0.permissionLevel == PermissionLevel.Admin }
+        var superAdmins = members.filter { $0.permissionLevel == PermissionLevel.SuperAdmin }
+        var regularMembers = members.filter { $0.permissionLevel == PermissionLevel.Member }
+
+        XCTAssertEqual(admins.count, 0)
+        XCTAssertEqual(superAdmins.count, 1)
+        XCTAssertEqual(regularMembers.count, 2)
+
+        // Add alice as an admin
+        try await bobGroup.addAdmin(inboxId: fixtures.aliceClient.inboxID)
+        try await bobGroup.sync()
+        try await aliceGroup.sync()
+
+        members = try bobGroup.members
+        admins = members.filter { $0.permissionLevel == PermissionLevel.Admin }
+        superAdmins = members.filter { $0.permissionLevel == PermissionLevel.SuperAdmin }
+        regularMembers = members.filter { $0.permissionLevel == PermissionLevel.Member }
+
+        XCTAssertEqual(admins.count, 1)
+        XCTAssertEqual(superAdmins.count, 1)
+        XCTAssertEqual(regularMembers.count, 1)
+
+        // Add caro as a super admin
+        try await bobGroup.addSuperAdmin(inboxId: fixtures.caroClient.inboxID)
+        try await bobGroup.sync()
+        try await aliceGroup.sync()
+
+        members = try bobGroup.members
+        admins = members.filter { $0.permissionLevel == PermissionLevel.Admin }
+        superAdmins = members.filter { $0.permissionLevel == PermissionLevel.SuperAdmin }
+        regularMembers = members.filter { $0.permissionLevel == PermissionLevel.Member }
+
+        XCTAssertEqual(admins.count, 1)
+        XCTAssertEqual(superAdmins.count, 2)
+        XCTAssertTrue(regularMembers.isEmpty)
+    }
+
+}

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -87,82 +87,98 @@ class GroupTests: XCTestCase {
 		)
 	}
 
-//	func testCanCreateAGroupWithDefaultPermissions() async throws {
-//		let fixtures = try await localFixtures()
-//		let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address])
-//		try await fixtures.aliceClient.conversations.sync()
-//		let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
-//		XCTAssert(!bobGroup.id.isEmpty)
-//		XCTAssert(!aliceGroup.id.isEmpty)
-//		
-//		try await aliceGroup.addMembers(addresses: [fixtures.fred.address])
-//		try await bobGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 3)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 3)
+	func testCanCreateAGroupWithDefaultPermissions() async throws {
+		let fixtures = try await localFixtures()
+		let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address])
+		try await fixtures.aliceClient.conversations.sync()
+		let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
+		XCTAssert(!bobGroup.id.isEmpty)
+		XCTAssert(!aliceGroup.id.isEmpty)
+		
+		try await aliceGroup.addMembers(addresses: [fixtures.fred.address])
+		try await bobGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//		XCTAssertEqual(try aliceGroup.members.count, 3)
+		XCTAssertEqual(try bobGroup.members.count, 3)
+
+		try await aliceGroup.removeMembers(addresses: [fixtures.fred.address])
+		try await bobGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//      XCTAssertEqual(try aliceGroup.members.count, 2)
+		XCTAssertEqual(try bobGroup.members.count, 2)
+
+		try await bobGroup.addMembers(addresses: [fixtures.fred.address])
+		try await aliceGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//		XCTAssertEqual(try aliceGroup.members.count, 3)
+		XCTAssertEqual(try bobGroup.members.count, 3)
+		
+		XCTAssertEqual(try bobGroup.permissionLevel(), .allMembers)
+		XCTAssertEqual(try aliceGroup.permissionLevel(), .allMembers)
+
+        XCTAssert(try bobGroup.isAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssert(try !bobGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+        XCTAssert(try aliceGroup.isAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssert(try !aliceGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+		
+	}
 //
-//		try await aliceGroup.removeMembers(addresses: [fixtures.fred.address])
-//		try await bobGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 2)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 2)
-//
-//		try await bobGroup.addMembers(addresses: [fixtures.fred.address])
-//		try await aliceGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 3)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 3)
-//		
-////		XCTAssertEqual(try bobGroup.permissionLevel(), .everyoneIsAdmin)
-////		XCTAssertEqual(try aliceGroup.permissionLevel(), .everyoneIsAdmin)
-//		XCTAssertEqual(try bobGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
-//		XCTAssertEqual(try aliceGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
-//		XCTAssert(try bobGroup.isAdmin())
-//		XCTAssert(try !aliceGroup.isAdmin())
-//	}
-//
-//	func testCanCreateAGroupWithAdminPermissions() async throws {
-//		let fixtures = try await localFixtures()
-//		let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address], permissions: GroupPermissions.groupCreatorIsAdmin)
-//		try await fixtures.aliceClient.conversations.sync()
-//		let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
-//		XCTAssert(!bobGroup.id.isEmpty)
-//		XCTAssert(!aliceGroup.id.isEmpty)
-//
-//		let bobConsentResult = await fixtures.bobClient.contacts.consentList.groupState(groupId: bobGroup.id)
-//		XCTAssertEqual(bobConsentResult, ConsentState.allowed)
-//
-//		let aliceConsentResult = await fixtures.aliceClient.contacts.consentList.groupState(groupId: aliceGroup.id)
-//		XCTAssertEqual(aliceConsentResult, ConsentState.unknown)
-//
-//		try await bobGroup.addMembers(addresses: [fixtures.fred.address])
-//		try await aliceGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 3)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 3)
-//
-//		await assertThrowsAsyncError(
-//			try await aliceGroup.removeMembers(addresses: [fixtures.fred.address])
-//		)
-//		try await bobGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 3)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 3)
-//		
-//		try await bobGroup.removeMembers(addresses: [fixtures.fred.address])
-//		try await aliceGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 2)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 2)
-//
-//		await assertThrowsAsyncError(
-//			try await aliceGroup.addMembers(addresses: [fixtures.fred.address])
-//		)
-//		try await bobGroup.sync()
-//		XCTAssertEqual(aliceGroup.memberAddresses.count, 2)
-//		XCTAssertEqual(bobGroup.memberAddresses.count, 2)
-//		
-////		XCTAssertEqual(try bobGroup.permissionLevel(), .groupCreatorIsAdmin)
-////		XCTAssertEqual(try aliceGroup.permissionLevel(), .groupCreatorIsAdmin)
-//		XCTAssertEqual(try bobGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
-//		XCTAssertEqual(try aliceGroup.adminAddress().lowercased(), fixtures.bobClient.address.lowercased())
-//		XCTAssert(try bobGroup.isAdmin())
-//		XCTAssert(try !aliceGroup.isAdmin())
-//	}
+	func testCanCreateAGroupWithAdminPermissions() async throws {
+		let fixtures = try await localFixtures()
+		let bobGroup = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address], permissions: GroupPermissions.adminOnly)
+		try await fixtures.aliceClient.conversations.sync()
+		let aliceGroup = try await fixtures.aliceClient.conversations.groups().first!
+		XCTAssert(!bobGroup.id.isEmpty)
+		XCTAssert(!aliceGroup.id.isEmpty)
+
+		let bobConsentResult = await fixtures.bobClient.contacts.consentList.groupState(groupId: bobGroup.id)
+		XCTAssertEqual(bobConsentResult, ConsentState.allowed)
+
+		let aliceConsentResult = await fixtures.aliceClient.contacts.consentList.groupState(groupId: aliceGroup.id)
+		XCTAssertEqual(aliceConsentResult, ConsentState.unknown)
+
+		try await bobGroup.addMembers(addresses: [fixtures.fred.address])
+		try await aliceGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//		XCTAssertEqual(try aliceGroup.members.count, 3)
+		XCTAssertEqual(try bobGroup.members.count, 3)
+
+		await assertThrowsAsyncError(
+			try await aliceGroup.removeMembers(addresses: [fixtures.fred.address])
+		)
+		try await bobGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//		XCTAssertEqual(try aliceGroup.members.count, 3)
+		XCTAssertEqual(try bobGroup.members.count, 3)
+		
+		try await bobGroup.removeMembers(addresses: [fixtures.fred.address])
+		try await aliceGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//		XCTAssertEqual(try aliceGroup.members.count, 2)
+		XCTAssertEqual(try bobGroup.members.count, 2)
+
+		await assertThrowsAsyncError(
+			try await aliceGroup.addMembers(addresses: [fixtures.fred.address])
+		)
+		try await bobGroup.sync()
+        // Issue members is not returning correctly for non group creators:
+        // https://github.com/xmtp/libxmtp/issues/769
+//		XCTAssertEqual(try aliceGroup.members.count, 2)
+		XCTAssertEqual(try bobGroup.members.count, 2)
+		
+		XCTAssertEqual(try bobGroup.permissionLevel(), .adminOnly)
+		XCTAssertEqual(try aliceGroup.permissionLevel(), .adminOnly)
+        XCTAssert(try bobGroup.isAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssert(try !bobGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+        XCTAssert(try aliceGroup.isAdmin(inboxId: fixtures.bobClient.inboxID))
+        XCTAssert(try !aliceGroup.isAdmin(inboxId: fixtures.aliceClient.inboxID))
+	}
 
 	func testCanListGroups() async throws {
 		let fixtures = try await localFixtures()

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.12.0"
-  spec.dependency 'LibXMTP', '= 0.5.0-beta0'
+  spec.dependency 'LibXMTP', '= 0.5.0-beta1'
 end

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.10.12"
+  spec.version      = "0.11.00"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Part of https://github.com/xmtp/libxmtp/issues/664

Related to:
- https://github.com/xmtp/libxmtp/pull/789
- https://github.com/xmtp/libxmtp/pull/782
- https://github.com/xmtp/libxmtp-swift/pull/31
- https://github.com/xmtp/xmtp-android/pull/245

# Introduction 📟
<!-- Brief explanation of the problem to be solved / bug to be fixed. -->

## Purpose ℹ️ 
<!-- What is the goal of the proposed change? -->

PR adds functions for accessing and updating admin and superadmin lists for managing group permissions. See [XIP-47](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-47-group-chat-permissions.md) for more information. 

## Scope 🔭
<!-- What is the technical scope of the changes? -->

PR adds the following

- isAdmin / isSuperAdmin
- adminList() \ superAdminList()
- add / remove admin
- updates group creation options to AllMembers / AdminOnly
- renames functions to isCreator / creatorAddress()

<!-- Beginning of comment block
From this point on, all the following titles are optional.
Move the ones you need out of the comment block and delete the rest of the template.
There is a table example included for screenshots

## Out of Scope ⚔️

## Testing 🧪

## TODOs ☑️
- [ ] [Change log] updated or ignored

## Discussion 🎙

End of comment block -->
