### PR TITLE
Dual Send 1to1 Conversations in V3

### DIFF
--- a/Sources/XMTPiOS/ConversationV2.swift
+++ b/Sources/XMTPiOS/ConversationV2.swift
@@ -262,7 +262,7 @@ public struct ConversationV2 {
 					try await dm.send(encodedContent: encodedContent)
 				}
 			} catch {
-				print("ConversationV1 send \(error)")
+				print("ConversationV2 send \(error)")
 			}
 		}
         try await client.publish(envelopes: prepared.envelopes)

--- a/Sources/XMTPiOS/ConversationV2.swift
+++ b/Sources/XMTPiOS/ConversationV2.swift
@@ -96,7 +96,7 @@ public struct ConversationV2 {
 		let topic = options?.ephemeral == true ? ephemeralTopic : topic
 
 		let envelope = Envelope(topic: topic, timestamp: Date(), message: try Message(v2: message).serializedData())
-		return PreparedMessage(envelopes: [envelope])
+		return PreparedMessage(envelopes: [envelope], encodedContent: encodedContent)
 	}
 
 	func prepareMessage<T>(content: T, options: SendOptions?) async throws -> PreparedMessage {
@@ -255,6 +255,16 @@ public struct ConversationV2 {
 	}
 
     @discardableResult func send(prepared: PreparedMessage) async throws -> String {
+		if (client.v3Client != nil) {
+			do {
+				let dm = try await client.conversations.findOrCreateDm(with: peerAddress)
+				if let encodedContent = prepared.encodedContent {
+					try await dm.send(encodedContent: encodedContent)
+				}
+			} catch {
+				print("ConversationV1 send \(error)")
+			}
+		}
         try await client.publish(envelopes: prepared.envelopes)
         if((try await client.contacts.consentList.state(address: peerAddress)) == .unknown) {
             try await client.contacts.allow(addresses: [peerAddress])

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -816,7 +816,7 @@ public actor Conversations {
 		Task {
 			await self.addConversation(conversation)
 		}
-		if (client.v3Client != nil) {
+		if client.v3Client != nil {
 			do {
 				try await client.conversations.findOrCreateDm(with: peerAddress)
 			} catch {

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -183,11 +183,6 @@ public actor Conversations {
 	public func dms(
 		createdAfter: Date? = nil, createdBefore: Date? = nil, limit: Int? = nil
 	) async throws -> [Dm] {
-		if client.hasV2Client {
-			throw ConversationError.v2NotSupported(
-				"Only supported with V3 only clients use newConversation instead"
-			)
-		}
 		guard let v3Client = client.v3Client else {
 			return []
 		}
@@ -214,11 +209,6 @@ public actor Conversations {
 		limit: Int? = nil, order: ConversationOrder = .createdAt,
 		consentState: ConsentState? = nil
 	) async throws -> [Conversation] {
-		if client.hasV2Client {
-			throw ConversationError.v2NotSupported(
-				"Only supported with V3 only clients use list instead")
-		}
-		// Todo: add ability to order and consent state
 		guard let v3Client = client.v3Client else {
 			return []
 		}
@@ -350,13 +340,6 @@ public actor Conversations {
 		Conversation, Error
 	> {
 		AsyncThrowingStream { continuation in
-			if client.hasV2Client {
-				continuation.finish(
-					throwing: ConversationError.v2NotSupported(
-						"Only supported with V3 only clients use stream instead"
-					))
-				return
-			}
 			let ffiStreamActor = FfiStreamActor()
 			let task = Task {
 				let stream = await self.client.v3Client?.conversations().stream(
@@ -405,12 +388,6 @@ public actor Conversations {
 	}
 
 	public func findOrCreateDm(with peerAddress: String) async throws -> Dm {
-		if client.hasV2Client {
-			throw ConversationError.v2NotSupported(
-				"Only supported with V3 only clients use newConversation instead"
-			)
-		}
-
 		guard let v3Client = client.v3Client else {
 			throw GroupError.alphaMLSNotEnabled
 		}
@@ -537,13 +514,6 @@ public actor Conversations {
 		DecodedMessage, Error
 	> {
 		AsyncThrowingStream { continuation in
-			if client.hasV2Client {
-				continuation.finish(
-					throwing: ConversationError.v2NotSupported(
-						"Only supported with V3 clients. Use streamAllMessages instead."
-					))
-				return
-			}
 			let ffiStreamActor = FfiStreamActor()
 			let task = Task {
 				let stream = await self.client.v3Client?.conversations()
@@ -583,13 +553,6 @@ public actor Conversations {
 		DecryptedMessage, Error
 	> {
 		AsyncThrowingStream { continuation in
-			if client.hasV2Client {
-				continuation.finish(
-					throwing: ConversationError.v2NotSupported(
-						"Only supported with V3 clients. Use streamAllMessages instead."
-					))
-				return
-			}
 			let ffiStreamActor = FfiStreamActor()
 			let task = Task {
 				let stream = await self.client.v3Client?.conversations()
@@ -852,6 +815,13 @@ public actor Conversations {
 		let conversation: Conversation = .v2(conversationV2)
 		Task {
 			await self.addConversation(conversation)
+		}
+		if (client.v3Client != nil) {
+			do {
+				try await client.conversations.findOrCreateDm(with: peerAddress)
+			} catch {
+				print("newConversation \(error)")
+			}
 		}
 		return conversation
 	}

--- a/Sources/XMTPiOS/PreparedMessage.swift
+++ b/Sources/XMTPiOS/PreparedMessage.swift
@@ -13,11 +13,12 @@ public struct PreparedMessage {
     // Any more are for required intros/invites etc.
     // A client can just publish these when it has connectivity.
     public let envelopes: [Envelope]
+	public let encodedContent: EncodedContent?
 
     // Note: we serialize as a PublishRequest as a convenient `envelopes` wrapper.
     public static func fromSerializedData(_ serializedData: Data) throws -> PreparedMessage {
         let req = try Xmtp_MessageApi_V1_PublishRequest(serializedData: serializedData)
-        return PreparedMessage(envelopes: req.envelopes)
+		return PreparedMessage(envelopes: req.envelopes, encodedContent: nil)
     }
 
     // Note: we serialize as a PublishRequest as a convenient `envelopes` wrapper.

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "XMTP"
-  spec.version      = "0.16.1"
+  spec.version      = "0.16.2"
   spec.summary      = "XMTP SDK Cocoapod"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This PR has evolved a lot and I've ended on the simplest function to get a V2/V3 client pre creating conversations and dual sending messages.

This does not do any listing of V2 and V3 conversations in the same list which is where a lot of the complication arises with handling dual sent messages and requires a V2 database in libxmtp.
