### PR TITLE
Remove pinned frame url

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "c9d3bdff9ead5d70a803d290de4eb75c9e9fc4f2",
-        "version" : "3.0.21"
+        "revision" : "3d13358d041b27fb4180f0d15b21d184bdac9077",
+        "version" : "3.0.22"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "3d13358d041b27fb4180f0d15b21d184bdac9077",
-        "version" : "3.0.22"
+        "revision" : "dbdd1b31656ef8973ec305c030745b361f3b335c",
+        "version" : "3.0.23"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.22")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.23")
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.21")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.22")
 	],
 	targets: [
 		.target(

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -54,21 +54,34 @@ public struct ClientOptions {
 	public var dbDirectory: String?
 	public var historySyncUrl: String?
 
-	public init(
-		api: Api = Api(),
-		codecs: [any ContentCodec] = [],
-		preAuthenticateToInboxCallback: PreEventCallback? = nil,
-		dbEncryptionKey: Data,
-		dbDirectory: String? = nil,
-		historySyncUrl: String? = nil
-	) {
-		self.api = api
-		self.codecs = codecs
-		self.preAuthenticateToInboxCallback = preAuthenticateToInboxCallback
-		self.dbEncryptionKey = dbEncryptionKey
-		self.dbDirectory = dbDirectory
-		self.historySyncUrl = historySyncUrl
-	}
+    public init(
+        api: Api = Api(),
+        codecs: [any ContentCodec] = [],
+        preAuthenticateToInboxCallback: PreEventCallback? = nil,
+        dbEncryptionKey: Data,
+        dbDirectory: String? = nil,
+        historySyncUrl: String? = nil
+    ) {
+        self.api = api
+        self.codecs = codecs
+        self.preAuthenticateToInboxCallback = preAuthenticateToInboxCallback
+        self.dbEncryptionKey = dbEncryptionKey
+        self.dbDirectory = dbDirectory
+        if historySyncUrl == nil {
+            switch api.env {
+            case .production:
+                self.historySyncUrl =
+                "https://message-history.production.ephemera.network/"
+            case .local:
+                self.historySyncUrl = "http://localhost:5558"
+            default:
+                self.historySyncUrl =
+                "https://message-history.dev.ephemera.network/"
+            }
+        } else {
+            self.historySyncUrl = historySyncUrl
+        }
+    }
 }
 
 actor ApiClientCache {

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -60,23 +60,22 @@ public struct ClientOptions {
         preAuthenticateToInboxCallback: PreEventCallback? = nil,
         dbEncryptionKey: Data,
         dbDirectory: String? = nil,
-        historySyncUrl: String? = nil
+        historySyncUrl: String? = nil,
+        useDefaultHistorySyncUrl: Bool = true
     ) {
         self.api = api
         self.codecs = codecs
         self.preAuthenticateToInboxCallback = preAuthenticateToInboxCallback
         self.dbEncryptionKey = dbEncryptionKey
         self.dbDirectory = dbDirectory
-        if historySyncUrl == nil {
+        if useDefaultHistorySyncUrl && historySyncUrl == nil {
             switch api.env {
             case .production:
-                self.historySyncUrl =
-                "https://message-history.production.ephemera.network/"
+                self.historySyncUrl = "https://message-history.production.ephemera.network/"
             case .local:
                 self.historySyncUrl = "http://localhost:5558"
             default:
-                self.historySyncUrl =
-                "https://message-history.dev.ephemera.network/"
+                self.historySyncUrl = "https://message-history.dev.ephemera.network/"
             }
         } else {
             self.historySyncUrl = historySyncUrl

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -278,7 +278,6 @@ public actor Conversations {
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
-		pinnedFrameUrl: String = "",
         messageDisappearingSettings: FfiMessageDisappearingSettings? = nil,
 		messageExpirationMs: Int64? = nil
 	) async throws -> Group {
@@ -290,7 +289,6 @@ public actor Conversations {
 			name: name,
 			imageUrlSquare: imageUrlSquare,
 			description: description,
-			pinnedFrameUrl: pinnedFrameUrl,
 			permissionPolicySet: nil,
             messageDisappearingSettings: messageDisappearingSettings
 		)
@@ -302,7 +300,6 @@ public actor Conversations {
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
-		pinnedFrameUrl: String = "",
         messageDisappearingSettings: FfiMessageDisappearingSettings? = nil
 	) async throws -> Group {
 		return try await newGroupInternal(
@@ -311,7 +308,6 @@ public actor Conversations {
 			name: name,
 			imageUrlSquare: imageUrlSquare,
 			description: description,
-			pinnedFrameUrl: pinnedFrameUrl,
 			permissionPolicySet: PermissionPolicySet.toFfiPermissionPolicySet(
 				permissionPolicySet),
             messageDisappearingSettings: messageDisappearingSettings
@@ -324,7 +320,6 @@ public actor Conversations {
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
-		pinnedFrameUrl: String = "",
 		permissionPolicySet: FfiPermissionPolicySet? = nil,
         messageDisappearingSettings: FfiMessageDisappearingSettings? = nil
 	) async throws -> Group {
@@ -350,7 +345,6 @@ public actor Conversations {
 				groupName: name,
 				groupImageUrlSquare: imageUrlSquare,
 				groupDescription: description,
-				groupPinnedFrameUrl: pinnedFrameUrl,
 				customPermissionPolicySet: permissionPolicySet,
                 messageDisappearingSettings: messageDisappearingSettings
             )
@@ -364,7 +358,6 @@ public actor Conversations {
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
-		pinnedFrameUrl: String = "",
         messageDisappearingSettings: FfiMessageDisappearingSettings? = nil
 	) async throws -> Group {
 		return try await newGroupInternalWithInboxIds(
@@ -375,7 +368,6 @@ public actor Conversations {
 			name: name,
 			imageUrlSquare: imageUrlSquare,
 			description: description,
-			pinnedFrameUrl: pinnedFrameUrl,
 			permissionPolicySet: nil,
             messageDisappearingSettings: messageDisappearingSettings
 		)
@@ -387,7 +379,6 @@ public actor Conversations {
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
-		pinnedFrameUrl: String = "",
         messageDisappearingSettings: FfiMessageDisappearingSettings? = nil
 	) async throws -> Group {
 		return try await newGroupInternalWithInboxIds(
@@ -396,7 +387,6 @@ public actor Conversations {
 			name: name,
 			imageUrlSquare: imageUrlSquare,
 			description: description,
-			pinnedFrameUrl: pinnedFrameUrl,
 			permissionPolicySet: PermissionPolicySet.toFfiPermissionPolicySet(
 				permissionPolicySet),
             messageDisappearingSettings: messageDisappearingSettings
@@ -409,7 +399,6 @@ public actor Conversations {
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
-		pinnedFrameUrl: String = "",
 		permissionPolicySet: FfiPermissionPolicySet? = nil,
         messageDisappearingSettings: FfiMessageDisappearingSettings? = nil
 	) async throws -> Group {
@@ -425,7 +414,6 @@ public actor Conversations {
 				groupName: name,
 				groupImageUrlSquare: imageUrlSquare,
 				groupDescription: description,
-				groupPinnedFrameUrl: pinnedFrameUrl,
 				customPermissionPolicySet: permissionPolicySet,
                 messageDisappearingSettings: messageDisappearingSettings
 			)

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -158,10 +158,6 @@ public struct Group: Identifiable, Equatable, Hashable {
 		return try ffiGroup.groupDescription()
 	}
 
-	public func groupPinnedFrameUrl() throws -> String {
-		return try ffiGroup.groupPinnedFrameUrl()
-	}
-
 	public func updateGroupName(groupName: String) async throws {
 		try await ffiGroup.updateGroupName(groupName: groupName)
 	}
@@ -174,13 +170,6 @@ public struct Group: Identifiable, Equatable, Hashable {
 	public func updateGroupDescription(groupDescription: String) async throws {
 		try await ffiGroup.updateGroupDescription(
 			groupDescription: groupDescription)
-	}
-
-	public func updateGroupPinnedFrameUrl(groupPinnedFrameUrl: String)
-		async throws
-	{
-		try await ffiGroup.updateGroupPinnedFrameUrl(
-			pinnedFrameUrl: groupPinnedFrameUrl)
 	}
 
 	public func updateAddMemberPermission(newPermissionOption: PermissionOption)
@@ -247,16 +236,6 @@ public struct Group: Identifiable, Equatable, Hashable {
 			permissionPolicyOption: PermissionOption.toFfiPermissionPolicy(
 				option: newPermissionOption),
 			metadataField: FfiMetadataField.imageUrlSquare)
-	}
-
-	public func updateGroupPinnedFrameUrlPermission(
-		newPermissionOption: PermissionOption
-	) async throws {
-		try await ffiGroup.updatePermissionPolicy(
-			permissionUpdateType: FfiPermissionUpdateType.updateMetadata,
-			permissionPolicyOption: PermissionOption.toFfiPermissionPolicy(
-				option: newPermissionOption),
-			metadataField: FfiMetadataField.pinnedFrameUrl)
 	}
 
 	public func updateConsentState(state: ConsentState) async throws {

--- a/Sources/XMTPiOS/Libxmtp/PermissionPolicySet.swift
+++ b/Sources/XMTPiOS/Libxmtp/PermissionPolicySet.swift
@@ -67,7 +67,6 @@ public class PermissionPolicySet {
 	public var updateGroupNamePolicy: PermissionOption
 	public var updateGroupDescriptionPolicy: PermissionOption
 	public var updateGroupImagePolicy: PermissionOption
-	public var updateGroupPinnedFrameUrlPolicy: PermissionOption
 	public var updateMessageDisappearingPolicy: PermissionOption
 
 	public init(
@@ -76,7 +75,6 @@ public class PermissionPolicySet {
 		updateGroupNamePolicy: PermissionOption,
 		updateGroupDescriptionPolicy: PermissionOption,
 		updateGroupImagePolicy: PermissionOption,
-		updateGroupPinnedFrameUrlPolicy: PermissionOption,
         updateMessageDisappearingPolicy: PermissionOption
 	) {
 		self.addMemberPolicy = addMemberPolicy
@@ -86,7 +84,6 @@ public class PermissionPolicySet {
 		self.updateGroupNamePolicy = updateGroupNamePolicy
 		self.updateGroupDescriptionPolicy = updateGroupDescriptionPolicy
 		self.updateGroupImagePolicy = updateGroupImagePolicy
-		self.updateGroupPinnedFrameUrlPolicy = updateGroupPinnedFrameUrlPolicy
 		self.updateMessageDisappearingPolicy = updateMessageDisappearingPolicy
 	}
 
@@ -110,9 +107,6 @@ public class PermissionPolicySet {
 			updateGroupImageUrlSquarePolicy:
 				PermissionOption.toFfiPermissionPolicy(
 					option: permissionPolicySet.updateGroupImagePolicy),
-			updateGroupPinnedFrameUrlPolicy:
-				PermissionOption.toFfiPermissionPolicy(
-					option: permissionPolicySet.updateGroupPinnedFrameUrlPolicy),
             updateMessageDisappearingPolicy:
 				PermissionOption.toFfiPermissionPolicy(
 					option: permissionPolicySet.updateMessageDisappearingPolicy)
@@ -141,10 +135,6 @@ public class PermissionPolicySet {
 			updateGroupImagePolicy: PermissionOption.fromFfiPermissionPolicy(
 				ffiPolicy: ffiPermissionPolicySet
 					.updateGroupImageUrlSquarePolicy),
-			updateGroupPinnedFrameUrlPolicy:
-				PermissionOption.fromFfiPermissionPolicy(
-					ffiPolicy: ffiPermissionPolicySet
-						.updateGroupPinnedFrameUrlPolicy),
             updateMessageDisappearingPolicy:
 				PermissionOption.fromFfiPermissionPolicy(
 					ffiPolicy: ffiPermissionPolicySet

--- a/Tests/XMTPTests/GroupPermissionsTests.swift
+++ b/Tests/XMTPTests/GroupPermissionsTests.swift
@@ -305,50 +305,6 @@ class GroupPermissionTests: XCTestCase {
 			try alixGroup.groupDescription(), "alix group description")
 	}
 
-	func testCanUpdatePinnedFrameUrl() async throws {
-		let fixtures = try await fixtures()
-		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address, fixtures.caro.address],
-			permissions: .adminOnly,
-			pinnedFrameUrl: "initial url"
-		)
-		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
-			.listGroups().first!
-
-		// Verify that alix cannot update group pinned frame url
-		XCTAssertEqual(try boGroup.groupPinnedFrameUrl(), "initial url")
-		await assertThrowsAsyncError(
-			try await alixGroup.updateGroupPinnedFrameUrl(
-				groupPinnedFrameUrl: "https://foo/bar.com")
-		)
-
-		try await alixGroup.sync()
-		try await boGroup.sync()
-		XCTAssertEqual(
-			try boGroup.permissionPolicySet().updateGroupPinnedFrameUrlPolicy,
-			.admin)
-
-		// Update group pinned frame url permissions so alix can update
-		try await boGroup.updateGroupPinnedFrameUrlPermission(
-			newPermissionOption: .allow)
-		try await boGroup.sync()
-		try await alixGroup.sync()
-		XCTAssertEqual(
-			try boGroup.permissionPolicySet().updateGroupPinnedFrameUrlPolicy,
-			.allow)
-
-		// Verify that alix can now update group pinned frame url
-		try await alixGroup.updateGroupPinnedFrameUrl(
-			groupPinnedFrameUrl: "https://foo/barz.com")
-		try await alixGroup.sync()
-		try await boGroup.sync()
-		XCTAssertEqual(
-			try boGroup.groupPinnedFrameUrl(), "https://foo/barz.com")
-		XCTAssertEqual(
-			try alixGroup.groupPinnedFrameUrl(), "https://foo/barz.com")
-	}
-
 	func testCanCreateGroupWithCustomPermissions() async throws {
 		let fixtures = try await fixtures()
 		let permissionPolicySet = PermissionPolicySet(
@@ -359,14 +315,12 @@ class GroupPermissionTests: XCTestCase {
 			updateGroupNamePolicy: PermissionOption.admin,
 			updateGroupDescriptionPolicy: PermissionOption.allow,
 			updateGroupImagePolicy: PermissionOption.admin,
-			updateGroupPinnedFrameUrlPolicy: PermissionOption.deny,
             updateMessageDisappearingPolicy: PermissionOption.allow
 		)
 		_ = try await fixtures.boClient.conversations
 			.newGroupCustomPermissions(
 				with: [fixtures.alix.address, fixtures.caro.address],
-				permissionPolicySet: permissionPolicySet,
-				pinnedFrameUrl: "initial url"
+				permissionPolicySet: permissionPolicySet
 			)
 
 		try await fixtures.alixClient.conversations.sync()
@@ -387,9 +341,6 @@ class GroupPermissionTests: XCTestCase {
 				== PermissionOption.allow)
 		XCTAssert(
 			alixPermissionSet.updateGroupImagePolicy == PermissionOption.admin)
-		XCTAssert(
-			alixPermissionSet.updateGroupPinnedFrameUrlPolicy
-				== PermissionOption.deny)
 	}
 	
 	func testCanCreateGroupWithInboxIdCustomPermissions() async throws {
@@ -402,14 +353,12 @@ class GroupPermissionTests: XCTestCase {
 			updateGroupNamePolicy: PermissionOption.admin,
 			updateGroupDescriptionPolicy: PermissionOption.allow,
 			updateGroupImagePolicy: PermissionOption.admin,
-			updateGroupPinnedFrameUrlPolicy: PermissionOption.deny,
             updateMessageDisappearingPolicy: PermissionOption.allow
 		)
 		_ = try await fixtures.boClient.conversations
 			.newGroupCustomPermissionsWithInboxIds(
 				with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
-				permissionPolicySet: permissionPolicySet,
-				pinnedFrameUrl: "initial url"
+				permissionPolicySet: permissionPolicySet
 			)
 
 		try await fixtures.alixClient.conversations.sync()
@@ -430,9 +379,6 @@ class GroupPermissionTests: XCTestCase {
 				== PermissionOption.allow)
 		XCTAssert(
 			alixPermissionSet.updateGroupImagePolicy == PermissionOption.admin)
-		XCTAssert(
-			alixPermissionSet.updateGroupPinnedFrameUrlPolicy
-				== PermissionOption.deny)
 	}
 
 	func testCreateGroupWithInvalidPermissionsFails() async throws {
@@ -446,15 +392,13 @@ class GroupPermissionTests: XCTestCase {
 			updateGroupNamePolicy: PermissionOption.admin,
 			updateGroupDescriptionPolicy: PermissionOption.allow,
 			updateGroupImagePolicy: PermissionOption.admin,
-			updateGroupPinnedFrameUrlPolicy: PermissionOption.deny,
             updateMessageDisappearingPolicy: PermissionOption.allow
 		)
 		await assertThrowsAsyncError(
 			try await fixtures.boClient.conversations
 				.newGroupCustomPermissions(
 					with: [fixtures.alix.address, fixtures.caro.address],
-					permissionPolicySet: permissionPolicySetInvalid,
-					pinnedFrameUrl: "initial url"
+					permissionPolicySet: permissionPolicySetInvalid
 				)
 		)
 	}

--- a/Tests/XMTPTests/HistorySyncTests.swift
+++ b/Tests/XMTPTests/HistorySyncTests.swift
@@ -106,7 +106,10 @@ class HistorySyncTests: XCTestCase {
 		let state = try await alixClient2.inboxState(refreshFromNetwork: true)
 		XCTAssertEqual(state.installations.count, 2)
 
-		try await group.send(content: "hi")
+        // If we move this line before alixClient2 create, we fail with the group
+		// not being found. history sync seems to get messages, but maybe
+		// not groups?
+        try await group.send(content: "hi")
 
 		try await alixClient.conversations.syncAllConversations()
 		sleep(2)

--- a/Tests/XMTPTests/HistorySyncTests.swift
+++ b/Tests/XMTPTests/HistorySyncTests.swift
@@ -23,6 +23,7 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db"
+                // useDefaultHistorySyncUrl: false
 			)
 		)
 
@@ -37,6 +38,7 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db2"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 
@@ -82,14 +84,14 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 
 		let group = try await alixClient.conversations.newGroup(
 			with: [fixtures.bo.walletAddress])
-		try await group.send(content: "hi")
 		let messageCount = try await group.messages().count
-		XCTAssertEqual(messageCount, 2)
+		XCTAssertEqual(messageCount, 1)
 
 		let alixClient2 = try await Client.create(
 			account: alix,
@@ -97,23 +99,28 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db2"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 
 		let state = try await alixClient2.inboxState(refreshFromNetwork: true)
 		XCTAssertEqual(state.installations.count, 2)
 
+		try await group.send(content: "hi")
+
 		try await alixClient.conversations.syncAllConversations()
 		sleep(2)
 		try await alixClient2.conversations.syncAllConversations()
 		sleep(2)
 
-		if let dm2 = try await alixClient2.findConversation(
-			conversationId: group.id)
+		if let group2 = try await alixClient2.findGroup(
+			groupId: group.id)
 		{
-			let messageCount = try await group.messages().count
-			XCTAssertEqual(messageCount, 2)
-		}
+			let messageCount2 = try await group2.messages().count
+			XCTAssertEqual(messageCount2, 2)
+        } else {
+            XCTFail()
+        }
 	}
 
 	func testStreamConsent() async throws {
@@ -128,6 +135,7 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 
@@ -141,6 +149,7 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db2"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 
@@ -184,6 +193,7 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 		
@@ -205,6 +215,7 @@ class HistorySyncTests: XCTestCase {
 				api: .init(env: .local, isSecure: false),
 				dbEncryptionKey: key,
 				dbDirectory: "xmtp_db2"
+//                useDefaultHistorySyncUrl: false
 			)
 		)
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "3.0.26"
+  spec.version      = "3.0.27"
 
   spec.summary      = "XMTP SDK Cocoapod"
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 3.0.21'
+  spec.dependency 'LibXMTP', '= 3.0.22'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 3.0.22'
+  spec.dependency 'LibXMTP', '= 3.0.23'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "6b0166d5e9680905cee1ca141854de30e1c28317",
-        "version" : "3.0.20"
+        "revision" : "c9d3bdff9ead5d70a803d290de4eb75c9e9fc4f2",
+        "version" : "3.0.21"
       }
     },
     {


### PR DESCRIPTION
Dependent on PR https://github.com/xmtp/libxmtp/pull/1534 landing first

We could do this in a less breaking way and just set the pinned frame always to an empty string if we want to merge this before libxmtp changes land but this would be the cleanest.

- Remove pinned frame url
- Defaults History Sync back on
