### PR TITLE
Fix conflicting streams issue

### DIFF
--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -17,7 +17,7 @@ public enum ConversationError: Error, CustomStringConvertible {
 }
 
 public enum GroupError: Error, CustomStringConvertible {
-	case alphaMLSNotEnabled, memberCannotBeSelf, memberNotRegistered([String]), groupsRequireMessagePassed, notSupportedByGroups
+	case alphaMLSNotEnabled, memberCannotBeSelf, memberNotRegistered([String]), groupsRequireMessagePassed, notSupportedByGroups, streamingFailure
 
 	public var description: String {
 		switch self {
@@ -31,6 +31,8 @@ public enum GroupError: Error, CustomStringConvertible {
 			return "GroupError.groupsRequireMessagePassed you cannot call this method without passing a message instead of an envelope"
 		case .notSupportedByGroups:
 			return "GroupError.notSupportedByGroups this method is not supported by groups"
+		case .streamingFailure:
+			return "GroupError.streamingFailure a stream has failed"
 		}
 	}
 }
@@ -97,7 +99,7 @@ public actor Conversations {
 				}
 				
 				guard let stream = try await self.client.v3Client?.conversations().stream(callback: groupCallback) else {
-					continuation.finish(throwing: GroupError.notSupportedByGroups)
+					continuation.finish(throwing: GroupError.streamingFailure)
 					return
 				}
 				

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -562,6 +562,31 @@ class GroupTests: XCTestCase {
 		await waitForExpectations(timeout: 3)
 	}
 	
+	func testStreamGroupsAndAllMessages() async throws {
+		let fixtures = try await localFixtures()
+		
+		let expectation1 = expectation(description: "got a group")
+		let expectation2 = expectation(description: "got a message")
+
+
+		Task(priority: .userInitiated) {
+			for try await _ in try await fixtures.aliceClient.conversations.streamGroups() {
+				expectation1.fulfill()
+			}
+		}
+		
+		Task(priority: .userInitiated) {
+			for try await _ in try await fixtures.aliceClient.conversations.streamAllMessages(includeGroups: true) {
+				expectation2.fulfill()
+			}
+		}
+
+		let group = try await fixtures.bobClient.conversations.newGroup(with: [fixtures.alice.address])
+		try await group.send(content: "hello")
+
+		await waitForExpectations(timeout: 3)
+	}
+	
 	func testCanStreamAllMessages() async throws {
 		let fixtures = try await localFixtures()
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.11.5"
+  spec.version      = "0.11.6"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift",
       "state" : {
-        "revision" : "bc7e65b4db73430ae259bce32b391eefa82d4071",
-        "version" : "0.5.1-beta0"
+        "revision" : "c5e9ed9d3ee9de55beec4d7a8f76861c9d43230d",
+        "version" : "0.5.1-beta1"
       }
     },
     {


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-react-native/issues/415

When streaming both all group messages and groups the streams would conflict and fail. 
Was not able to reproduce in Android and compared the Android libxmtp logs to the iOS libxmtp logs and saw that they were identical this allowed me to carefully reconstruct the concurrency in iOS and get the tests to pass.