### PR TITLE
Fix send encoded content in Conversation class

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,21 +19,21 @@
       }
     },
     {
+      "identity" : "csecp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tesseract-one/CSecp256k1.swift.git",
+      "state" : {
+        "revision" : "cfbd6f540d5084bc96a60af841121472fbe725a3",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "libxmtp-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "f495d4feaab40a0a6a48c1d5a99585de8107f5d2",
-        "version" : "3.0.1"
-      }
-    },
-    {
-      "identity" : "secp256k1.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Boilertalk/secp256k1.swift.git",
-      "state" : {
-        "revision" : "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
-        "version" : "0.1.7"
+        "revision" : "bab83b5de3ed4713d50535e61bca281179bf04fd",
+        "version" : "3.0.10"
       }
     },
     {

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -132,14 +132,13 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 	}
 
 	@discardableResult public func send(
-		encodedContent: EncodedContent, options: SendOptions? = nil
-	) async throws -> String {
+		encodedContent: EncodedContent) async throws -> String {
 		switch self {
 		case let .group(group):
 			return try await group.send(
-				content: encodedContent, options: options)
+                encodedContent: encodedContent)
 		case let .dm(dm):
-			return try await dm.send(content: encodedContent, options: options)
+            return try await dm.send(encodedContent: encodedContent)
 		}
 	}
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "3.0.14"
+  spec.version      = "3.0.15"
   spec.summary      = "XMTP SDK Cocoapod"
 
   spec.description  = <<-DESC


### PR DESCRIPTION
This change unblocks custom content types in V3. 

Related to https://github.com/xmtp/xmtp-react-native/pull/559