### PR TITLE
Fixing group streams

### DIFF
--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -225,7 +225,7 @@ class GroupTests: XCTestCase {
 
 		try await group.sync()
 		let members = try await group.members.map(\.inboxId).sorted()
-		let peerMembers = try Conversation.group(group).peerAddresses.sorted()
+		let peerMembers = try await group.peerInboxIds.sorted()
 
 		XCTAssertEqual([fixtures.bobClient.inboxID, fixtures.aliceClient.inboxID].sorted(), members)
 		XCTAssertEqual([fixtures.bobClient.inboxID].sorted(), peerMembers)

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.14.17"
+  spec.version      = "0.14.18"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
## Introduction 📟
Sometimes groups were not getting streamed well in the RN SDK, especially when streaming messages at the same time

## Purpose ℹ️ 
Make group streaming still work even if streaming all messages at the same time

## Scope 🔭
We were using a single `StreamHolder` so when cancelling a `Task` if something was streamed we were detecting it (with for instance `Task.isCancelled` and calling `self.streamHolder.stream?.end()` on a stream which might not be the one we thought! Using an actor inside each streaming method to save & end the stream fixes it.

## Testing 🧪

I never managed to do a reproducible test directly in Swift. However I do have a failing test in the React Native repo: `can stream groups and messages` is failing on iOS on my side, but if I bring these Swift changes inside the XMTP Pod, it passes.

See https://github.com/xmtp/xmtp-react-native/pull/503