### PR TITLE
Expose dbPath and static inboxId 

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -99,7 +99,7 @@ public final class Client {
 	let apiClient: ApiClient
 	let v3Client: LibXMTP.FfiXmtpClient?
 	public let libXMTPVersion: String = getVersionInfo()
-	let dbPath: String
+	public let dbPath: String
 	public let installationID: String
 	public let inboxID: String
 
@@ -281,7 +281,7 @@ public final class Client {
 		return nil
 	}
 	
-	static func getOrCreateInboxId(options: ClientOptions, address: String) async throws -> String {
+	public static func getOrCreateInboxId(options: ClientOptions, address: String) async throws -> String {
 		var inboxId: String
 		do {
 			inboxId = try await getInboxIdForAddress(

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -121,6 +121,7 @@ class ClientTests: XCTestCase {
 		var groupCount = try await boClient.conversations.groups().count
 		XCTAssertEqual(groupCount, 1)
 
+		assert(!boClient.dbPath.isEmpty)
 		try boClient.deleteLocalDatabase()
 
 		boClient = try await Client.create(
@@ -410,5 +411,24 @@ class ClientTests: XCTestCase {
 		)
 		let boInboxId = try await alixClient.inboxIdFromAddress(address: boClient.address)
 		XCTAssertEqual(boClient.inboxID, boInboxId)
+	}
+	
+	func testCreatesAV3Client() async throws {
+		let key = try Crypto.secureRandomBytes(count: 32)
+		let alix = try PrivateKey.generate()
+		let options = ClientOptions.init(
+			api: .init(env: .local, isSecure: false),
+			   enableV3: true,
+			   encryptionKey: key
+		   )
+
+
+		let inboxId = try await Client.getOrCreateInboxId(options: options, address: alix.address)
+		let alixClient = try await Client.create(
+			account: alix,
+			options: options
+		)
+
+		XCTAssertEqual(inboxId, alixClient.inboxID)
 	}
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.13.13"
+  spec.version      = "0.13.14"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Moves the inboxId creation method to be static and exposes the dbPath.