### PR TITLE
Bump to latest versions of libxmtp 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
 		.package(url: "https://github.com/1024jp/GzipSwift", from: "5.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "0.12.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "0.5.8-beta1"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "0.5.8-beta3"),
 	],
 	targets: [
 		// Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.14.9"
+  spec.version      = "0.14.10"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.
@@ -44,5 +44,5 @@ Pod::Spec.new do |spec|
   spec.dependency "web3.swift"
   spec.dependency "GzipSwift"
   spec.dependency "Connect-Swift", "= 0.12.0"
-  spec.dependency 'LibXMTP', '= 0.5.8-beta1'
+  spec.dependency 'LibXMTP', '= 0.5.8-beta3'
 end

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "5ff057ed6ab42ba8cdc9cb9c107dddfc5fb4746b",
-        "version" : "0.5.8-beta0"
+        "revision" : "06e890646a32c3ae9b9ac78150a7ec4971e54c9d",
+        "version" : "0.5.8-beta3"
       }
     },
     {


### PR DESCRIPTION
## What's Changed
* Stop setting new lifetimes by @neekolas in https://github.com/xmtp/libxmtp/pull/964
* Add libxmtp version to requests by @neekolas in https://github.com/xmtp/libxmtp/pull/1011
* Store or ignore group messages by @neekolas in https://github.com/xmtp/libxmtp/pull/1019
* Fix send update interval ns calculation, move to configuration by @cameronvoell in https://github.com/xmtp/libxmtp/pull/1008
* Create group with initial members by @neekolas in https://github.com/xmtp/libxmtp/pull/1020
* Retry PoolNeedsConnection Errors by @nplasterer in https://github.com/xmtp/libxmtp/pull/1010
* Skip duplicate message processing by @neekolas https://github.com/xmtp/libxmtp/pull/1022
