### PR TITLE
Performance testing

### DIFF
--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -837,4 +837,37 @@ class GroupTests: XCTestCase {
 
 		XCTAssertEqual(preparedMessageId, messages.first!.id)
 	}
+	
+	func createGroups(client: Client, peer: Client, numGroups: Int) async throws {
+		for i in 0..<numGroups {
+			try await client.conversations.newGroup(with: [peer.address])
+		}
+	}
+	
+	func testGroupListPerformance() async throws {
+		let fixtures = try await localFixtures()
+
+		try await createGroups(client: fixtures.aliceClient, peer: fixtures.bobClient, numGroups: 50)
+
+		var start = Date()
+		var groups = try await fixtures.aliceClient.conversations.groups()
+		var end = Date()
+		print("Alix loaded \(groups.count) groups in \(end.timeIntervalSince(start) * 1000)ms")
+
+		start = Date()
+		try await fixtures.aliceClient.conversations.sync()
+		end = Date()
+		print("Alix synced \(groups.count) groups in \(end.timeIntervalSince(start) * 1000)ms")
+
+		start = Date()
+		try await fixtures.bobClient.conversations.sync()
+		end = Date()
+		print("Bo synced \(groups.count) groups in \(end.timeIntervalSince(start) * 1000)ms")
+
+		start = Date()
+		groups = try await fixtures.bobClient.conversations.groups()
+		end = Date()
+		print("Bo loaded \(groups.count) groups in \(end.timeIntervalSince(start) * 1000)ms")
+
+	}
 }


### PR DESCRIPTION
Based off of the test in RN that errors. Here are the logs in iOS

```
Alix loaded 50 groups in 0.4819631576538086ms
Alix synced 50 groups in 2.364039421081543ms
Bo synced 50 groups in 115.60404300689697ms
Bo loaded 50 groups in 0.29098987579345703ms
```

```
2024-08-01 09:30:05.281274-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] [f9f6919bb937946f9f32ff05e891104d7f13da472be3a02e3b4738ec55ed09e4] merging pending commit for intent 50
2024-08-01 09:30:05.281800-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] f9f6919bb937946f9f32ff05e891104d7f13da472be3a02e3b4738ec55ed09e4: Storing a transcript message with 1 members added and 0 members removed and 0 metadata changes
2024-08-01 09:30:05.287881-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
Alix loaded 50 groups in 0.4819631576538086ms
2024-08-01 09:30:05.288378-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
Alix synced 50 groups in 2.364039421081543ms
2024-08-01 09:30:05.290761-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.294627-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.302768-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.305309-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.307281-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.309349-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.311355-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.313516-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.315581-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.317528-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.319639-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.321972-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.323902-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.326039-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.327962-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.330042-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.332123-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.334360-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.336257-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.338242-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.340265-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.342450-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.344452-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.346378-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.348307-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.350230-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.352186-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.354402-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.356320-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.358305-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.360226-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.362258-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.364241-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.366199-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.368157-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.370545-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.372495-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.374717-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.376926-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.379045-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.381262-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.383379-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.385468-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.387571-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.389695-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.391745-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.393931-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.396378-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.398845-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.401444-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
2024-08-01 09:30:05.403821-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
Bo synced 50 groups in 115.60404300689697ms
2024-08-01 09:30:05.406383-0600 xctest[37003:39343841] libxmtp[INFO] - [libxmtp] Pulling connection from pool, idle_connections=10, total_connections=10
Bo loaded 50 groups in 0.29098987579345703ms
```