### PR TITLE
Always set an inbox id for V2

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.13.7"
+  spec.version      = "0.13.8"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
To get React Native working https://github.com/xmtp/xmtp-react-native/pull/440

We need to have the unique identifier of an inboxID set even for V2 clients. This can be done since a v3 client does not need to be created to create an inboxId based on address.