### PR TITLE
Add back the requirement on encryption key

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -141,6 +141,7 @@ public final class Client {
 		if options?.enableV3 == true {
 			let address = accountAddress.lowercased()
 
+<<<<<<< HEAD
 			var inboxId: String
 			do {
 				inboxId = try await getInboxIdForAddress(
@@ -173,7 +174,10 @@ public final class Client {
 			let alias = "xmtp-\(options?.api.env.rawValue ?? "")-\(inboxId).db3"
 			let dbURL = directoryURL.appendingPathComponent(alias).path
 			
-			let encryptionKey = options?.dbEncryptionKey
+			var encryptionKey = options?.dbEncryptionKey
+			if (encryptionKey == nil) {
+				throw ClientError.creationError("No encryption key passed for the database. Please store and provide a secure encryption key.")
+			}
 
 			let v3Client = try await LibXMTP.createClient(
 				logger: XMTPLogger(),

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -141,7 +141,6 @@ public final class Client {
 		if options?.enableV3 == true {
 			let address = accountAddress.lowercased()
 
-<<<<<<< HEAD
 			var inboxId: String
 			do {
 				inboxId = try await getInboxIdForAddress(

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -94,13 +94,15 @@ class ClientTests: XCTestCase {
 	}
 	
 	func testCanDeleteDatabase() async throws {
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 		let alix = try PrivateKey.generate()
 		var boClient = try await Client.create(
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 	
@@ -108,7 +110,8 @@ class ClientTests: XCTestCase {
 			account: alix,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 
@@ -124,7 +127,8 @@ class ClientTests: XCTestCase {
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -138,13 +138,15 @@ class ClientTests: XCTestCase {
 	}
 	
 	func testCanDropReconnectDatabase() async throws {
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 		let alix = try PrivateKey.generate()
 		var boClient = try await Client.create(
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 	
@@ -152,7 +154,8 @@ class ClientTests: XCTestCase {
 			account: alix,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 
@@ -344,13 +347,15 @@ class ClientTests: XCTestCase {
 	}
 	
 	func testCanGetAnInboxIdFromAddress() async throws {
+		let key = try Crypto.secureRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 		let alix = try PrivateKey.generate()
 		let boClient = try await Client.create(
 			account: bo,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 	
@@ -358,7 +363,8 @@ class ClientTests: XCTestCase {
 			account: alix,
 			options: .init(
 				api: .init(env: .local, isSecure: false),
-				enableV3: true
+				enableV3: true,
+				encryptionKey: key
 			)
 		)
 		let boInboxId = try await alixClient.inboxIdFromAddress(address: boClient.address)

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.13.5"
+  spec.version      = "0.13.6"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "b19830dc02d03deea89e9fad3b3ed22e102f86f2",
-        "version" : "0.5.4-beta3"
+        "revision" : "c38c7be91f18d2021f66bee9d878ec1dde7b91f5",
+        "version" : "0.5.4-beta4"
       }
     },
     {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "c38c7be91f18d2021f66bee9d878ec1dde7b91f5",
-        "version" : "0.5.4-beta4"
+        "revision" : "b19830dc02d03deea89e9fad3b3ed22e102f86f2",
+        "version" : "0.5.4-beta3"
       }
     },
     {


### PR DESCRIPTION
Require the passing of an encryption key again 

Part of https://github.com/xmtp/xmtp-ios/issues/363
