### PR TITLE
Make addWallet a delicate API 

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -368,14 +368,16 @@ public final class Client {
 		message:
 			"This function is delicate and should be used with caution. Adding a wallet already associated with an inboxId will cause the wallet to loose access to that inbox. See: inboxIdFromAddress(address)"
 	)
-	public func addAccount(newAccount: SigningKey, changeInboxId: Bool = false)
+	public func addAccount(
+		newAccount: SigningKey, allowReassignInboxId: Bool = false
+	)
 		async throws
 	{
 		let inboxId: String? =
-			changeInboxId
+			allowReassignInboxId
 			? nil : try await inboxIdFromAddress(address: newAccount.address)
 
-		if changeInboxId || (inboxId?.isEmpty ?? true) {
+		if allowReassignInboxId || (inboxId?.isEmpty ?? true) {
 			let signatureRequest = try await ffiClient.addWallet(
 				newWalletAddress: newAccount.address.lowercased())
 

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -54,33 +54,35 @@ public struct ClientOptions {
 	public var dbDirectory: String?
 	public var historySyncUrl: String?
 
-    public init(
-        api: Api = Api(),
-        codecs: [any ContentCodec] = [],
-        preAuthenticateToInboxCallback: PreEventCallback? = nil,
-        dbEncryptionKey: Data,
-        dbDirectory: String? = nil,
-        historySyncUrl: String? = nil,
-        useDefaultHistorySyncUrl: Bool = true
-    ) {
-        self.api = api
-        self.codecs = codecs
-        self.preAuthenticateToInboxCallback = preAuthenticateToInboxCallback
-        self.dbEncryptionKey = dbEncryptionKey
-        self.dbDirectory = dbDirectory
-        if useDefaultHistorySyncUrl && historySyncUrl == nil {
-            switch api.env {
-            case .production:
-                self.historySyncUrl = "https://message-history.production.ephemera.network/"
-            case .local:
-                self.historySyncUrl = "http://localhost:5558"
-            default:
-                self.historySyncUrl = "https://message-history.dev.ephemera.network/"
-            }
-        } else {
-            self.historySyncUrl = historySyncUrl
-        }
-    }
+	public init(
+		api: Api = Api(),
+		codecs: [any ContentCodec] = [],
+		preAuthenticateToInboxCallback: PreEventCallback? = nil,
+		dbEncryptionKey: Data,
+		dbDirectory: String? = nil,
+		historySyncUrl: String? = nil,
+		useDefaultHistorySyncUrl: Bool = true
+	) {
+		self.api = api
+		self.codecs = codecs
+		self.preAuthenticateToInboxCallback = preAuthenticateToInboxCallback
+		self.dbEncryptionKey = dbEncryptionKey
+		self.dbDirectory = dbDirectory
+		if useDefaultHistorySyncUrl && historySyncUrl == nil {
+			switch api.env {
+			case .production:
+				self.historySyncUrl =
+					"https://message-history.production.ephemera.network/"
+			case .local:
+				self.historySyncUrl = "http://localhost:5558"
+			default:
+				self.historySyncUrl =
+					"https://message-history.dev.ephemera.network/"
+			}
+		} else {
+			self.historySyncUrl = historySyncUrl
+		}
+	}
 }
 
 actor ApiClientCache {
@@ -361,19 +363,35 @@ public final class Client {
 		self.environment = environment
 	}
 
-	public func addAccount(newAccount: SigningKey)
+	@available(
+		*, deprecated,
+		message:
+			"This function is delicate and should be used with caution. Adding a wallet already associated with an inboxId will cause the wallet to loose access to that inbox. See: inboxIdFromAddress(address)"
+	)
+	public func addAccount(newAccount: SigningKey, changeInboxId: Bool = false)
 		async throws
 	{
-		let signatureRequest = try await ffiClient.addWallet(
-			newWalletAddress: newAccount.address.lowercased())
-		do {
-			try await Client.handleSignature(
-				for: signatureRequest, signingKey: newAccount)
-			try await ffiClient.applySignatureRequest(
-				signatureRequest: signatureRequest)
-		} catch {
+		let inboxId: String? =
+			changeInboxId
+			? nil : try await inboxIdFromAddress(address: newAccount.address)
+
+		if changeInboxId || (inboxId?.isEmpty ?? true) {
+			let signatureRequest = try await ffiClient.addWallet(
+				newWalletAddress: newAccount.address.lowercased())
+
+			do {
+				try await Client.handleSignature(
+					for: signatureRequest, signingKey: newAccount)
+				try await ffiClient.applySignatureRequest(
+					signatureRequest: signatureRequest)
+			} catch {
+				throw ClientError.creationError(
+					"Failed to sign the message: \(error.localizedDescription)")
+			}
+		} else {
 			throw ClientError.creationError(
-				"Failed to sign the message: \(error.localizedDescription)")
+				"This wallet is already associated with inbox \(inboxId ?? "Unknown")"
+			)
 		}
 	}
 

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -56,7 +56,7 @@ class ClientTests: XCTestCase {
 				"Failed for address: \(address)")
 		}
 	}
-	
+
 	func testStaticInboxState() async throws {
 		let fixtures = try await fixtures()
 
@@ -321,7 +321,7 @@ class ClientTests: XCTestCase {
 
 		XCTAssertEqual(alixClient2.inboxID, alixClient.inboxID)
 	}
-	
+
 	func testRevokeInstallations() async throws {
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
@@ -355,7 +355,8 @@ class ClientTests: XCTestCase {
 		let state = try await alixClient3.inboxState(refreshFromNetwork: true)
 		XCTAssertEqual(state.installations.count, 3)
 
-		try await alixClient3.revokeInstallations(signingKey: alix, installationIds: [alixClient2.installationID])
+		try await alixClient3.revokeInstallations(
+			signingKey: alix, installationIds: [alixClient2.installationID])
 
 		let newState = try await alixClient3.inboxState(
 			refreshFromNetwork: true)
@@ -440,6 +441,25 @@ class ClientTests: XCTestCase {
 				fixtures.alixClient.address.lowercased(),
 			].sorted()
 		)
+	}
+
+	func testAddAccountsWithExistingInboxIds() async throws {
+		let fixtures = try await fixtures()
+
+		await assertThrowsAsyncError(
+			try await fixtures.alixClient.addAccount(newAccount: fixtures.bo))
+
+		XCTAssert(fixtures.boClient.inboxID != fixtures.alixClient.inboxID)
+		try await fixtures.alixClient.addAccount(
+			newAccount: fixtures.bo, allowReassignInboxId: true)
+
+		let state = try await fixtures.alixClient.inboxState(
+			refreshFromNetwork: true)
+		XCTAssertEqual(state.addresses.count, 2)
+
+		let inboxId = try await fixtures.alixClient.inboxIdFromAddress(
+			address: fixtures.boClient.address)
+		XCTAssertEqual(inboxId, fixtures.alixClient.inboxID)
 	}
 
 	func testRemovingAccounts() async throws {


### PR DESCRIPTION
Require a boolean to be passed to allow overriding an existing inboxId when calling addWallet. Also makes a new annotation for delicate Apis.
