### PR TITLE
Try to add sql cipher directly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,10 @@ let package = Package(
 		.package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.5"),
-		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3")
+		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
+		.package(url: "https://github.com/sqlcipher/sqlcipher", exact: "4.5.7"),
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.5")
+
 	],
 	targets: [
 		.target(
@@ -30,7 +32,8 @@ let package = Package(
 				.product(name: "CSecp256k1", package: "CSecp256k1.swift"),
 				.product(name: "Connect", package: "connect-swift"),
 				.product(name: "LibXMTP", package: "libxmtp-swift"),
-				.product(name: "CryptoSwift", package: "CryptoSwift")
+				.product(name: "CryptoSwift", package: "CryptoSwift"),
+				.product(name: "SQLCipher", package: "sqlcipher") 
 			]
 		),
 		.target(

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |spec|
   spec.dependency "Connect-Swift", "= 1.0.0"
   spec.dependency 'LibXMTP', '= 3.0.5'
   spec.dependency 'CryptoSwift', '= 1.8.3'
+  spec.dependency 'SQLCipher', '= 4.5.7'
   
   spec.ios.deployment_target = '14.0'
 end


### PR DESCRIPTION
Integrators are hitting `LibXMTP.GenericError.Storage(message: "Storage error: Cipher salt doesn\'t exist in database not found")` It appears that often the cipher library is not linked correctly from rust so link it explicitly here.
