### PR TITLE
Remove client from serializable objects

### DIFF
--- a/Sources/XMTPiOS/Codecs/AttachmentCodec.swift
+++ b/Sources/XMTPiOS/Codecs/AttachmentCodec.swift
@@ -31,7 +31,7 @@ public struct AttachmentCodec: ContentCodec {
 
 	public var contentType = ContentTypeAttachment
 
-	public func encode(content: Attachment, client _: Client) throws -> EncodedContent {
+	public func encode(content: Attachment) throws -> EncodedContent {
 		var encodedContent = EncodedContent()
 
 		encodedContent.type = ContentTypeAttachment
@@ -44,7 +44,7 @@ public struct AttachmentCodec: ContentCodec {
 		return encodedContent
 	}
 
-	public func decode(content: EncodedContent, client _: Client) throws -> Attachment {
+	public func decode(content: EncodedContent) throws -> Attachment {
 		guard let mimeType = content.parameters["mimeType"],
 		      let filename = content.parameters["filename"]
 		else {

--- a/Sources/XMTPiOS/Codecs/ContentCodec.swift
+++ b/Sources/XMTPiOS/Codecs/ContentCodec.swift
@@ -14,8 +14,8 @@ enum CodecError: String, Error {
 public typealias EncodedContent = Xmtp_MessageContents_EncodedContent
 
 extension EncodedContent {
-	public func decoded<T>(with client: Client) throws -> T {
-		let codec = client.codecRegistry.find(for: type)
+	public func decoded<T>() throws -> T {
+		let codec = Client.codecRegistry.find(for: type)
 
 		var encodedContent = self
 
@@ -23,7 +23,7 @@ extension EncodedContent {
 			encodedContent = try decompressContent()
 		}
 
-		if let content = try codec.decode(content: encodedContent, client: client) as? T {
+		if let content = try codec.decode(content: encodedContent) as? T {
 			return content
 		}
 
@@ -82,8 +82,8 @@ public protocol ContentCodec: Hashable, Equatable {
 	associatedtype T
 
 	var contentType: ContentTypeID { get }
-	func encode(content: T, client: Client) throws -> EncodedContent
-	func decode(content: EncodedContent, client: Client) throws -> T
+	func encode(content: T) throws -> EncodedContent
+	func decode(content: EncodedContent) throws -> T
 	func fallback(content: T) throws -> String?
 	func shouldPush(content: T) throws -> Bool
 }

--- a/Sources/XMTPiOS/Codecs/GroupUpdatedCodec.swift
+++ b/Sources/XMTPiOS/Codecs/GroupUpdatedCodec.swift
@@ -19,7 +19,7 @@ public struct GroupUpdatedCodec: ContentCodec {
 
 	public var contentType = ContentTypeGroupUpdated
 
-	public func encode(content: GroupUpdated, client _: Client) throws -> EncodedContent {
+	public func encode(content: GroupUpdated) throws -> EncodedContent {
 		var encodedContent = EncodedContent()
 
 		encodedContent.type = ContentTypeGroupUpdated
@@ -28,7 +28,7 @@ public struct GroupUpdatedCodec: ContentCodec {
 		return encodedContent
 	}
 
-	public func decode(content: EncodedContent, client _: Client) throws -> GroupUpdated {
+	public func decode(content: EncodedContent) throws -> GroupUpdated {
 		return try GroupUpdated(serializedData: content.content)
 	}
 

--- a/Sources/XMTPiOS/Codecs/ReactionCodec.swift
+++ b/Sources/XMTPiOS/Codecs/ReactionCodec.swift
@@ -61,7 +61,7 @@ public struct ReactionCodec: ContentCodec {
 
     public init() {}
 
-    public func encode(content: Reaction, client _: Client) throws -> EncodedContent {
+    public func encode(content: Reaction) throws -> EncodedContent {
         var encodedContent = EncodedContent()
 
         encodedContent.type = ContentTypeReaction
@@ -70,7 +70,7 @@ public struct ReactionCodec: ContentCodec {
         return encodedContent
     }
 
-    public func decode(content: EncodedContent, client _: Client) throws -> Reaction {
+    public func decode(content: EncodedContent) throws -> Reaction {
         // First try to decode it in the canonical form.
         // swiftlint:disable no_optional_try
         if let reaction = try? JSONDecoder().decode(Reaction.self, from: content.content) {

--- a/Sources/XMTPiOS/Codecs/ReadReceiptCodec.swift
+++ b/Sources/XMTPiOS/Codecs/ReadReceiptCodec.swift
@@ -20,7 +20,7 @@ public struct ReadReceiptCodec: ContentCodec {
 
     public var contentType = ContentTypeReadReceipt
 
-    public func encode(content: ReadReceipt, client _: Client) throws -> EncodedContent {
+    public func encode(content: ReadReceipt) throws -> EncodedContent {
         var encodedContent = EncodedContent()
 
         encodedContent.type = ContentTypeReadReceipt
@@ -29,7 +29,7 @@ public struct ReadReceiptCodec: ContentCodec {
         return encodedContent
     }
 
-    public func decode(content: EncodedContent, client _: Client) throws -> ReadReceipt {
+    public func decode(content: EncodedContent) throws -> ReadReceipt {
         return ReadReceipt()
     }
 

--- a/Sources/XMTPiOS/Codecs/RemoteAttachmentCodec.swift
+++ b/Sources/XMTPiOS/Codecs/RemoteAttachmentCodec.swift
@@ -88,9 +88,9 @@ public struct RemoteAttachment {
 		}
 	}
 
-	public static func encodeEncrypted<Codec: ContentCodec, T>(content: T, codec: Codec, with client: Client) throws -> EncryptedEncodedContent where Codec.T == T {
+	public static func encodeEncrypted<Codec: ContentCodec, T>(content: T, codec: Codec) throws -> EncryptedEncodedContent where Codec.T == T {
 		let secret = try Crypto.secureRandomBytes(count: 32)
-		let encodedContent = try codec.encode(content: content, client: client).serializedData()
+		let encodedContent = try codec.encode(content: content).serializedData()
 		let ciphertext = try Crypto.encrypt(secret, encodedContent)
 		let contentDigest = sha256(data: ciphertext.aes256GcmHkdfSha256.payload)
 
@@ -149,7 +149,7 @@ public struct RemoteAttachmentCodec: ContentCodec {
 
 	public var contentType = ContentTypeRemoteAttachment
 
-	public func encode(content: RemoteAttachment, client _: Client) throws -> EncodedContent {
+	public func encode(content: RemoteAttachment) throws -> EncodedContent {
 		var encodedContent = EncodedContent()
 
 		encodedContent.type = ContentTypeRemoteAttachment
@@ -167,7 +167,7 @@ public struct RemoteAttachmentCodec: ContentCodec {
 		return encodedContent
 	}
 
-	public func decode(content: EncodedContent, client _: Client) throws -> RemoteAttachment {
+	public func decode(content: EncodedContent) throws -> RemoteAttachment {
 		guard let url = String(data: content.content, encoding: .utf8) else {
 			throw RemoteAttachmentError.invalidURL
 		}

--- a/Sources/XMTPiOS/Codecs/ReplyCodec.swift
+++ b/Sources/XMTPiOS/Codecs/ReplyCodec.swift
@@ -26,27 +26,27 @@ public struct ReplyCodec: ContentCodec {
 
 	public init() {}
 
-	public func encode(content reply: Reply, client: Client) throws -> EncodedContent {
+	public func encode(content reply: Reply) throws -> EncodedContent {
 		var encodedContent = EncodedContent()
-		let replyCodec = client.codecRegistry.find(for: reply.contentType)
+		let replyCodec = Client.codecRegistry.find(for: reply.contentType)
 
 		encodedContent.type = contentType
 		// TODO: cut when we're certain no one is looking for "contentType" here.
 		encodedContent.parameters["contentType"] = reply.contentType.description
 		encodedContent.parameters["reference"] = reply.reference
-		encodedContent.content = try encodeReply(codec: replyCodec, content: reply.content, client: client).serializedData()
+		encodedContent.content = try encodeReply(codec: replyCodec, content: reply.content).serializedData()
 
 		return encodedContent
 	}
 
-	public func decode(content: EncodedContent, client: Client) throws -> Reply {
+	public func decode(content: EncodedContent) throws -> Reply {
 		guard let reference = content.parameters["reference"] else {
 			throw CodecError.invalidContent
 		}
 
 		let replyEncodedContent = try EncodedContent(serializedData: content.content)
-		let replyCodec = client.codecRegistry.find(for: replyEncodedContent.type)
-		let replyContent = try replyCodec.decode(content: replyEncodedContent, client: client)
+		let replyCodec = Client.codecRegistry.find(for: replyEncodedContent.type)
+		let replyContent = try replyCodec.decode(content: replyEncodedContent)
 
 		return Reply(
 			reference: reference,
@@ -55,9 +55,9 @@ public struct ReplyCodec: ContentCodec {
 		)
 	}
 
-	func encodeReply<Codec: ContentCodec>(codec: Codec, content: Any, client: Client) throws -> EncodedContent {
+	func encodeReply<Codec: ContentCodec>(codec: Codec, content: Any) throws -> EncodedContent {
 		if let content = content as? Codec.T {
-			return try codec.encode(content: content, client: client)
+			return try codec.encode(content: content)
 		} else {
 			throw CodecError.invalidContent
 		}

--- a/Sources/XMTPiOS/Codecs/TextCodec.swift
+++ b/Sources/XMTPiOS/Codecs/TextCodec.swift
@@ -21,7 +21,7 @@ public struct TextCodec: ContentCodec {
 
 	public var contentType = ContentTypeText
 
-	public func encode(content: String, client _: Client) throws -> EncodedContent {
+	public func encode(content: String) throws -> EncodedContent {
 		var encodedContent = EncodedContent()
 
 		encodedContent.type = ContentTypeText
@@ -31,7 +31,7 @@ public struct TextCodec: ContentCodec {
 		return encodedContent
 	}
 
-	public func decode(content: EncodedContent, client _: Client) throws -> String {
+	public func decode(content: EncodedContent) throws -> String {
 		if let encoding = content.parameters["encoding"], encoding != "UTF-8" {
 			throw TextCodecError.invalidEncoding
 		}

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -175,10 +175,6 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public var clientAddress: String {
-		return client.address
-	}
-
 	public var topic: String {
 		switch self {
 		case let .group(group):
@@ -215,15 +211,6 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus
 			)
-		}
-	}
-
-	var client: Client {
-		switch self {
-		case let .group(group):
-			return group.client
-		case let .dm(dm):
-			return dm.client
 		}
 	}
 }

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -334,7 +334,7 @@ public actor Conversations {
 		AsyncThrowingStream { continuation in
 			let ffiStreamActor = FfiStreamActor()
 
-			let messageCallback = MessageCallback(client: self.client) {
+			let messageCallback = MessageCallback() {
 				message in
 				guard !Task.isCancelled else {
 					continuation.finish()
@@ -343,8 +343,7 @@ public actor Conversations {
 					}
 					return
 				}
-				if let message = Message.create(
-					client: self.client, ffiMessage: message)
+				if let message = Message.create(ffiMessage: message)
 				{
 					continuation.yield(message)
 				}

--- a/Sources/XMTPiOS/Extensions/Ffi.swift
+++ b/Sources/XMTPiOS/Extensions/Ffi.swift
@@ -3,11 +3,11 @@ import LibXMTP
 
 extension FfiConversation {
 	func groupFromFFI(client: Client) -> Group {
-		Group(ffiGroup: self, client: client)
+		Group(ffiGroup: self, clientInboxId: client.inboxID)
 	}
 
 	func dmFromFFI(client: Client) -> Dm {
-		Dm(ffiConversation: self, client: client)
+		Dm(ffiConversation: self, clientInboxId: client.inboxID)
 	}
 
 	func toConversation(client: Client) async throws -> Conversation {
@@ -23,13 +23,13 @@ extension FfiConversationListItem {
 	func groupFromFFI(client: Client) -> Group {
 		Group(
 			ffiGroup: self.conversation(), ffiLastMessage: self.lastMessage(),
-			client: client)
+			clientInboxId: client.inboxID)
 	}
 
 	func dmFromFFI(client: Client) -> Dm {
 		Dm(
 			ffiConversation: self.conversation(),
-			ffiLastMessage: self.lastMessage(), client: client)
+			ffiLastMessage: self.lastMessage(), clientInboxId: client.inboxID)
 	}
 
 	func toConversation(client: Client) async throws -> Conversation {

--- a/Sources/XMTPiOS/Libxmtp/Message.swift
+++ b/Sources/XMTPiOS/Libxmtp/Message.swift
@@ -89,7 +89,7 @@ public struct Message: Identifiable {
 		}
 	}
 
-	public static func create(client: Client, ffiMessage: FfiMessage)
+	public static func create(ffiMessage: FfiMessage)
 		-> Message?
 	{
 		do {
@@ -102,7 +102,7 @@ public struct Message: Identifiable {
 					"Error decoding group membership change")
 			}
 			// Decode the content once during creation
-			let decodedContent: Any = try encodedContent.decoded(with: client)
+			let decodedContent: Any = try encodedContent.decoded()
 			return Message(
 				ffiMessage: ffiMessage, decodedContent: decodedContent)
 		} catch {

--- a/Tests/XMTPTests/AttachmentTests.swift
+++ b/Tests/XMTPTests/AttachmentTests.swift
@@ -15,7 +15,7 @@ class AttachmentsTests: XCTestCase {
 		let conversation = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)
 
-		fixtures.alixClient.register(codec: AttachmentCodec())
+		Client.register(codec: AttachmentCodec())
 
 		try await conversation.send(
 			content: Attachment(

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -19,7 +19,7 @@ struct NumberCodec: ContentCodec {
 			versionMinor: 1)
 	}
 
-	func encode(content: Double, client _: Client) throws
+	func encode(content: Double) throws
 		-> XMTPiOS.EncodedContent
 	{
 		var encodedContent = EncodedContent()
@@ -32,7 +32,7 @@ struct NumberCodec: ContentCodec {
 		return encodedContent
 	}
 
-	func decode(content: XMTPiOS.EncodedContent, client _: Client) throws
+	func decode(content: XMTPiOS.EncodedContent) throws
 		-> Double
 	{
 		return try JSONDecoder().decode(Double.self, from: content.content)
@@ -48,7 +48,7 @@ class CodecTests: XCTestCase {
 		let alixConversation = try await alixClient.conversations
 			.newConversation(with: fixtures.bo.address)
 
-		alixClient.register(codec: NumberCodec())
+		Client.register(codec: NumberCodec())
 
 		try await alixConversation.send(
 			content: 3.14,
@@ -70,14 +70,14 @@ class CodecTests: XCTestCase {
 		let alixConversation = try await alixClient.conversations
 			.newConversation(with: fixtures.bo.address)
 
-		alixClient.register(codec: NumberCodec())
+		Client.register(codec: NumberCodec())
 
 		try await alixConversation.send(
 			content: 3.14,
 			options: .init(contentType: NumberCodec().contentType))
 
 		// Remove number codec from registry
-		alixClient.codecRegistry.codecs.removeValue(forKey: NumberCodec().id)
+		Client.codecRegistry.codecs.removeValue(forKey: NumberCodec().id)
 
 		let messages = try await alixConversation.messages()
 		XCTAssertEqual(messages.count, 1)

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -246,7 +246,7 @@ class GroupTests: XCTestCase {
 
 	func testCanAddGroupMembers() async throws {
 		let fixtures = try await fixtures()
-		fixtures.alixClient.register(codec: GroupUpdatedCodec())
+		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
 			with: [fixtures.bo.address])
 
@@ -271,7 +271,7 @@ class GroupTests: XCTestCase {
 
 	func testCanAddGroupMembersByInboxId() async throws {
 		let fixtures = try await fixtures()
-		fixtures.alixClient.register(codec: GroupUpdatedCodec())
+		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
 			with: [fixtures.bo.address])
 
@@ -298,7 +298,7 @@ class GroupTests: XCTestCase {
 
 	func testCanRemoveMembers() async throws {
 		let fixtures = try await fixtures()
-		fixtures.alixClient.register(codec: GroupUpdatedCodec())
+		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
 			with: [fixtures.bo.address, fixtures.caro.address])
 
@@ -332,7 +332,7 @@ class GroupTests: XCTestCase {
 
 	func testCanRemoveMembersByInboxId() async throws {
 		let fixtures = try await fixtures()
-		fixtures.alixClient.register(codec: GroupUpdatedCodec())
+		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
 			with: [fixtures.bo.address, fixtures.caro.address])
 
@@ -501,8 +501,7 @@ class GroupTests: XCTestCase {
 
 	func testCanSendMessagesToGroup() async throws {
 		let fixtures = try await fixtures()
-		fixtures.boClient.register(codec: GroupUpdatedCodec())
-		fixtures.alixClient.register(codec: GroupUpdatedCodec())
+		Client.register(codec: GroupUpdatedCodec())
 		let alixGroup = try await fixtures.alixClient.conversations.newGroup(
 			with: [fixtures.bo.address])
 		let membershipChange = GroupUpdated()
@@ -580,7 +579,7 @@ class GroupTests: XCTestCase {
 
 	func testCanStreamGroupMessages() async throws {
 		let fixtures = try await fixtures()
-		fixtures.boClient.register(codec: GroupUpdatedCodec())
+		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
 			fixtures.alix.address
 		])

--- a/Tests/XMTPTests/ReactionTests.swift
+++ b/Tests/XMTPTests/ReactionTests.swift
@@ -37,9 +37,9 @@ class ReactionTests: XCTestCase {
 
 		let fixtures = try await fixtures()
 		let canonical = try codec.decode(
-			content: canonicalEncoded, client: fixtures.alixClient)
+			content: canonicalEncoded)
 		let legacy = try codec.decode(
-			content: legacyEncoded, client: fixtures.alixClient)
+			content: legacyEncoded)
 
 		XCTAssertEqual(ReactionAction.added, canonical.action)
 		XCTAssertEqual(ReactionAction.added, legacy.action)
@@ -56,7 +56,7 @@ class ReactionTests: XCTestCase {
 		let conversation = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)
 
-		fixtures.alixClient.register(codec: ReactionCodec())
+		Client.register(codec: ReactionCodec())
 
 		_ = try await conversation.send(text: "hey alix 2 bo")
 
@@ -116,9 +116,9 @@ class ReactionTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let canonical = try codec.decode(
-			content: canonicalEncoded, client: fixtures.alixClient)
+			content: canonicalEncoded)
 		let legacy = try codec.decode(
-			content: legacyEncoded, client: fixtures.alixClient)
+			content: legacyEncoded)
 
 		XCTAssertEqual(ReactionAction.unknown, canonical.action)
 		XCTAssertEqual(ReactionAction.unknown, legacy.action)

--- a/Tests/XMTPTests/ReadReceiptTests.swift
+++ b/Tests/XMTPTests/ReadReceiptTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class ReadReceiptTests: XCTestCase {
 	func testCanUseReadReceiptCodec() async throws {
 		let fixtures = try await fixtures()
-		fixtures.alixClient.register(codec: ReadReceiptCodec())
+		Client.register(codec: ReadReceiptCodec())
 
 		let conversation = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)

--- a/Tests/XMTPTests/RemoteAttachmentTest.swift
+++ b/Tests/XMTPTests/RemoteAttachmentTest.swift
@@ -34,13 +34,13 @@ class RemoteAttachmentTests: XCTestCase {
 	func testBasic() async throws {
 		let fixtures = try await fixtures()
 
-		fixtures.alixClient.register(codec: AttachmentCodec())
-		fixtures.alixClient.register(codec: RemoteAttachmentCodec())
+		Client.register(codec: AttachmentCodec())
+		Client.register(codec: RemoteAttachmentCodec())
 
 		let conversation = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)
 		let enecryptedEncodedContent = try RemoteAttachment.encodeEncrypted(
-			content: "Hello", codec: TextCodec(), with: fixtures.alixClient)
+			content: "Hello", codec: TextCodec())
 		var remoteAttachmentContent = try RemoteAttachment(
 			url: "https://example.com",
 			encryptedEncodedContent: enecryptedEncodedContent)
@@ -57,14 +57,13 @@ class RemoteAttachmentTests: XCTestCase {
 		let conversation = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)
 
-		fixtures.alixClient.register(codec: AttachmentCodec())
-		fixtures.alixClient.register(codec: RemoteAttachmentCodec())
+		Client.register(codec: AttachmentCodec())
+		Client.register(codec: RemoteAttachmentCodec())
 
 		let encryptedEncodedContent = try RemoteAttachment.encodeEncrypted(
 			content: Attachment(
 				filename: "icon.png", mimeType: "image/png", data: iconData),
-			codec: AttachmentCodec(),
-			with: fixtures.alixClient
+			codec: AttachmentCodec()
 		)
 
 		let tempFileURL = URL.temporaryDirectory.appendingPathComponent(
@@ -100,8 +99,7 @@ class RemoteAttachmentTests: XCTestCase {
 
 		let encodedContent: EncodedContent =
 			try await remoteAttachment.content()
-		let attachment: Attachment = try encodedContent.decoded(
-			with: fixtures.alixClient)
+		let attachment: Attachment = try encodedContent.decoded()
 
 		XCTAssertEqual("icon.png", attachment.filename)
 		XCTAssertEqual("image/png", attachment.mimeType)
@@ -114,14 +112,13 @@ class RemoteAttachmentTests: XCTestCase {
 		_ = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)
 
-		fixtures.alixClient.register(codec: AttachmentCodec())
-		fixtures.alixClient.register(codec: RemoteAttachmentCodec())
+		Client.register(codec: AttachmentCodec())
+		Client.register(codec: RemoteAttachmentCodec())
 
 		let encryptedEncodedContent = try RemoteAttachment.encodeEncrypted(
 			content: Attachment(
 				filename: "icon.png", mimeType: "image/png", data: iconData),
-			codec: AttachmentCodec(),
-			with: fixtures.alixClient
+			codec: AttachmentCodec()
 		)
 
 		let tempFileURL = URL.temporaryDirectory.appendingPathComponent(
@@ -150,8 +147,7 @@ class RemoteAttachmentTests: XCTestCase {
 		let encryptedEncodedContent = try RemoteAttachment.encodeEncrypted(
 			content: Attachment(
 				filename: "icon.png", mimeType: "image/png", data: iconData),
-			codec: AttachmentCodec(),
-			with: fixtures.alixClient
+			codec: AttachmentCodec()
 		)
 
 		let tempFileURL = URL.temporaryDirectory.appendingPathComponent(

--- a/Tests/XMTPTests/ReplyTests.swift
+++ b/Tests/XMTPTests/ReplyTests.swift
@@ -10,7 +10,7 @@ class ReplyTests: XCTestCase {
 		let conversation = try await fixtures.alixClient.conversations
 			.newConversation(with: fixtures.boClient.address)
 
-		fixtures.alixClient.register(codec: ReplyCodec())
+		Client.register(codec: ReplyCodec())
 
 		_ = try await conversation.send(text: "hey alix 2 bo")
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "3.0.22"
+  spec.version      = "3.0.23"
 
   spec.summary      = "XMTP SDK Cocoapod"
 

--- a/XMTPiOSExample/XMTPiOSExample/Views/ConversationDetailView.swift
+++ b/XMTPiOSExample/XMTPiOSExample/Views/ConversationDetailView.swift
@@ -12,7 +12,7 @@ struct ConversationDetailView: View {
 	var client: Client
 	var conversation: Conversation
 
-	@State private var messages: [DecodedMessage] = []
+	@State private var messages: [Message] = []
 
 	var body: some View {
 		VStack {

--- a/XMTPiOSExample/XMTPiOSExample/Views/GroupDetailView.swift
+++ b/XMTPiOSExample/XMTPiOSExample/Views/GroupDetailView.swift
@@ -12,7 +12,7 @@ struct GroupDetailView: View {
 	var client: Client
 	var group: XMTPiOS.Group
 
-	@State private var messages: [DecodedMessage] = []
+	@State private var messages: [Message] = []
 	@State private var isShowingSettings = false
 
 	var body: some View {

--- a/XMTPiOSExample/XMTPiOSExample/Views/MessageListView.swift
+++ b/XMTPiOSExample/XMTPiOSExample/Views/MessageListView.swift
@@ -10,7 +10,7 @@ import XMTPiOS
 
 struct MessageListView: View {
 	var myAddress: String
-	var messages: [DecodedMessage]
+	var messages: [Message]
 	var isGroup: Bool = false
 
 	var body: some View {
@@ -22,7 +22,7 @@ struct MessageListView: View {
 				}
 
 				VStack {
-					ForEach(Array(messages.sorted(by: { $0.sent < $1.sent }).enumerated()), id: \.0) { i, message in
+					ForEach(Array(messages.sorted(by: { $0.sentAt < $1.sentAt }).enumerated()), id: \.0) { i, message in
 						MessageCellView(myAddress: myAddress, message: message, isGroup: isGroup)
 							.transition(.scale)
 							.id(i)


### PR DESCRIPTION
It would be nicer if Conversations did not require a client so that they could be better serialized in apps.
