### PR TITLE
Ignore Empty Key Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.12.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "0.5.7-beta0"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "0.5.7-beta1"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -1,7 +1,7 @@
 import Foundation
 import LibXMTP
 
-public enum ConversationError: Error, CustomStringConvertible {
+public enum ConversationError: Error, CustomStringConvertible, LocalizedError {
 	case recipientNotOnNetwork, recipientIsSender, v1NotSupported(String)
 
 	public var description: String {
@@ -14,9 +14,13 @@ public enum ConversationError: Error, CustomStringConvertible {
 			return "ConversationError.v1NotSupported: V1 does not support: \(str)"
 		}
 	}
+	
+	public var errorDescription: String? {
+		return description
+	}
 }
 
-public enum GroupError: Error, CustomStringConvertible {
+public enum GroupError: Error, CustomStringConvertible, LocalizedError {
 	case alphaMLSNotEnabled, memberCannotBeSelf, memberNotRegistered([String]), groupsRequireMessagePassed, notSupportedByGroups, streamingFailure
 
 	public var description: String {
@@ -34,6 +38,10 @@ public enum GroupError: Error, CustomStringConvertible {
 		case .streamingFailure:
 			return "GroupError.streamingFailure a stream has failed"
 		}
+	}
+	
+	public var errorDescription: String? {
+		return description
 	}
 }
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.14.1"
+  spec.version      = "0.14.2"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.12.0"
-  spec.dependency 'LibXMTP', '= 0.5.7-beta0'
+  spec.dependency 'LibXMTP', '= 0.5.7-beta1'
 end

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "65e9a6eed3db394c1afad7d895b89a0c1cae914b",
-        "version" : "0.5.7-beta0"
+        "revision" : "c7cec01e9065812c1b604edd85ff72492bfd51b7",
+        "version" : "0.5.7-beta1"
       }
     },
     {


### PR DESCRIPTION
If a installation has an empty key package just ignore it and don't error