### PR TITLE
Update libxmtp - Fix pending commit clearing after invalid permissions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "bc7e65b4db73430ae259bce32b391eefa82d4071",
-        "version" : "0.5.1-beta0"
+        "revision" : "c5e9ed9d3ee9de55beec4d7a8f76861c9d43230d",
+        "version" : "0.5.1-beta1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "bfee6cde5cadf0e1842b77daf80e6e4a88830194",
-        "version" : "0.5.0-beta1"
+        "revision" : "bc7e65b4db73430ae259bce32b391eefa82d4071",
+        "version" : "0.5.1-beta0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.12.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.5.1-beta0"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift", exact: "0.5.1-beta1"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/XMTPTests/GroupPermissionsTests.swift
+++ b/Tests/XMTPTests/GroupPermissionsTests.swift
@@ -107,15 +107,15 @@ class GroupPermissionTests: XCTestCase {
         XCTAssertTrue(superAdminList.contains(fixtures.bobClient.inboxID))
         
         // Verify that alice can NOT update group name
-        XCTAssertEqual(try bobGroup.groupName(), "New Group")
+        XCTAssertEqual(try bobGroup.groupName(), "")
         await assertThrowsAsyncError(
             try await aliceGroup.updateGroupName(groupName: "Alice group name")
         )
         
         try await aliceGroup.sync()
         try await bobGroup.sync()
-        XCTAssertEqual(try bobGroup.groupName(), "New Group")
-        XCTAssertEqual(try aliceGroup.groupName(), "New Group")
+        XCTAssertEqual(try bobGroup.groupName(), "")
+        XCTAssertEqual(try aliceGroup.groupName(), "")
         
         try await bobGroup.addAdmin(inboxId: fixtures.aliceClient.inboxID)
         try await bobGroup.sync()

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -645,7 +645,7 @@ class GroupTests: XCTestCase {
         
         var groupName = try group.groupName()
         
-        XCTAssertEqual(groupName, "New Group")
+        XCTAssertEqual(groupName, "")
 
         try await group.updateGroupName(groupName: "Test Group Name 1")
         
@@ -666,7 +666,7 @@ class GroupTests: XCTestCase {
                 bobGroup = group
         }
         groupName = try bobGroup.groupName()
-        XCTAssertEqual(groupName, "New Group")
+        XCTAssertEqual(groupName, "")
         
         try await bobGroup.sync()
         groupName = try bobGroup.groupName()

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.11.4"
+  spec.version      = "0.11.5"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.12.0"
-  spec.dependency 'LibXMTP', '= 0.5.1-beta0'
+  spec.dependency 'LibXMTP', '= 0.5.1-beta1'
 end


### PR DESCRIPTION
## Introduction 📟
<!-- Brief explanation of the problem to be solved / bug to be fixed. -->

Notable Updates:

- Default group name is now empty string
- Now correctly clearing pending commits after invalid permission commits

## Purpose ℹ️ 
<!-- What is the goal of the proposed change? -->

See https://github.com/xmtp/libxmtp/issues/805

## Scope 🔭
<!-- What is the technical scope of the changes? -->

<!-- Beginning of comment block
From this point on, all the following titles are optional.
Move the ones you need out of the comment block and delete the rest of the template.
There is a table example included for screenshots

## Out of Scope ⚔️

## Testing 🧪

## TODOs ☑️
- [ ] [Change log] updated or ignored

## Discussion 🎙

End of comment block -->
