### PR TITLE
Passkey Read

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "3.0.30")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", branch: "np/passkey-read")
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", branch: "np/passkey-read")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.0.0-rc1")
 	],
 	targets: [
 		.target(

--- a/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -33,14 +33,14 @@
 		}
 	}
 
-	public struct FakeWallet: SigningKey {
+public struct FakeWallet: SigningKey {
+		public var identity: XMTPiOS.PublicIdentity {
+			XMTPiOS.PublicIdentity(kind: .ethereum, identifier: key.walletAddress)
+		}
+	
 		public static func generate() throws -> FakeWallet {
 			let key = try PrivateKey.generate()
 			return FakeWallet(key)
-		}
-
-		public var address: String {
-			key.walletAddress
 		}
 
 		public func sign(_ data: Data) async throws -> XMTPiOS.Signature {

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -6,6 +6,7 @@ public typealias PreEventCallback = () async throws -> Void
 public enum ClientError: Error, CustomStringConvertible, LocalizedError {
 	case creationError(String)
 	case missingInboxId
+	case invalidInboxId(String)
 
 	public var description: String {
 		switch self {
@@ -13,6 +14,9 @@ public enum ClientError: Error, CustomStringConvertible, LocalizedError {
 			return "ClientError.creationError: \(err)"
 		case .missingInboxId:
 			return "ClientError.missingInboxId"
+		case .invalidInboxId(let inboxId):
+			return
+				"Invalid inboxId: \(inboxId). Inbox IDs cannot start with '0x'."
 		}
 	}
 
@@ -97,9 +101,10 @@ actor ApiClientCache {
 	}
 }
 
+public typealias InboxId = String
+
 public final class Client {
-	public let address: String
-	public let inboxID: String
+	public let inboxID: InboxId
 	public let libXMTPVersion: String = getVersionInfo()
 	public let dbPath: String
 	public let installationID: String
@@ -120,20 +125,19 @@ public final class Client {
 	}
 
 	static func initializeClient(
-		accountAddress: String,
+		publicIdentity: PublicIdentity,
 		options: ClientOptions,
 		signingKey: SigningKey?,
-		inboxId: String,
+		inboxId: InboxId,
 		apiClient: XmtpApiClient? = nil
 	) async throws -> Client {
 		let (libxmtpClient, dbPath) = try await initFFiClient(
-			accountAddress: accountAddress.lowercased(),
+			accountIdentifier: publicIdentity,
 			options: options,
 			inboxId: inboxId
 		)
 
 		let client = try Client(
-			address: accountAddress.lowercased(),
 			ffiClient: libxmtpClient,
 			dbPath: dbPath,
 			installationID: libxmtpClient.installationId().toHex,
@@ -174,12 +178,12 @@ public final class Client {
 	)
 		async throws -> Client
 	{
-		let accountAddress = account.address.lowercased()
+		let identity = account.identity
 		let inboxId = try await getOrCreateInboxId(
-			api: options.api, address: accountAddress)
+			api: options.api, publicIdentity: identity)
 
 		return try await initializeClient(
-			accountAddress: accountAddress,
+			publicIdentity: identity,
 			options: options,
 			signingKey: account,
 			inboxId: inboxId
@@ -187,21 +191,21 @@ public final class Client {
 	}
 
 	public static func build(
-		address: String, options: ClientOptions, inboxId: String? = nil
+		publicIdentity: PublicIdentity, options: ClientOptions,
+		inboxId: InboxId? = nil
 	)
 		async throws -> Client
 	{
-		let accountAddress = address.lowercased()
 		let resolvedInboxId: String
 		if let existingInboxId = inboxId {
 			resolvedInboxId = existingInboxId
 		} else {
 			resolvedInboxId = try await getOrCreateInboxId(
-				api: options.api, address: accountAddress)
+				api: options.api, publicIdentity: publicIdentity)
 		}
 
 		return try await initializeClient(
-			accountAddress: accountAddress,
+			publicIdentity: publicIdentity,
 			options: options,
 			signingKey: nil,
 			inboxId: resolvedInboxId
@@ -218,20 +222,18 @@ public final class Client {
 			"""
 	)
 	public static func ffiCreateClient(
-		address: String, clientOptions: ClientOptions
+		identity: PublicIdentity, clientOptions: ClientOptions
 	) async throws -> Client {
-		let accountAddress = address.lowercased()
 		let recoveredInboxId = try await getOrCreateInboxId(
-			api: clientOptions.api, address: accountAddress)
+			api: clientOptions.api, publicIdentity: identity)
 
 		let (ffiClient, dbPath) = try await initFFiClient(
-			accountAddress: accountAddress,
+			accountIdentifier: identity,
 			options: clientOptions,
 			inboxId: recoveredInboxId
 		)
 
 		return try Client(
-			address: accountAddress,
 			ffiClient: ffiClient,
 			dbPath: dbPath,
 			installationID: ffiClient.installationId().toHex,
@@ -241,12 +243,10 @@ public final class Client {
 	}
 
 	private static func initFFiClient(
-		accountAddress: String,
+		accountIdentifier: PublicIdentity,
 		options: ClientOptions,
-		inboxId: String
+		inboxId: InboxId
 	) async throws -> (FfiXmtpClient, String) {
-		let address = accountAddress.lowercased()
-
 		let mlsDbDirectory = options.dbDirectory
 		var directoryURL: URL
 		if let mlsDbDirectory = mlsDbDirectory {
@@ -276,7 +276,7 @@ public final class Client {
 			db: dbURL,
 			encryptionKey: options.dbEncryptionKey,
 			inboxId: inboxId,
-			accountAddress: address,
+			accountIdentifier: accountIdentifier.ffiPrivate,
 			nonce: 0,
 			legacySignedPrivateKeyProto: nil,
 			historySyncUrl: options.historySyncUrl
@@ -298,7 +298,7 @@ public final class Client {
 				message: signatureRequest.signatureText())
 			try await signatureRequest.addScwSignature(
 				signatureBytes: signedData,
-				address: signingKey.address.lowercased(),
+				address: signingKey.identity.identifier,
 				chainId: UInt64(chainId),
 				blockNumber: signingKey.blockNumber.flatMap {
 					$0 >= 0 ? UInt64($0) : nil
@@ -328,35 +328,37 @@ public final class Client {
 	}
 
 	public static func getOrCreateInboxId(
-		api: ClientOptions.Api, address: String
-	) async throws -> String {
+		api: ClientOptions.Api, publicIdentity: PublicIdentity
+	) async throws -> InboxId {
 		var inboxId: String
 		do {
 			inboxId =
-				try await getInboxIdForAddress(
+				try await getInboxIdForIdentifier(
 					api: connectToApiBackend(api: api),
-					accountAddress: address.lowercased()
-				)
+					accountIdentifier: publicIdentity.ffiPrivate)
 				?? generateInboxId(
-					accountAddress: address.lowercased(), nonce: 0)
+					accountIdentifier: publicIdentity.ffiPrivate, nonce: 0)
 		} catch {
 			inboxId = try generateInboxId(
-				accountAddress: address.lowercased(), nonce: 0)
+				accountIdentifier: publicIdentity.ffiPrivate, nonce: 0)
 		}
 		return inboxId
 	}
 
 	private static func prepareClient(
 		api: ClientOptions.Api,
-		address: String = "0x0000000000000000000000000000000000000000"
+		identity: PublicIdentity = PublicIdentity(
+			kind: .ethereum,
+			identifier: "0x0000000000000000000000000000000000000000")
 	) async throws -> FfiXmtpClient {
-		let inboxId = try await getOrCreateInboxId(api: api, address: address)
+		let inboxId = try await getOrCreateInboxId(
+			api: api, publicIdentity: identity)
 		return try await LibXMTP.createClient(
 			api: connectToApiBackend(api: api),
 			db: nil,
 			encryptionKey: nil,
 			inboxId: inboxId,
-			accountAddress: address,
+			accountIdentifier: identity.ffiPrivate,
 			nonce: 0,
 			legacySignedPrivateKeyProto: nil,
 			historySyncUrl: nil
@@ -364,16 +366,19 @@ public final class Client {
 	}
 
 	public static func canMessage(
-		accountAddresses: [String],
-		api: ClientOptions.Api
+		identities: [PublicIdentity], api: ClientOptions.Api
 	) async throws -> [String: Bool] {
 		let ffiClient = try await prepareClient(api: api)
-		return try await ffiClient.canMessage(
-			accountAddresses: accountAddresses)
+		let ffiIdentifiers = identities.map { $0.ffiPrivate }
+		let result = try await ffiClient.canMessage(
+			accountIdentifiers: ffiIdentifiers)
+
+		return Dictionary(
+			uniqueKeysWithValues: result.map { ($0.key.identifier, $0.value) })
 	}
 
 	public static func inboxStatesForInboxIds(
-		inboxIds: [String],
+		inboxIds: [InboxId],
 		api: ClientOptions.Api
 	) async throws -> [InboxState] {
 		let ffiClient = try await prepareClient(api: api)
@@ -383,10 +388,9 @@ public final class Client {
 	}
 
 	init(
-		address: String, ffiClient: LibXMTP.FfiXmtpClient, dbPath: String,
-		installationID: String, inboxID: String, environment: XMTPEnvironment
+		ffiClient: LibXMTP.FfiXmtpClient, dbPath: String,
+		installationID: String, inboxID: InboxId, environment: XMTPEnvironment
 	) throws {
-		self.address = address
 		self.ffiClient = ffiClient
 		self.dbPath = dbPath
 		self.installationID = installationID
@@ -397,7 +401,7 @@ public final class Client {
 	@available(
 		*, deprecated,
 		message:
-			"This function is delicate and should be used with caution. Adding a wallet already associated with an inboxId will cause the wallet to loose access to that inbox. See: inboxIdFromAddress(address)"
+			"This function is delicate and should be used with caution. Adding a wallet already associated with an inboxId will cause the wallet to loose access to that inbox. See: inboxIdFromIdentity(publicIdentity)"
 	)
 	public func addAccount(
 		newAccount: SigningKey, allowReassignInboxId: Bool = false
@@ -406,12 +410,11 @@ public final class Client {
 	{
 		let inboxId: String? =
 			allowReassignInboxId
-			? nil : try await inboxIdFromAddress(address: newAccount.address)
+			? nil : try await inboxIdFromIdentity(identity: newAccount.identity)
 
 		if allowReassignInboxId || (inboxId?.isEmpty ?? true) {
-			let signatureRequest = try await ffiAddWallet(
-				addressToAdd: newAccount.address.lowercased())
-
+			let signatureRequest = try await ffiAddIdentity(
+				identityToAdd: newAccount.identity)
 			do {
 				try await Client.handleSignature(
 					for: signatureRequest.ffiSignatureRequest,
@@ -430,10 +433,10 @@ public final class Client {
 	}
 
 	public func removeAccount(
-		recoveryAccount: SigningKey, addressToRemove: String
+		recoveryAccount: SigningKey, identityToRemove: PublicIdentity
 	) async throws {
-		let signatureRequest = try await ffiRevokeWallet(
-			addressToRemove: addressToRemove.lowercased())
+		let signatureRequest = try await ffiRevokeIdentity(
+			identityToRemove: identityToRemove)
 		do {
 			try await Client.handleSignature(
 				for: signatureRequest.ffiSignatureRequest,
@@ -479,15 +482,21 @@ public final class Client {
 		}
 	}
 
-	public func canMessage(address: String) async throws -> Bool {
-		let canMessage = try await ffiClient.canMessage(accountAddresses: [
-			address
+	public func canMessage(identities: PublicIdentity) async throws -> Bool {
+		let canMessage = try await canMessage(identities: [
+			identities
 		])
-		return canMessage[address.lowercased()] ?? false
+		return canMessage[identities.identifier] ?? false
 	}
 
-	public func canMessage(addresses: [String]) async throws -> [String: Bool] {
-		return try await ffiClient.canMessage(accountAddresses: addresses)
+	func canMessage(identities: [PublicIdentity]) async throws -> [String: Bool]
+	{
+		let ffiIdentifiers = identities.map { $0.ffiPrivate }
+		let result = try await ffiClient.canMessage(
+			accountIdentifiers: ffiIdentifiers)
+
+		return Dictionary(
+			uniqueKeysWithValues: result.map { ($0.key.identifier, $0.value) })
 	}
 
 	public func deleteLocalDatabase() throws {
@@ -509,8 +518,10 @@ public final class Client {
 		try await ffiClient.dbReconnect()
 	}
 
-	public func inboxIdFromAddress(address: String) async throws -> String? {
-		return try await ffiClient.findInboxId(address: address.lowercased())
+	public func inboxIdFromIdentity(identity: PublicIdentity) async throws
+		-> InboxId?
+	{
+		return try await ffiClient.findInboxId(identifier: identity.ffiPrivate)
 	}
 
 	public func signWithInstallationKey(message: String) throws -> Data {
@@ -549,7 +560,7 @@ public final class Client {
 	}
 
 	public func inboxStatesForInboxIds(
-		refreshFromNetwork: Bool, inboxIds: [String]
+		refreshFromNetwork: Bool, inboxIds: [InboxId]
 	) async throws -> [InboxState] {
 		return try await ffiClient.addressesFromInboxId(
 			refreshFromNetwork: refreshFromNetwork, inboxIds: inboxIds
@@ -611,14 +622,14 @@ public final class Client {
 		message: """
 			This function is delicate and should be used with caution. 
 			Should only be used if trying to manage the signature flow independently; 
-			otherwise use `removeWallet()` instead.
+			otherwise use `removeIdentity()` instead.
 			"""
 	)
-	public func ffiRevokeWallet(addressToRemove: String) async throws
+	public func ffiRevokeIdentity(identityToRemove: PublicIdentity) async throws
 		-> SignatureRequest
 	{
-		let ffiSigReq = try await ffiClient.revokeWallet(
-			walletAddress: addressToRemove.lowercased())
+		let ffiSigReq = try await ffiClient.revokeIdentity(
+			identifier: identityToRemove.ffiPrivate)
 		return SignatureRequest(ffiSignatureRequest: ffiSigReq)
 	}
 
@@ -628,14 +639,14 @@ public final class Client {
 		message: """
 			This function is delicate and should be used with caution. 
 			Should only be used if trying to manage the create and register flow independently; 
-			otherwise use `addWallet()` instead.
+			otherwise use `addIdentity()` instead.
 			"""
 	)
-	public func ffiAddWallet(addressToAdd: String) async throws
+	public func ffiAddIdentity(identityToAdd: PublicIdentity) async throws
 		-> SignatureRequest
 	{
-		let ffiSigReq = try await ffiClient.addWallet(
-			newWalletAddress: addressToAdd.lowercased())
+		let ffiSigReq = try await ffiClient.addIdentity(
+			newIdentity: identityToAdd.ffiPrivate)
 		return SignatureRequest(ffiSignatureRequest: ffiSigReq)
 	}
 

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -414,7 +414,9 @@ public final class Client {
 
 		if allowReassignInboxId || (inboxId?.isEmpty ?? true) {
 			let signatureRequest = try await ffiAddIdentity(
-				identityToAdd: newAccount.identity)
+				identityToAdd: newAccount.identity,
+                allowReassignInboxId: allowReassignInboxId
+            )
 			do {
 				try await Client.handleSignature(
 					for: signatureRequest.ffiSignatureRequest,
@@ -642,9 +644,9 @@ public final class Client {
 			otherwise use `addIdentity()` instead.
 			"""
 	)
-	public func ffiAddIdentity(
-		identityToAdd: PublicIdentity, allowReassignInboxId: Bool = false
-	) async throws
+    public func ffiAddIdentity(
+        identityToAdd: PublicIdentity, allowReassignInboxId: Bool = false
+    ) async throws
 		-> SignatureRequest
 	{
 		let inboxId: InboxId? =

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -123,7 +123,7 @@ public actor Conversations {
 		return nil
 	}
 
-	public func findDmByInboxId(inboxId: String) throws -> Dm? {
+	public func findDmByInboxId(inboxId: InboxId) throws -> Dm? {
 		do {
 			let conversation = try ffiClient.dmConversation(
 				targetInboxId: inboxId)
@@ -134,9 +134,12 @@ public actor Conversations {
 		}
 	}
 
-	public func findDmByAddress(address: String) async throws -> Dm? {
+	public func findDmByIdentity(publicIdentity: PublicIdentity) async throws
+		-> Dm?
+	{
 		guard
-			let inboxId = try await client.inboxIdFromAddress(address: address)
+			let inboxId = try await client.inboxIdFromIdentity(
+				identity: publicIdentity)
 		else {
 			throw ClientError.creationError("No inboxId present")
 		}
@@ -308,33 +311,30 @@ public actor Conversations {
 		}
 	}
 
-	public func newConversation(
-		with peerAddress: String,
+	public func newConversationWithIdentity(
+		with peerIdentity: PublicIdentity,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Conversation {
-		let dm = try await findOrCreateDm(
-			with: peerAddress,
+		let dm = try await findOrCreateDmWithIdentity(
+			with: peerIdentity,
 			disappearingMessageSettings: disappearingMessageSettings)
 		return Conversation.dm(dm)
 	}
 
-	public func findOrCreateDm(
-		with peerAddress: String,
+	public func findOrCreateDmWithIdentity(
+		with peerIdentity: PublicIdentity,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Dm {
-		if peerAddress.lowercased() == client.address.lowercased() {
+		if try await client.inboxState(refreshFromNetwork: false).identities
+			.map({ $0.identifier }).contains(peerIdentity.identifier)
+		{
 			throw ConversationError.memberCannotBeSelf
-		}
-		let canMessage = try await self.client.canMessage(
-			address: peerAddress)
-		if !canMessage {
-			throw ConversationError.memberNotRegistered([peerAddress])
 		}
 
 		let dm =
 			try await ffiConversations
 			.findOrCreateDm(
-				accountAddress: peerAddress.lowercased(),
+				targetIdentity: peerIdentity.ffiPrivate,
 				opts: FfiCreateDmOptions(
 					messageDisappearingSettings: FfiMessageDisappearingSettings(
 						fromNs: disappearingMessageSettings?
@@ -345,23 +345,23 @@ public actor Conversations {
 		return dm.dmFromFFI(client: client)
 	}
 
-	public func newConversationWithInboxId(
-		with peerInboxId: String,
+	public func newConversation(
+		with peerInboxId: InboxId,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Conversation {
-		let dm = try await findOrCreateDmWithInboxId(
+		let dm = try await findOrCreateDm(
 			with: peerInboxId,
 			disappearingMessageSettings: disappearingMessageSettings)
 		return Conversation.dm(dm)
 	}
 
-	public func findOrCreateDmWithInboxId(
-		with peerInboxId: String,
+	public func findOrCreateDm(
+		with peerInboxId: InboxId,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	)
 		async throws -> Dm
 	{
-		if peerInboxId.lowercased() == client.inboxID.lowercased() {
+		if peerInboxId == client.inboxID {
 			throw ConversationError.memberCannotBeSelf
 		}
 
@@ -379,16 +379,16 @@ public actor Conversations {
 
 	}
 
-	public func newGroup(
-		with addresses: [String],
+	public func newGroupWithIdentities(
+		with identities: [PublicIdentity],
 		permissions: GroupPermissionPreconfiguration = .allMembers,
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
-		return try await newGroupInternal(
-			with: addresses,
+		return try await newGroupInternalWithIdentities(
+			with: identities,
 			permissions:
 				GroupPermissionPreconfiguration.toFfiGroupPermissionOptions(
 					option: permissions),
@@ -400,16 +400,16 @@ public actor Conversations {
 		)
 	}
 
-	public func newGroupCustomPermissions(
-		with addresses: [String],
+	public func newGroupCustomPermissionsWithIdentities(
+		with identities: [PublicIdentity],
 		permissionPolicySet: PermissionPolicySet,
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
-		return try await newGroupInternal(
-			with: addresses,
+		return try await newGroupInternalWithIdentities(
+			with: identities,
 			permissions: FfiGroupPermissionsOptions.customPolicy,
 			name: name,
 			imageUrlSquare: imageUrlSquare,
@@ -420,8 +420,8 @@ public actor Conversations {
 		)
 	}
 
-	private func newGroupInternal(
-		with addresses: [String],
+	private func newGroupInternalWithIdentities(
+		with identities: [PublicIdentity],
 		permissions: FfiGroupPermissionsOptions = .default,
 		name: String = "",
 		imageUrlSquare: String = "",
@@ -429,23 +429,8 @@ public actor Conversations {
 		permissionPolicySet: FfiPermissionPolicySet? = nil,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
-		if addresses.first(where: {
-			$0.lowercased() == client.address.lowercased()
-		}) != nil {
-			throw ConversationError.memberCannotBeSelf
-		}
-		let addressMap = try await self.client.canMessage(addresses: addresses)
-		let unregisteredAddresses =
-			addressMap
-			.filter { !$0.value }
-			.map { $0.key }
-
-		if !unregisteredAddresses.isEmpty {
-			throw ConversationError.memberNotRegistered(unregisteredAddresses)
-		}
-
 		let group = try await ffiConversations.createGroup(
-			accountAddresses: addresses,
+			accountIdentities: identities.map { $0.ffiPrivate },
 			opts: FfiCreateGroupOptions(
 				permissions: permissions,
 				groupName: name,
@@ -463,15 +448,15 @@ public actor Conversations {
 		return group
 	}
 
-	public func newGroupWithInboxIds(
-		with inboxIds: [String],
+	public func newGroup(
+		with inboxIds: [InboxId],
 		permissions: GroupPermissionPreconfiguration = .allMembers,
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
-		return try await newGroupInternalWithInboxIds(
+		return try await newGroupInternal(
 			with: inboxIds,
 			permissions:
 				GroupPermissionPreconfiguration.toFfiGroupPermissionOptions(
@@ -484,15 +469,15 @@ public actor Conversations {
 		)
 	}
 
-	public func newGroupCustomPermissionsWithInboxIds(
-		with inboxIds: [String],
+	public func newGroupCustomPermissions(
+		with inboxIds: [InboxId],
 		permissionPolicySet: PermissionPolicySet,
 		name: String = "",
 		imageUrlSquare: String = "",
 		description: String = "",
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
-		return try await newGroupInternalWithInboxIds(
+		return try await newGroupInternal(
 			with: inboxIds,
 			permissions: FfiGroupPermissionsOptions.customPolicy,
 			name: name,
@@ -504,8 +489,8 @@ public actor Conversations {
 		)
 	}
 
-	private func newGroupInternalWithInboxIds(
-		with inboxIds: [String],
+	private func newGroupInternal(
+		with inboxIds: [InboxId],
 		permissions: FfiGroupPermissionsOptions = .default,
 		name: String = "",
 		imageUrlSquare: String = "",
@@ -513,11 +498,6 @@ public actor Conversations {
 		permissionPolicySet: FfiPermissionPolicySet? = nil,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
-		if inboxIds.contains(where: {
-			$0.lowercased() == client.inboxID.lowercased()
-		}) {
-			throw ConversationError.memberCannotBeSelf
-		}
 		let group = try await ffiConversations.createGroupWithInboxIds(
 			inboxIds: inboxIds,
 			opts: FfiCreateGroupOptions(

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -364,7 +364,7 @@ public actor Conversations {
 		if peerInboxId == client.inboxID {
 			throw ConversationError.memberCannotBeSelf
 		}
-
+		try validateInboxId(peerInboxId)
 		let dm =
 			try await ffiConversations
 			.findOrCreateDmByInboxId(
@@ -498,6 +498,7 @@ public actor Conversations {
 		permissionPolicySet: FfiPermissionPolicySet? = nil,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Group {
+		try validateInboxIds(inboxIds)
 		let group = try await ffiConversations.createGroupWithInboxIds(
 			inboxIds: inboxIds,
 			opts: FfiCreateGroupOptions(

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -47,11 +47,11 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		return try await metadata().creatorInboxId() == client.inboxID
 	}
 
-	public func creatorInboxId() async throws -> String {
+	public func creatorInboxId() async throws -> InboxId {
 		return try await metadata().creatorInboxId()
 	}
 
-	public func addedByInboxId() throws -> String {
+	public func addedByInboxId() throws -> InboxId {
 		return try ffiConversation.addedByInboxId()
 	}
 
@@ -64,7 +64,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public var peerInboxId: String {
+	public var peerInboxId: InboxId {
 		get throws {
 			try ffiConversation.dmPeerInboxId()
 		}

--- a/Sources/XMTPiOS/Extensions/Ffi.swift
+++ b/Sources/XMTPiOS/Extensions/Ffi.swift
@@ -77,7 +77,6 @@ extension FfiConsentEntityType {
 	var fromFFI: EntryType {
 		switch self {
 		case .inboxId: return EntryType.inbox_id
-		case .address: return EntryType.address
 		case .conversationId: return EntryType.conversation_id
 		}
 	}
@@ -88,7 +87,6 @@ extension EntryType {
 		switch self {
 		case .conversation_id: return FfiConsentEntityType.conversationId
 		case .inbox_id: return FfiConsentEntityType.inboxId
-		case .address: return FfiConsentEntityType.address
 		}
 	}
 }

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -75,35 +75,35 @@ public struct Group: Identifiable, Equatable, Hashable {
 		return try await metadata().creatorInboxId() == client.inboxID
 	}
 
-	public func isAdmin(inboxId: String) throws -> Bool {
+	public func isAdmin(inboxId: InboxId) throws -> Bool {
 		return try ffiGroup.isAdmin(inboxId: inboxId)
 	}
 
-	public func isSuperAdmin(inboxId: String) throws -> Bool {
+	public func isSuperAdmin(inboxId: InboxId) throws -> Bool {
 		return try ffiGroup.isSuperAdmin(inboxId: inboxId)
 	}
 
-	public func addAdmin(inboxId: String) async throws {
+	public func addAdmin(inboxId: InboxId) async throws {
 		try await ffiGroup.addAdmin(inboxId: inboxId)
 	}
 
-	public func removeAdmin(inboxId: String) async throws {
+	public func removeAdmin(inboxId: InboxId) async throws {
 		try await ffiGroup.removeAdmin(inboxId: inboxId)
 	}
 
-	public func addSuperAdmin(inboxId: String) async throws {
+	public func addSuperAdmin(inboxId: InboxId) async throws {
 		try await ffiGroup.addSuperAdmin(inboxId: inboxId)
 	}
 
-	public func removeSuperAdmin(inboxId: String) async throws {
+	public func removeSuperAdmin(inboxId: InboxId) async throws {
 		try await ffiGroup.removeSuperAdmin(inboxId: inboxId)
 	}
 
-	public func listAdmins() throws -> [String] {
+	public func listAdmins() throws -> [InboxId] {
 		try ffiGroup.adminList()
 	}
 
-	public func listSuperAdmins() throws -> [String] {
+	public func listSuperAdmins() throws -> [InboxId] {
 		try ffiGroup.superAdminList()
 	}
 
@@ -112,11 +112,11 @@ public struct Group: Identifiable, Equatable, Hashable {
 			try permissions().policySet())
 	}
 
-	public func creatorInboxId() async throws -> String {
+	public func creatorInboxId() async throws -> InboxId {
 		return try await metadata().creatorInboxId()
 	}
 
-	public func addedByInboxId() throws -> String {
+	public func addedByInboxId() throws -> InboxId {
 		return try ffiGroup.addedByInboxId()
 	}
 
@@ -128,7 +128,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public var peerInboxIds: [String] {
+	public var peerInboxIds: [InboxId] {
 		get async throws {
 			var ids = try await members.map(\.inboxId)
 			if let index = ids.firstIndex(of: client.inboxID) {
@@ -142,20 +142,27 @@ public struct Group: Identifiable, Equatable, Hashable {
 		Date(millisecondsSinceEpoch: ffiGroup.createdAtNs())
 	}
 
-	public func addMembers(addresses: [String]) async throws {
-		try await ffiGroup.addMembers(accountAddresses: addresses)
-	}
-
-	public func removeMembers(addresses: [String]) async throws {
-		try await ffiGroup.removeMembers(accountAddresses: addresses)
-	}
-
-	public func addMembersByInboxId(inboxIds: [String]) async throws {
+	public func addMembers(inboxIds: [InboxId]) async throws {
+		try validateInboxIds(inboxIds)
 		try await ffiGroup.addMembersByInboxId(inboxIds: inboxIds)
 	}
 
-	public func removeMembersByInboxId(inboxIds: [String]) async throws {
+	public func removeMembers(inboxIds: [InboxId]) async throws {
+		try validateInboxIds(inboxIds)
 		try await ffiGroup.removeMembersByInboxId(inboxIds: inboxIds)
+	}
+
+	public func addMembersByIdentity(identities: [PublicIdentity]) async throws
+	{
+		try await ffiGroup.addMembers(
+			accountIdentifiers: identities.map { $0.ffiPrivate })
+	}
+
+	public func removeMembersByIdentity(identities: [PublicIdentity])
+		async throws
+	{
+		try await ffiGroup.removeMembers(
+			accountIdentifiers: identities.map { $0.ffiPrivate })
 	}
 
 	public func groupName() throws -> String {

--- a/Sources/XMTPiOS/Libxmtp/InboxState.swift
+++ b/Sources/XMTPiOS/Libxmtp/InboxState.swift
@@ -15,20 +15,20 @@ public struct InboxState {
 		self.ffiInboxState = ffiInboxState
 	}
 
-	public var inboxId: String {
+	public var inboxId: InboxId {
 		ffiInboxState.inboxId
 	}
 	
-	public var addresses: [String] {
-		ffiInboxState.accountAddresses
+	public var identities: [PublicIdentity] {
+		ffiInboxState.accountIdentities.map { PublicIdentity(ffiPrivate: $0) }
 	}
 	
 	public var installations: [Installation] {
 		ffiInboxState.installations.map { Installation(ffiInstallation: $0) }
 	}
 	
-	public var recoveryAddress: String {
-		ffiInboxState.recoveryAddress
+	public var recoveryIdentity: PublicIdentity {
+		PublicIdentity(ffiPrivate: ffiInboxState.recoveryIdentity)
 	}
 
 }

--- a/Sources/XMTPiOS/Libxmtp/Installation.swift
+++ b/Sources/XMTPiOS/Libxmtp/Installation.swift
@@ -24,4 +24,3 @@ public struct Installation {
 		return Date(timeIntervalSince1970: TimeInterval(timestampNs) / 1_000_000_000)
 	}
 }
-

--- a/Sources/XMTPiOS/Libxmtp/Member.swift
+++ b/Sources/XMTPiOS/Libxmtp/Member.swift
@@ -19,12 +19,12 @@ public struct Member {
         self.ffiGroupMember = ffiGroupMember
     }
 
-    public var inboxId: String {
+    public var inboxId: InboxId {
         ffiGroupMember.inboxId
     }
     
-    public var addresses: [String] {
-        ffiGroupMember.accountAddresses
+    public var identities: [PublicIdentity] {
+		ffiGroupMember.accountIdentifiers.map { PublicIdentity(ffiPrivate: $0) }
     }
 
 	public var permissionLevel: PermissionLevel {

--- a/Sources/XMTPiOS/Libxmtp/Message.swift
+++ b/Sources/XMTPiOS/Libxmtp/Message.swift
@@ -30,7 +30,7 @@ public struct Message: Identifiable {
 		ffiMessage.conversationId.toHex
 	}
 
-	public var senderInboxId: String {
+	public var senderInboxId: InboxId {
 		ffiMessage.senderInboxId
 	}
 

--- a/Sources/XMTPiOS/Libxmtp/PublicIdentity.swift
+++ b/Sources/XMTPiOS/Libxmtp/PublicIdentity.swift
@@ -33,7 +33,7 @@ public struct PublicIdentity {
 	}
 
 	public var identifier: String {
-		return ffiPrivate.identifier
+		return ffiPrivate.identifier.lowercased()
 	}
 
 	public var relyingPartner: String? {

--- a/Sources/XMTPiOS/Libxmtp/PublicIdentity.swift
+++ b/Sources/XMTPiOS/Libxmtp/PublicIdentity.swift
@@ -1,0 +1,64 @@
+//
+//  PublicIdentity.swift
+//  XMTPiOS
+//
+//  Created by Naomi Plasterer on 3/6/25.
+//
+
+import Foundation
+import LibXMTP
+
+public enum IdentityKind {
+	case ethereum
+	case passkey
+}
+
+public struct PublicIdentity {
+	let ffiPrivate: FfiIdentifier
+
+	public init(kind: IdentityKind, identifier: String, relyingPartner: String? = nil) {
+		self.ffiPrivate = FfiIdentifier(
+			identifier: identifier,
+			identifierKind: kind.toFfiPublicIdentifierKind(),
+			relyingPartner: relyingPartner
+		)
+	}
+
+	init(ffiPrivate: FfiIdentifier) {
+		self.ffiPrivate = ffiPrivate
+	}
+
+	public var kind: IdentityKind {
+		return ffiPrivate.identifierKind.toIdentityKind()
+	}
+
+	public var identifier: String {
+		return ffiPrivate.identifier
+	}
+
+	public var relyingPartner: String? {
+		return ffiPrivate.relyingPartner
+	}
+}
+
+extension IdentityKind {
+	public func toFfiPublicIdentifierKind() -> FfiIdentifierKind {
+		switch self {
+		case .ethereum:
+			return .ethereum
+		case .passkey:
+			return .passkey
+		}
+	}
+}
+
+extension FfiIdentifierKind {
+	public func toIdentityKind() -> IdentityKind {
+		switch self {
+		case .ethereum:
+			return .ethereum
+		case .passkey:
+			return .passkey
+		}
+	}
+}

--- a/Sources/XMTPiOS/Libxmtp/PublicIdentity.swift
+++ b/Sources/XMTPiOS/Libxmtp/PublicIdentity.swift
@@ -16,11 +16,10 @@ public enum IdentityKind {
 public struct PublicIdentity {
 	let ffiPrivate: FfiIdentifier
 
-	public init(kind: IdentityKind, identifier: String, relyingPartner: String? = nil) {
+	public init(kind: IdentityKind, identifier: String) {
 		self.ffiPrivate = FfiIdentifier(
 			identifier: identifier,
-			identifierKind: kind.toFfiPublicIdentifierKind(),
-			relyingPartner: relyingPartner
+			identifierKind: kind.toFfiPublicIdentifierKind()
 		)
 	}
 
@@ -34,10 +33,6 @@ public struct PublicIdentity {
 
 	public var identifier: String {
 		return ffiPrivate.identifier.lowercased()
-	}
-
-	public var relyingPartner: String? {
-		return ffiPrivate.relyingPartner
 	}
 }
 

--- a/Sources/XMTPiOS/Messages/PrivateKey.swift
+++ b/Sources/XMTPiOS/Messages/PrivateKey.swift
@@ -21,8 +21,8 @@ enum PrivateKeyError: Error, CustomStringConvertible {
 }
 
 extension PrivateKey: SigningKey {
-	public var address: String {
-		walletAddress
+	public var identity: PublicIdentity {
+		return PublicIdentity(kind: .ethereum, identifier: walletAddress)
 	}
 
 	public func sign(_ data: Data) async throws -> Signature {

--- a/Sources/XMTPiOS/PrivatePreferences.swift
+++ b/Sources/XMTPiOS/PrivatePreferences.swift
@@ -5,7 +5,7 @@ public enum ConsentState: String, Codable {
 	case allowed, denied, unknown
 }
 public enum EntryType: String, Codable {
-	case address, conversation_id, inbox_id
+	case conversation_id, inbox_id
 }
 public enum PreferenceType: String, Codable {
 	case hmac_keys
@@ -19,12 +19,6 @@ public struct ConsentRecord: Codable, Hashable {
 		self.consentType = consentType
 	}
 
-	static func address(_ address: String, type: ConsentState = .unknown)
-		-> ConsentRecord
-	{
-		ConsentRecord(value: address, entryType: .address, consentType: type)
-	}
-
 	static func conversationId(
 		conversationId: String, type: ConsentState = ConsentState.unknown
 	) -> ConsentRecord {
@@ -33,7 +27,7 @@ public struct ConsentRecord: Codable, Hashable {
 			consentType: type)
 	}
 
-	static func inboxId(_ inboxId: String, type: ConsentState = .unknown)
+	static func inboxId(_ inboxId: InboxId, type: ConsentState = .unknown)
 		-> ConsentRecord
 	{
 		ConsentRecord(
@@ -63,13 +57,6 @@ public actor PrivatePreferences {
 		try await ffiClient.setConsentStates(records: entries.map(\.toFFI))
 	}
 
-	public func addressState(address: String) async throws -> ConsentState {
-		return try await ffiClient.getConsentState(
-			entityType: .address,
-			entity: address
-		).fromFFI
-	}
-
 	public func conversationState(conversationId: String) async throws
 		-> ConsentState
 	{
@@ -79,7 +66,7 @@ public actor PrivatePreferences {
 		).fromFFI
 	}
 
-	public func inboxIdState(inboxId: String) async throws -> ConsentState {
+	public func inboxIdState(inboxId: InboxId) async throws -> ConsentState {
 		return try await ffiClient.getConsentState(
 			entityType: .inboxId,
 			entity: inboxId

--- a/Sources/XMTPiOS/SigningKey.swift
+++ b/Sources/XMTPiOS/SigningKey.swift
@@ -1,7 +1,7 @@
 import Foundation
 import LibXMTP
 
-public enum WalletType {
+public enum SignerType {
 	case EOA, SCW
 }
 
@@ -14,10 +14,10 @@ public enum WalletType {
 /// handle key management yourself.
 public protocol SigningKey {
 	/// A wallet address for this key
-	var address: String { get }
+	var identity: PublicIdentity { get }
 	
 	/// The wallet type if Smart Contract Wallet this should be type SCW. Default EOA
-	var type: WalletType { get }
+	var type: SignerType { get }
 	
 	/// The name of the chainId for example "1"
 	var chainId: Int64? { get }
@@ -37,8 +37,8 @@ public protocol SigningKey {
 }
 
 extension SigningKey {
-	public var type: WalletType {
-		return WalletType.EOA
+	public var type: SignerType {
+		return SignerType.EOA
 	}
 	
 	public var chainId: Int64? {

--- a/Sources/XMTPiOS/Util.swift
+++ b/Sources/XMTPiOS/Util.swift
@@ -5,8 +5,8 @@
 //  Created by Pat Nakajima on 11/20/22.
 //
 
-import Foundation
 import CryptoSwift
+import Foundation
 
 enum Util {
 	static func keccak256(_ data: Data) -> Data {
@@ -15,9 +15,21 @@ enum Util {
 }
 
 extension Array {
-    func chunks(_ chunkSize: Int) -> [[Element]] {
-        return stride(from: 0, to: self.count, by: chunkSize).map {
-            Array(self[$0..<Swift.min($0 + chunkSize, self.count)])
-        }
-    }
+	func chunks(_ chunkSize: Int) -> [[Element]] {
+		return stride(from: 0, to: self.count, by: chunkSize).map {
+			Array(self[$0..<Swift.min($0 + chunkSize, self.count)])
+		}
+	}
+}
+
+func validateInboxId(_ inboxId: String) throws {
+	if inboxId.lowercased().hasPrefix("0x") {
+		throw ClientError.invalidInboxId(inboxId)
+	}
+}
+
+func validateInboxIds(_ inboxIds: [String]) throws {
+	for inboxId in inboxIds {
+		try validateInboxId(inboxId)
+	}
 }

--- a/Tests/XMTPTests/AttachmentTests.swift
+++ b/Tests/XMTPTests/AttachmentTests.swift
@@ -13,7 +13,7 @@ class AttachmentsTests: XCTestCase {
 					.utf8))!
 		let fixtures = try await fixtures()
 		let conversation = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		Client.register(codec: AttachmentCodec())
 

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -46,7 +46,7 @@ class CodecTests: XCTestCase {
 
 		let alixClient = fixtures.alixClient!
 		let alixConversation = try await alixClient.conversations
-			.newConversation(with: fixtures.bo.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		Client.register(codec: NumberCodec())
 

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -68,7 +68,7 @@ class CodecTests: XCTestCase {
 
 		let alixClient = fixtures.alixClient!
 		let alixConversation = try await alixClient.conversations
-			.newConversation(with: fixtures.bo.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		Client.register(codec: NumberCodec())
 

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -11,10 +11,10 @@ class ConversationTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 
 		let sameDm = try await fixtures.boClient.conversations.findConversationByTopic(
 			topic: dm.topic)
@@ -29,9 +29,9 @@ class ConversationTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 
 		let convoCount = try await fixtures.boClient.conversations
@@ -56,9 +56,9 @@ class ConversationTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 
 		let convoCount = try await fixtures.boClient.conversations
@@ -87,9 +87,9 @@ class ConversationTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 
 		let convoCount = try await fixtures.boClient.conversations
@@ -118,11 +118,11 @@ class ConversationTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let group1 = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.caro.walletAddress])
+			with: [fixtures.caroClient.inboxID])
 		let group2 = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.caro.walletAddress])
+			with: [fixtures.caroClient.inboxID])
 
 		_ = try await dm.send(content: "Howdy")
 		_ = try await group2.send(content: "Howdy")
@@ -150,12 +150,12 @@ class ConversationTests: XCTestCase {
 		}
 
 		_ = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		_ = try await fixtures.boClient.conversations.newConversation(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 		_ = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 
 		await fulfillment(of: [expectation1], timeout: 3)
 	}
@@ -166,12 +166,12 @@ class ConversationTests: XCTestCase {
 		let expectation1 = XCTestExpectation(description: "got a conversation")
 		expectation1.expectedFulfillmentCount = 2
 		let convo = try await fixtures.boClient.conversations.newConversation(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		let dm = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 
 		try await fixtures.alixClient.conversations.sync()
 		Task(priority: .userInitiated) {
@@ -204,7 +204,7 @@ class ConversationTests: XCTestCase {
 				let newConversation = try await fixtures.alixClient
 					.conversations
 					.newConversation(
-						with: client.address
+						with: client.inboxID
 					)
 				conversations.append(newConversation)
 			} catch {
@@ -224,12 +224,12 @@ class ConversationTests: XCTestCase {
 
 		let alixGroup = try await fixtures.alixClient.conversations.newGroup(
 			with: [
-				fixtures.caroClient.address, fixtures.boClient.address,
+				fixtures.caroClient.inboxID, fixtures.boClient.inboxID,
 			])
 
 		let caroGroup2 = try await fixtures.caroClient.conversations.newGroup(
 			with: [
-				fixtures.alixClient.address, fixtures.boClient.address,
+				fixtures.alixClient.inboxID, fixtures.boClient.inboxID,
 			])
 
 		_ = try await fixtures.alixClient.conversations.syncAllConversations()
@@ -290,7 +290,7 @@ class ConversationTests: XCTestCase {
 					let spamMessage = "Davon Spam Message \(i)"
 					let group = try await fixtures.davonClient.conversations
 						.newGroup(
-							with: [fixtures.caroClient.address]
+							with: [fixtures.caroClient.inboxID]
 						)
 					_ = try await group.send(content: spamMessage)
 					print("Davon spam: \(spamMessage)")

--- a/Tests/XMTPTests/DmTests.swift
+++ b/Tests/XMTPTests/DmTests.swift
@@ -70,7 +70,7 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(peer, fixtures.alixClient.inboxID)
 	}
 
-	func testCannotStartGroupWithSelf() async throws {
+	func testCannotStartDmWithSelf() async throws {
 		let fixtures = try await fixtures()
 
 		await assertThrowsAsyncError(
@@ -78,8 +78,23 @@ class DmTests: XCTestCase {
 				with: fixtures.alixClient.inboxID)
 		)
 	}
+	
+	func testCannotStartDmWithAddressWhenExpectingInboxId() async throws {
+		let fixtures = try await fixtures()
 
-	func testCannotStartGroupWithNonRegisteredIdentity() async throws {
+		do {
+			_ = try await fixtures.boClient.conversations.newConversation(with: fixtures.alix.walletAddress)
+			XCTFail("Did not throw error")
+		} catch {
+			if case let ClientError.invalidInboxId(message) = error {
+				XCTAssertEqual(message.lowercased(), fixtures.alix.walletAddress.lowercased())
+			} else {
+				XCTFail("Did not throw correct error")
+			}
+		}
+	}
+
+	func testCannotStartDmWithNonRegisteredIdentity() async throws {
 		let fixtures = try await fixtures()
 		let nonRegistered = try PrivateKey.generate()
 

--- a/Tests/XMTPTests/DmTests.swift
+++ b/Tests/XMTPTests/DmTests.swift
@@ -11,7 +11,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 
 		let caroDm = try await fixtures.boClient.conversations.findDmByInboxId(
 			inboxId: fixtures.caroClient.inboxID)
@@ -26,12 +26,10 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 
-		let caroDm = try await fixtures.boClient.conversations.findDmByAddress(
-			address: fixtures.caroClient.address)
-		let alixDm = try await fixtures.boClient.conversations.findDmByAddress(
-			address: fixtures.alixClient.address)
+		let caroDm = try await fixtures.boClient.conversations.findDmByIdentity(publicIdentity: fixtures.caro.identity)
+		let alixDm = try await fixtures.boClient.conversations.findDmByIdentity(publicIdentity: fixtures.alix.identity)
 
 		XCTAssertNil(alixDm)
 		XCTAssertEqual(caroDm?.id, dm.id)
@@ -41,22 +39,22 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let convo1 = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		try await fixtures.alixClient.conversations.sync()
 		let sameConvo1 = try await fixtures.alixClient.conversations
-			.findOrCreateDm(with: fixtures.bo.walletAddress)
+			.findOrCreateDm(with: fixtures.boClient.inboxID)
 		XCTAssertEqual(convo1.id, sameConvo1.id)
 	}
 
-	func testCanCreateADmWithInboxId() async throws {
+	func testCanCreateADmWithIdentity() async throws {
 		let fixtures = try await fixtures()
 
 		let convo1 = try await fixtures.boClient.conversations
-			.findOrCreateDmWithInboxId(
-				with: fixtures.alixClient.inboxID)
+			.findOrCreateDmWithIdentity(
+				with: fixtures.alix.identity)
 		try await fixtures.alixClient.conversations.sync()
 		let sameConvo1 = try await fixtures.alixClient.conversations
-			.findOrCreateDmWithInboxId(with: fixtures.boClient.inboxID)
+			.newConversationWithIdentity(with: fixtures.bo.identity)
 		XCTAssertEqual(convo1.id, sameConvo1.id)
 	}
 
@@ -64,7 +62,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		let members = try await dm.members
 		XCTAssertEqual(members.count, 2)
 
@@ -77,7 +75,7 @@ class DmTests: XCTestCase {
 
 		await assertThrowsAsyncError(
 			try await fixtures.alixClient.conversations.findOrCreateDm(
-				with: fixtures.alix.address)
+				with: fixtures.alixClient.inboxID)
 		)
 	}
 
@@ -86,8 +84,8 @@ class DmTests: XCTestCase {
 		let nonRegistered = try PrivateKey.generate()
 
 		await assertThrowsAsyncError(
-			try await fixtures.alixClient.conversations.findOrCreateDm(
-				with: nonRegistered.address)
+			try await fixtures.alixClient.conversations.findOrCreateDmWithIdentity(
+				with: nonRegistered.identity)
 		)
 	}
 
@@ -95,7 +93,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		_ = try await dm.send(content: "howdy")
 		_ = try await dm.send(content: "gm")
 		try await dm.sync()
@@ -110,11 +108,11 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let dm2 = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 
 		let convoCount = try await fixtures.boClient.conversations
@@ -143,11 +141,11 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let dm2 = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		let group2 = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.caro.walletAddress])
+			with: [fixtures.caroClient.inboxID])
 
 		_ = try await dm.send(content: "Howdy")
 		_ = try await dm2.send(content: "Howdy")
@@ -164,7 +162,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		_ = try await dm.send(content: "howdy")
 		let messageId = try await dm.send(content: "gm")
 		try await dm.sync()
@@ -189,7 +187,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		try await fixtures.alixClient.conversations.sync()
 
 		let expectation1 = XCTestExpectation(description: "got a message")
@@ -221,10 +219,10 @@ class DmTests: XCTestCase {
 		}
 
 		_ = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		_ = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 
 		await fulfillment(of: [expectation1], timeout: 3)
 	}
@@ -233,7 +231,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 		try await fixtures.alixClient.conversations.sync()
 
 		let expectation1 = XCTestExpectation(description: "got a message")
@@ -249,7 +247,7 @@ class DmTests: XCTestCase {
 
 		_ = try await dm.send(content: "hi")
 		let caroDm = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alixClient.address)
+			with: fixtures.alixClient.inboxID)
 		_ = try await caroDm.send(content: "hi")
 
 		await fulfillment(of: [expectation1], timeout: 3)
@@ -259,7 +257,7 @@ class DmTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress)
+			with: fixtures.alixClient.inboxID)
 
 		let isDm = try await fixtures.boClient.preferences
 			.conversationState(conversationId: dm.id)
@@ -294,7 +292,7 @@ class DmTests: XCTestCase {
 
 		// Create group with disappearing messages enabled
 		let boDm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.alix.walletAddress,
+			with: fixtures.alixClient.inboxID,
 			disappearingMessageSettings: initialSettings
 		)
 		_ = try await boDm.send(content: "howdy")

--- a/Tests/XMTPTests/GroupPermissionsTests.swift
+++ b/Tests/XMTPTests/GroupPermissionsTests.swift
@@ -30,7 +30,7 @@ class GroupPermissionTests: XCTestCase {
 	func testGroupCreatedWithCorrectAdminList() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address])
+			with: [fixtures.alixClient.inboxID])
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
 			.listGroups().first!
@@ -39,7 +39,7 @@ class GroupPermissionTests: XCTestCase {
 			try boGroup.isAdmin(inboxId: fixtures.boClient.inboxID))
 		XCTAssertTrue(
 			try boGroup.isSuperAdmin(inboxId: fixtures.boClient.inboxID))
-        let isAlixGroupCreator = try await alixGroup.isCreator()
+		let isAlixGroupCreator = try await alixGroup.isCreator()
 		XCTAssertFalse(isAlixGroupCreator)
 		XCTAssertFalse(
 			try alixGroup.isAdmin(inboxId: fixtures.alixClient.inboxID))
@@ -58,7 +58,7 @@ class GroupPermissionTests: XCTestCase {
 	func testGroupCanUpdateAdminList() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address, fixtures.caro.address],
+			with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
 			permissions: .adminOnly)
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
@@ -68,8 +68,8 @@ class GroupPermissionTests: XCTestCase {
 			try boGroup.isAdmin(inboxId: fixtures.boClient.inboxID))
 		XCTAssertTrue(
 			try boGroup.isSuperAdmin(inboxId: fixtures.boClient.inboxID))
-        let isAlixGroupCreator = try await alixGroup.isCreator()
-        XCTAssertFalse(isAlixGroupCreator)
+		let isAlixGroupCreator = try await alixGroup.isCreator()
+		XCTAssertFalse(isAlixGroupCreator)
 		XCTAssertFalse(
 			try alixGroup.isAdmin(inboxId: fixtures.alixClient.inboxID))
 		XCTAssertFalse(
@@ -136,7 +136,7 @@ class GroupPermissionTests: XCTestCase {
 	func testGroupCanUpdateSuperAdminList() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address, fixtures.caro.address],
+			with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
 			permissions: .adminOnly)
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
@@ -174,7 +174,7 @@ class GroupPermissionTests: XCTestCase {
 	func testGroupMembersAndPermissionLevel() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address, fixtures.caro.address],
+			with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
 			permissions: .adminOnly)
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
@@ -236,7 +236,7 @@ class GroupPermissionTests: XCTestCase {
 	func testCanCommitAfterInvalidPermissionsCommit() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address, fixtures.caro.address],
+			with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
 			permissions: .allMembers)
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
@@ -265,7 +265,7 @@ class GroupPermissionTests: XCTestCase {
 	func testCanUpdatePermissions() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address, fixtures.caro.address],
+			with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
 			permissions: .adminOnly
 		)
 		try await fixtures.alixClient.conversations.sync()
@@ -315,11 +315,13 @@ class GroupPermissionTests: XCTestCase {
 			updateGroupNamePolicy: PermissionOption.admin,
 			updateGroupDescriptionPolicy: PermissionOption.allow,
 			updateGroupImagePolicy: PermissionOption.admin,
-            updateMessageDisappearingPolicy: PermissionOption.allow
+			updateMessageDisappearingPolicy: PermissionOption.allow
 		)
 		_ = try await fixtures.boClient.conversations
 			.newGroupCustomPermissions(
-				with: [fixtures.alix.address, fixtures.caro.address],
+				with: [
+					fixtures.alixClient.inboxID, fixtures.caroClient.inboxID,
+				],
 				permissionPolicySet: permissionPolicySet
 			)
 
@@ -342,7 +344,7 @@ class GroupPermissionTests: XCTestCase {
 		XCTAssert(
 			alixPermissionSet.updateGroupImagePolicy == PermissionOption.admin)
 	}
-	
+
 	func testCanCreateGroupWithInboxIdCustomPermissions() async throws {
 		let fixtures = try await fixtures()
 		let permissionPolicySet = PermissionPolicySet(
@@ -353,11 +355,11 @@ class GroupPermissionTests: XCTestCase {
 			updateGroupNamePolicy: PermissionOption.admin,
 			updateGroupDescriptionPolicy: PermissionOption.allow,
 			updateGroupImagePolicy: PermissionOption.admin,
-            updateMessageDisappearingPolicy: PermissionOption.allow
+			updateMessageDisappearingPolicy: PermissionOption.allow
 		)
 		_ = try await fixtures.boClient.conversations
-			.newGroupCustomPermissionsWithInboxIds(
-				with: [fixtures.alixClient.inboxID, fixtures.caroClient.inboxID],
+			.newGroupCustomPermissionsWithIdentities(
+				with: [fixtures.alix.identity, fixtures.caro.identity],
 				permissionPolicySet: permissionPolicySet
 			)
 
@@ -392,12 +394,15 @@ class GroupPermissionTests: XCTestCase {
 			updateGroupNamePolicy: PermissionOption.admin,
 			updateGroupDescriptionPolicy: PermissionOption.allow,
 			updateGroupImagePolicy: PermissionOption.admin,
-            updateMessageDisappearingPolicy: PermissionOption.allow
+			updateMessageDisappearingPolicy: PermissionOption.allow
 		)
 		await assertThrowsAsyncError(
 			try await fixtures.boClient.conversations
 				.newGroupCustomPermissions(
-					with: [fixtures.alix.address, fixtures.caro.address],
+					with: [
+						fixtures.alixClient.inboxID,
+						fixtures.caroClient.inboxID,
+					],
 					permissionPolicySet: permissionPolicySetInvalid
 				)
 		)

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -244,12 +244,12 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let _ = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 		let _ = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.caro.walletAddress
+			fixtures.caroClient.inboxID
 		])
 
 		let convoCount = try await fixtures.boClient.conversations
@@ -278,11 +278,11 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
-			with: fixtures.caro.walletAddress)
+			with: fixtures.caroClient.inboxID)
 		let group1 = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.caro.walletAddress])
+			with: [fixtures.caroClient.inboxID])
 		let group2 = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.caro.walletAddress])
+			with: [fixtures.caroClient.inboxID])
 
 		_ = try await dm.send(content: "Howdy")
 		_ = try await group2.send(content: "Howdy")
@@ -414,10 +414,7 @@ class GroupTests: XCTestCase {
 				fixtures.caroClient.inboxID,
 			].sorted(), members)
 
-		try await group.removeMembersByIdentity(identities: [
-			PublicIdentity(
-				kind: .ethereum, identifier: fixtures.caroClient.inboxID)
-		])
+		try await group.removeMembersByIdentity(identities: [fixtures.caro.identity])
 
 		try await group.sync()
 
@@ -520,16 +517,6 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(alixAddress, whoAddedbo)
 	}
 
-	func testCannotStartGroupWithSelf() async throws {
-		let fixtures = try await fixtures()
-
-		await assertThrowsAsyncError(
-			try await fixtures.alixClient.conversations.newGroup(with: [
-				fixtures.alixClient.inboxID
-			])
-		)
-	}
-
 	func testCanStartEmptyGroup() async throws {
 		let fixtures = try await fixtures()
 		let group = try await fixtures.alixClient.conversations.newGroup(
@@ -557,7 +544,7 @@ class GroupTests: XCTestCase {
 	func testGroupStartsWithAllowedState() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.walletAddress])
+			with: [fixtures.alixClient.inboxID])
 
 		_ = try await boGroup.send(content: "howdy")
 		_ = try await boGroup.send(content: "gm")
@@ -1074,7 +1061,7 @@ class GroupTests: XCTestCase {
 
 		// Create group with disappearing messages enabled
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.walletAddress],
+			with: [fixtures.alixClient.inboxID],
 			disappearingMessageSettings: initialSettings
 		)
 		_ = try await boGroup.send(content: "howdy")

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -32,14 +32,14 @@ class GroupTests: XCTestCase {
 	func testCanCreateAGroupWithDefaultPermissions() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address])
+			with: [fixtures.alixClient.inboxID])
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
 			.listGroups().first!
 		XCTAssert(!boGroup.id.isEmpty)
 		XCTAssert(!alixGroup.id.isEmpty)
 
-		try await alixGroup.addMembers(addresses: [fixtures.caro.address])
+		try await alixGroup.addMembers(inboxIds: [fixtures.caroClient.inboxID])
 		try await boGroup.sync()
 
 		var alixMembersCount = try await alixGroup.members.count
@@ -49,7 +49,9 @@ class GroupTests: XCTestCase {
 
 		try await boGroup.addAdmin(inboxId: fixtures.alixClient.inboxID)
 
-		try await alixGroup.removeMembers(addresses: [fixtures.caro.address])
+		try await alixGroup.removeMembers(inboxIds: [
+			fixtures.caroClient.inboxID
+		])
 		try await boGroup.sync()
 
 		alixMembersCount = try await alixGroup.members.count
@@ -57,7 +59,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(alixMembersCount, 2)
 		XCTAssertEqual(boMembersCount, 2)
 
-		try await boGroup.addMembers(addresses: [fixtures.caro.address])
+		try await boGroup.addMembers(inboxIds: [fixtures.caroClient.inboxID])
 		try await alixGroup.sync()
 
 		try await boGroup.removeAdmin(inboxId: fixtures.alixClient.inboxID)
@@ -83,18 +85,22 @@ class GroupTests: XCTestCase {
 			try !alixGroup.isSuperAdmin(inboxId: fixtures.alixClient.inboxID))
 	}
 
-	func testCanCreateAGroupWithInboxIdDefaultPermissions() async throws {
+	func testCanCreateAGroupWithIdentityDefaultPermissions() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations
-			.newGroupWithInboxIds(
-				with: [fixtures.alixClient.inboxID])
+			.newGroupWithIdentities(
+				with: [
+					PublicIdentity(
+						kind: .ethereum, identifier: fixtures.alix.walletAddress
+					)
+				])
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
 			.listGroups().first!
 		XCTAssert(!boGroup.id.isEmpty)
 		XCTAssert(!alixGroup.id.isEmpty)
 
-		try await alixGroup.addMembers(addresses: [fixtures.caro.address])
+		try await alixGroup.addMembers(inboxIds: [fixtures.caroClient.inboxID])
 		try await boGroup.sync()
 
 		var alixMembersCount = try await alixGroup.members.count
@@ -104,7 +110,9 @@ class GroupTests: XCTestCase {
 
 		try await boGroup.addAdmin(inboxId: fixtures.alixClient.inboxID)
 
-		try await alixGroup.removeMembers(addresses: [fixtures.caro.address])
+		try await alixGroup.removeMembers(inboxIds: [
+			fixtures.caroClient.inboxID
+		])
 		try await boGroup.sync()
 
 		alixMembersCount = try await alixGroup.members.count
@@ -112,7 +120,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(alixMembersCount, 2)
 		XCTAssertEqual(boMembersCount, 2)
 
-		try await boGroup.addMembers(addresses: [fixtures.caro.address])
+		try await boGroup.addMembers(inboxIds: [fixtures.caroClient.inboxID])
 		try await alixGroup.sync()
 
 		try await boGroup.removeAdmin(inboxId: fixtures.alixClient.inboxID)
@@ -141,7 +149,7 @@ class GroupTests: XCTestCase {
 	func testCanCreateAGroupWithAdminPermissions() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address],
+			with: [fixtures.alixClient.inboxID],
 			permissions: GroupPermissionPreconfiguration.adminOnly)
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroup = try await fixtures.alixClient.conversations
@@ -156,7 +164,7 @@ class GroupTests: XCTestCase {
 			.conversationState(conversationId: alixGroup.id)
 		XCTAssertEqual(alixConsentResult, ConsentState.unknown)
 
-		try await boGroup.addMembers(addresses: [fixtures.caro.address])
+		try await boGroup.addMembers(inboxIds: [fixtures.caroClient.inboxID])
 		try await alixGroup.sync()
 
 		var alixMembersCount = try await alixGroup.members.count
@@ -165,8 +173,8 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(boMembersCount, 3)
 
 		await assertThrowsAsyncError(
-			try await alixGroup.removeMembers(addresses: [
-				fixtures.caro.address
+			try await alixGroup.removeMembers(inboxIds: [
+				fixtures.caroClient.inboxID
 			])
 		)
 		try await boGroup.sync()
@@ -176,7 +184,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(alixMembersCount, 3)
 		XCTAssertEqual(boMembersCount, 3)
 
-		try await boGroup.removeMembers(addresses: [fixtures.caro.address])
+		try await boGroup.removeMembers(inboxIds: [fixtures.caroClient.inboxID])
 		try await alixGroup.sync()
 
 		alixMembersCount = try await alixGroup.members.count
@@ -185,7 +193,9 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(boMembersCount, 2)
 
 		await assertThrowsAsyncError(
-			try await alixGroup.addMembers(addresses: [fixtures.caro.address])
+			try await alixGroup.addMembers(inboxIds: [
+				fixtures.caroClient.inboxID
+			])
 		)
 		try await boGroup.sync()
 
@@ -211,12 +221,12 @@ class GroupTests: XCTestCase {
 	func testCanListGroups() async throws {
 		let fixtures = try await fixtures()
 		_ = try await fixtures.alixClient.conversations.newGroup(with: [
-			fixtures.bo.address
+			fixtures.boClient.inboxID
 		])
 		_ = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.bo.address)
+			with: fixtures.boClient.inboxID)
 		_ = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 
 		try await fixtures.alixClient.conversations.sync()
 		let alixGroupCount = try await fixtures.alixClient.conversations
@@ -289,7 +299,7 @@ class GroupTests: XCTestCase {
 	func testCanListGroupMembers() async throws {
 		let fixtures = try await fixtures()
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address])
+			with: [fixtures.boClient.inboxID])
 
 		try await group.sync()
 		let members = try await group.members.map(\.inboxId).sorted()
@@ -305,9 +315,9 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address])
+			with: [fixtures.boClient.inboxID])
 
-		try await group.addMembers(addresses: [fixtures.caro.address])
+		try await group.addMembers(inboxIds: [fixtures.caroClient.inboxID])
 
 		try await group.sync()
 		let members = try await group.members.map(\.inboxId).sorted()
@@ -326,14 +336,15 @@ class GroupTests: XCTestCase {
 			[fixtures.caroClient.inboxID])
 	}
 
-	func testCanAddGroupMembersByInboxId() async throws {
+	func testCanAddGroupMembersByIdentity() async throws {
 		let fixtures = try await fixtures()
 		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address])
+			with: [fixtures.boClient.inboxID])
 
-		try await group.addMembersByInboxId(inboxIds: [
-			fixtures.caroClient.inboxID
+		try await group.addMembersByIdentity(identities: [
+			PublicIdentity(
+				kind: .ethereum, identifier: fixtures.caro.walletAddress)
 		])
 
 		try await group.sync()
@@ -357,7 +368,7 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address, fixtures.caro.address])
+			with: [fixtures.boClient.inboxID, fixtures.caroClient.inboxID])
 
 		try await group.sync()
 		let members = try await group.members.map(\.inboxId).sorted()
@@ -369,7 +380,7 @@ class GroupTests: XCTestCase {
 				fixtures.caroClient.inboxID,
 			].sorted(), members)
 
-		try await group.removeMembers(addresses: [fixtures.caro.address])
+		try await group.removeMembers(inboxIds: [fixtures.caroClient.inboxID])
 
 		try await group.sync()
 
@@ -387,11 +398,11 @@ class GroupTests: XCTestCase {
 			[fixtures.caroClient.inboxID])
 	}
 
-	func testCanRemoveMembersByInboxId() async throws {
+	func testCanRemoveMembersByIdentity() async throws {
 		let fixtures = try await fixtures()
 		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address, fixtures.caro.address])
+			with: [fixtures.boClient.inboxID, fixtures.caroClient.inboxID])
 
 		try await group.sync()
 		let members = try await group.members.map(\.inboxId).sorted()
@@ -403,8 +414,9 @@ class GroupTests: XCTestCase {
 				fixtures.caroClient.inboxID,
 			].sorted(), members)
 
-		try await group.removeMembersByInboxId(inboxIds: [
-			fixtures.caroClient.inboxID
+		try await group.removeMembersByIdentity(identities: [
+			PublicIdentity(
+				kind: .ethereum, identifier: fixtures.caroClient.inboxID)
 		])
 
 		try await group.sync()
@@ -427,17 +439,22 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 		let notOnNetwork = try PrivateKey.generate()
 		let canMessage = try await fixtures.alixClient.canMessage(
-			address: fixtures.boClient.address)
+			identities: fixtures.bo.identity)
 		let cannotMessage = try await fixtures.alixClient.canMessage(
-			addresses: [notOnNetwork.address, fixtures.boClient.address])
+			identities: [
+				PublicIdentity(
+					kind: .ethereum, identifier: notOnNetwork.walletAddress),
+				fixtures.bo.identity,
+			])
 		XCTAssert(canMessage)
-		XCTAssert(!(cannotMessage[notOnNetwork.address.lowercased()] ?? true))
+		XCTAssert(
+			!(cannotMessage[notOnNetwork.walletAddress.lowercased()] ?? true))
 	}
 
 	func testIsActive() async throws {
 		let fixtures = try await fixtures()
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address, fixtures.caro.address])
+			with: [fixtures.boClient.inboxID, fixtures.caroClient.inboxID])
 
 		try await group.sync()
 		let members = try await group.members.map(\.inboxId).sorted()
@@ -460,7 +477,7 @@ class GroupTests: XCTestCase {
 		XCTAssert(isalixActive)
 		XCTAssert(iscaroActive)
 
-		try await group.removeMembers(addresses: [fixtures.caro.address])
+		try await group.removeMembers(inboxIds: [fixtures.caroClient.inboxID])
 
 		try await group.sync()
 
@@ -486,7 +503,7 @@ class GroupTests: XCTestCase {
 
 		// alix creates a group and adds bo to the group
 		_ = try await fixtures.alixClient.conversations.newGroup(with: [
-			fixtures.bo.address
+			fixtures.boClient.inboxID
 		])
 
 		// bo syncs groups - this will decrypt the Welcome and then
@@ -508,7 +525,7 @@ class GroupTests: XCTestCase {
 
 		await assertThrowsAsyncError(
 			try await fixtures.alixClient.conversations.newGroup(with: [
-				fixtures.alix.address
+				fixtures.alixClient.inboxID
 			])
 		)
 	}
@@ -526,21 +543,15 @@ class GroupTests: XCTestCase {
 		let nonRegistered = try PrivateKey.generate()
 
 		do {
-			_ = try await fixtures.alixClient.conversations.newGroup(with: [
-				nonRegistered.address
-			])
+			_ = try await fixtures.alixClient.conversations
+				.newGroupWithIdentities(with: [
+					PublicIdentity(
+						kind: .ethereum, identifier: nonRegistered.walletAddress
+					)
+				])
 
 			XCTFail("did not throw error")
-		} catch {
-			if case let ConversationError.memberNotRegistered(addresses) = error
-			{
-				XCTAssertEqual(
-					[nonRegistered.address.lowercased()],
-					addresses.map { $0.lowercased() })
-			} else {
-				XCTFail("did not throw correct error")
-			}
-		}
+		} catch {}
 	}
 
 	func testGroupStartsWithAllowedState() async throws {
@@ -560,7 +571,7 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 		Client.register(codec: GroupUpdatedCodec())
 		let alixGroup = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address])
+			with: [fixtures.boClient.inboxID])
 		let membershipChange = GroupUpdated()
 
 		try await fixtures.boClient.conversations.sync()
@@ -592,7 +603,7 @@ class GroupTests: XCTestCase {
 	func testCanListGroupMessages() async throws {
 		let fixtures = try await fixtures()
 		let alixGroup = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address])
+			with: [fixtures.boClient.inboxID])
 		_ = try await alixGroup.send(content: "howdy")
 		_ = try await alixGroup.send(content: "gm")
 
@@ -638,7 +649,7 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 		Client.register(codec: GroupUpdatedCodec())
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		let membershipChange = GroupUpdated()
 		let expectation1 = XCTestExpectation(description: "got a message")
@@ -673,10 +684,10 @@ class GroupTests: XCTestCase {
 		}
 
 		_ = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		_ = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 
 		await fulfillment(of: [expectation1], timeout: 3)
 	}
@@ -704,7 +715,7 @@ class GroupTests: XCTestCase {
 		}
 
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		_ = try await group.send(content: "hello")
 
@@ -726,7 +737,7 @@ class GroupTests: XCTestCase {
 		}
 
 		let alixGroup = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address])
+			with: [fixtures.boClient.inboxID])
 		try await alixGroup.updateGroupName(groupName: "hello")
 		_ = try await alixGroup.send(content: "hello1")
 
@@ -781,10 +792,10 @@ class GroupTests: XCTestCase {
 		let expectation1 = XCTestExpectation(description: "got a conversation")
 
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		let dm = try await fixtures.caroClient.conversations.findOrCreateDm(
-			with: fixtures.alix.address)
+			with: fixtures.alixClient.inboxID)
 		try await fixtures.alixClient.conversations.sync()
 		Task(priority: .userInitiated) {
 			for try await _ in await fixtures.alixClient.conversations
@@ -803,7 +814,7 @@ class GroupTests: XCTestCase {
 	func testCanUpdateGroupMetadata() async throws {
 		let fixtures = try await fixtures()
 		let group = try await fixtures.alixClient.conversations.newGroup(
-			with: [fixtures.bo.address], name: "Start Name",
+			with: [fixtures.boClient.inboxID], name: "Start Name",
 			imageUrlSquare: "starturl.com")
 
 		var groupName = try group.groupName()
@@ -822,7 +833,8 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(groupImageUrlSquare, "newurl.com")
 
 		try await fixtures.boClient.conversations.sync()
-		let boGroup = try await fixtures.boClient.conversations.findGroup(groupId: group.id)!
+		let boGroup = try await fixtures.boClient.conversations.findGroup(
+			groupId: group.id)!
 		groupName = try boGroup.groupName()
 		XCTAssertEqual(groupName, "Start Name")
 
@@ -837,7 +849,7 @@ class GroupTests: XCTestCase {
 	func testGroupConsent() async throws {
 		let fixtures = try await fixtures()
 		let group = try await fixtures.boClient.conversations.newGroup(with: [
-			fixtures.alix.address
+			fixtures.alixClient.inboxID
 		])
 		XCTAssertEqual(try group.consentState(), .allowed)
 
@@ -854,7 +866,7 @@ class GroupTests: XCTestCase {
 	func testCanAllowAndDenyInboxId() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address])
+			with: [fixtures.alixClient.inboxID])
 		let inboxState = try await fixtures.boClient.preferences
 			.inboxIdState(
 				inboxId: fixtures.alixClient.inboxID)
@@ -891,29 +903,16 @@ class GroupTests: XCTestCase {
 			.inboxIdState(
 				inboxId: fixtures.alixClient.inboxID)
 		XCTAssertEqual(inboxState3, .denied)
-
-		try await fixtures.boClient.preferences.setConsentState(
-			entries: [
-				ConsentRecord(
-					value: fixtures.alixClient.address, entryType: .address,
-					consentType: .allowed)
-			])
-		let inboxState4 = try await fixtures.boClient.preferences
-			.inboxIdState(
-				inboxId: fixtures.alixClient.inboxID)
-		XCTAssertEqual(inboxState4, .allowed)
-		let addressState = try await fixtures.boClient.preferences
-			.addressState(address: fixtures.alixClient.address)
-		XCTAssertEqual(addressState, .allowed)
 	}
 
 	func testCanFetchGroupById() async throws {
 		let fixtures = try await fixtures()
 
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address])
+			with: [fixtures.alixClient.inboxID])
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations.findGroup(groupId: boGroup.id)
+		let alixGroup = try await fixtures.alixClient.conversations.findGroup(
+			groupId: boGroup.id)
 
 		XCTAssertEqual(alixGroup?.id, boGroup.id)
 	}
@@ -922,13 +921,15 @@ class GroupTests: XCTestCase {
 		let fixtures = try await fixtures()
 
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address])
+			with: [fixtures.alixClient.inboxID])
 
 		let boMessageId = try await boGroup.send(content: "Hello")
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations.findGroup(groupId: boGroup.id)
+		let alixGroup = try await fixtures.alixClient.conversations.findGroup(
+			groupId: boGroup.id)
 		try await alixGroup?.sync()
-		_ = try await fixtures.alixClient.conversations.findMessage(messageId: boMessageId)
+		_ = try await fixtures.alixClient.conversations.findMessage(
+			messageId: boMessageId)
 
 		XCTAssertEqual(alixGroup?.id, boGroup.id)
 	}
@@ -936,10 +937,11 @@ class GroupTests: XCTestCase {
 	func testUnpublishedMessages() async throws {
 		let fixtures = try await fixtures()
 		let boGroup = try await fixtures.boClient.conversations.newGroup(
-			with: [fixtures.alix.address])
+			with: [fixtures.alixClient.inboxID])
 
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations.findGroup(groupId: boGroup.id)!
+		let alixGroup = try await fixtures.alixClient.conversations.findGroup(
+			groupId: boGroup.id)!
 		let isGroupAllowed = try await fixtures.alixClient.preferences
 			.conversationState(conversationId: boGroup.id)
 		XCTAssertEqual(isGroupAllowed, .unknown)
@@ -985,11 +987,12 @@ class GroupTests: XCTestCase {
 
 		for _ in 0..<100 {
 			let group = try await fixtures.alixClient.conversations.newGroup(
-				with: [fixtures.bo.address])
+				with: [fixtures.boClient.inboxID])
 			groups.append(group)
 		}
 		try await fixtures.boClient.conversations.sync()
-		let boGroup = try await fixtures.boClient.conversations.findGroup(groupId: groups[0].id)
+		let boGroup = try await fixtures.boClient.conversations.findGroup(
+			groupId: groups[0].id)
 		_ = try await groups[0].send(content: "hi")
 		let messageCount = try await boGroup!.messages().count
 		XCTAssertEqual(messageCount, 0)
@@ -1014,8 +1017,8 @@ class GroupTests: XCTestCase {
 				XCTFail("failed converting conversation to group")
 				return
 			}
-			try await alixGroup.removeMembers(addresses: [
-				fixtures.boClient.address
+			try await alixGroup.removeMembers(inboxIds: [
+				fixtures.boClient.inboxID
 			])
 		}
 
@@ -1036,7 +1039,7 @@ class GroupTests: XCTestCase {
 
 		for _ in 0..<100 {
 			let group = try await fixtures.alixClient.conversations.newGroup(
-				with: [fixtures.bo.address])
+				with: [fixtures.boClient.inboxID])
 			groups.append(group)
 		}
 		do {

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -335,6 +335,45 @@ class GroupTests: XCTestCase {
 			groupChangedMessage.addedInboxes.map(\.inboxID),
 			[fixtures.caroClient.inboxID])
 	}
+	
+	func testCannotStartGroupOrAddMembersWithAddressWhenExpectingInboxId() async throws {
+		let fixtures = try await fixtures()
+
+		do {
+			_ = try await fixtures.boClient.conversations.newGroup(with: [fixtures.alix.walletAddress])
+			XCTFail("Did not throw error")
+		} catch {
+			if case let ClientError.invalidInboxId(message) = error {
+				XCTAssertEqual(message.lowercased(), fixtures.alix.walletAddress.lowercased())
+			} else {
+				XCTFail("Did not throw correct error")
+			}
+		}
+
+		let group = try await fixtures.boClient.conversations.newGroup(with: [fixtures.alixClient.inboxID])
+
+		do {
+			_ = try await group.addMembers(inboxIds: [fixtures.caro.walletAddress])
+			XCTFail("Did not throw error")
+		} catch {
+			if case let ClientError.invalidInboxId(message) = error {
+				XCTAssertEqual(message.lowercased(), fixtures.caro.walletAddress.lowercased())
+			} else {
+				XCTFail("Did not throw correct error")
+			}
+		}
+
+		do {
+			_ = try await group.removeMembers(inboxIds: [fixtures.alix.walletAddress])
+			XCTFail("Did not throw error")
+		} catch {
+			if case let ClientError.invalidInboxId(message) = error {
+				XCTAssertEqual(message.lowercased(), fixtures.alix.walletAddress.lowercased())
+			} else {
+				XCTFail("Did not throw correct error")
+			}
+		}
+	}
 
 	func testCanAddGroupMembersByIdentity() async throws {
 		let fixtures = try await fixtures()

--- a/Tests/XMTPTests/HistorySyncTests.swift
+++ b/Tests/XMTPTests/HistorySyncTests.swift
@@ -28,7 +28,7 @@ class HistorySyncTests: XCTestCase {
 		)
 
 		let group = try await alixClient.conversations.newGroup(
-			with: [fixtures.bo.walletAddress])
+			with: [fixtures.boClient.inboxID])
 		try await group.updateConsentState(state: .denied)
 		XCTAssertEqual(try group.consentState(), .denied)
 
@@ -89,7 +89,7 @@ class HistorySyncTests: XCTestCase {
 		)
 
 		let group = try await alixClient.conversations.newGroup(
-			with: [fixtures.bo.walletAddress])
+			with: [fixtures.boClient.inboxID])
 		let messageCount = try await group.messages().count
 		XCTAssertEqual(messageCount, 1)
 
@@ -143,7 +143,7 @@ class HistorySyncTests: XCTestCase {
 		)
 
 		let alixGroup = try await alixClient.conversations.newGroup(with: [
-			fixtures.bo.walletAddress
+			fixtures.boClient.inboxID
 		])
 
 		let alixClient2 = try await Client.create(

--- a/Tests/XMTPTests/MultiRemoteAttachmentTest.swift
+++ b/Tests/XMTPTests/MultiRemoteAttachmentTest.swift
@@ -113,7 +113,7 @@ class MultiRemoteAttachmentTests: XCTestCase {
         // Fetch messages
         try await alixConversation.sync()
         let messages = try await alixConversation.messages()
-        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages.count, 2)
         
         let received = messages[0]
         XCTAssertEqual(try received.encodedContent.type.id, ContentTypeMultiRemoteAttachment.id)

--- a/Tests/XMTPTests/MultiRemoteAttachmentTest.swift
+++ b/Tests/XMTPTests/MultiRemoteAttachmentTest.swift
@@ -47,7 +47,7 @@ class MultiRemoteAttachmentTests: XCTestCase {
         
         // Create a conversation
         let alixConversation = try await alixClient.conversations
-            .newConversation(with: boClient.address)
+			.newConversation(with: boClient.inboxID)
         
         // Create some dummy attachments to send
         let attachment1 = Attachment(

--- a/Tests/XMTPTests/PerformanceTests.swift
+++ b/Tests/XMTPTests/PerformanceTests.swift
@@ -23,7 +23,7 @@ class PerformanceTests: XCTestCase {
 				do {
 					PerformanceTests.dm = try await fixtures.alixClient
 						.conversations.findOrCreateDm(
-							with: fixtures.boClient.address)
+							with: fixtures.boClient.inboxID)
 
 					let elapsedTime =
 						(CFAbsoluteTimeGetCurrent() - startTime) * 1000
@@ -90,9 +90,9 @@ class PerformanceTests: XCTestCase {
 					PerformanceTests.group = try await fixtures.alixClient
 						.conversations.newGroup(
 							with: [
-								fixtures.boClient.address,
-								fixtures.caroClient.address,
-								fixtures.davonClient.address,
+								fixtures.boClient.inboxID,
+								fixtures.caroClient.inboxID,
+								fixtures.davonClient.inboxID,
 							]
 						)
 
@@ -168,7 +168,7 @@ class PerformanceTests: XCTestCase {
 		// Measure time to build a client
 		let start2 = Date()
 		let buildClient1 = try await Client.build(
-			address: fakeWallet.address,
+			publicIdentity: fakeWallet.identity,
 			options: ClientOptions(
 				api: ClientOptions.Api(env: .dev, isSecure: true),
 				dbEncryptionKey: key
@@ -181,7 +181,7 @@ class PerformanceTests: XCTestCase {
 		// Measure time to build a client with an inboxId
 		let start3 = Date()
 		let buildClient2 = try await Client.build(
-			address: fakeWallet.address,
+			publicIdentity: fakeWallet.identity,
 			options: ClientOptions(
 				api: ClientOptions.Api(env: .dev, isSecure: true),
 				dbEncryptionKey: key

--- a/Tests/XMTPTests/ReactionTests.swift
+++ b/Tests/XMTPTests/ReactionTests.swift
@@ -55,7 +55,7 @@ class ReactionTests: XCTestCase {
     func testCanUseReactionCodec() async throws {
         let fixtures = try await fixtures()
         let conversation = try await fixtures.alixClient.conversations
-            .newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
         
         Client.register(codec: ReactionCodec())
         
@@ -136,7 +136,7 @@ class ReactionTests: XCTestCase {
         
         let fixtures = try await fixtures()
         let conversation = try await fixtures.alixClient.conversations
-            .newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
         
         _ = try await conversation.send(text: "hey alice 2 bob")
         
@@ -179,7 +179,7 @@ class ReactionTests: XCTestCase {
         
         let fixtures = try await fixtures()
         let conversation = try await fixtures.alixClient.conversations
-            .newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
         
         // Send initial message
         _ = try await conversation.send(text: "hey alice 2 bob")

--- a/Tests/XMTPTests/ReactionTests.swift
+++ b/Tests/XMTPTests/ReactionTests.swift
@@ -165,7 +165,7 @@ class ReactionTests: XCTestCase {
         XCTAssertEqual(FfiReactionSchema.unicode, content.schema)
         
         let messagesWithReactions = try await conversation.messagesWithReactions()
-        XCTAssertEqual(messagesWithReactions.count, 1)
+        XCTAssertEqual(messagesWithReactions.count, 2)
         XCTAssertEqual(messagesWithReactions[0].id, messageToReact.id)
         
         let reactionContent: FfiReaction = try messagesWithReactions[0].childMessages![0].content()
@@ -213,7 +213,7 @@ class ReactionTests: XCTestCase {
         // Verify both reactions appear in messagesWithReactions
         let messagesWithReactions = try await conversation.messagesWithReactions()
         
-        XCTAssertEqual(1, messagesWithReactions.count)
+        XCTAssertEqual(2, messagesWithReactions.count)
         XCTAssertEqual(messageToReact.id, messagesWithReactions[0].id)
         XCTAssertEqual(2, messagesWithReactions[0].childMessages?.count)
         

--- a/Tests/XMTPTests/ReadReceiptTests.swift
+++ b/Tests/XMTPTests/ReadReceiptTests.swift
@@ -10,7 +10,7 @@ class ReadReceiptTests: XCTestCase {
 		Client.register(codec: ReadReceiptCodec())
 
 		let conversation = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		_ = try await conversation.send(text: "hey alix 2 bo")
 

--- a/Tests/XMTPTests/RemoteAttachmentTest.swift
+++ b/Tests/XMTPTests/RemoteAttachmentTest.swift
@@ -38,7 +38,7 @@ class RemoteAttachmentTests: XCTestCase {
 		Client.register(codec: RemoteAttachmentCodec())
 
 		let conversation = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 		let enecryptedEncodedContent = try RemoteAttachment.encodeEncrypted(
 			content: "Hello", codec: TextCodec())
 		var remoteAttachmentContent = try RemoteAttachment(
@@ -55,7 +55,7 @@ class RemoteAttachmentTests: XCTestCase {
 	func testCanUseAttachmentCodec() async throws {
 		let fixtures = try await fixtures()
 		let conversation = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		Client.register(codec: AttachmentCodec())
 		Client.register(codec: RemoteAttachmentCodec())
@@ -110,7 +110,7 @@ class RemoteAttachmentTests: XCTestCase {
 	func testCannotUseNonHTTPSUrl() async throws {
 		let fixtures = try await fixtures()
 		_ = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		Client.register(codec: AttachmentCodec())
 		Client.register(codec: RemoteAttachmentCodec())
@@ -142,7 +142,7 @@ class RemoteAttachmentTests: XCTestCase {
 	func testVerifiesContentDigest() async throws {
 		let fixtures = try await fixtures()
 		_ = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		let encryptedEncodedContent = try RemoteAttachment.encodeEncrypted(
 			content: Attachment(

--- a/Tests/XMTPTests/ReplyTests.swift
+++ b/Tests/XMTPTests/ReplyTests.swift
@@ -8,7 +8,7 @@ class ReplyTests: XCTestCase {
 	func testCanUseReplyCodec() async throws {
 		let fixtures = try await fixtures()
 		let conversation = try await fixtures.alixClient.conversations
-			.newConversation(with: fixtures.boClient.address)
+			.newConversation(with: fixtures.boClient.inboxID)
 
 		Client.register(codec: ReplyCodec())
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "3.0.33"
+  spec.version      = "4.0.0-rc1"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 3.0.30'
+  spec.dependency 'LibXMTP', '= 4.0.0-rc1'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "f9a6d33d8129dc2d489cd7ccac6f12a76eb444a2",
-        "version" : "3.0.30"
+        "branch" : "np/passkey-read",
+        "revision" : "46758d00c559649e5189da26c1e8a68c657f0568"
       }
     },
     {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "branch" : "np/passkey-read",
-        "revision" : "46758d00c559649e5189da26c1e8a68c657f0568"
+        "revision" : "0d1fc3aa00b940a76e991255a81dc997c0b7d4e5",
+        "version" : "4.0.0-rc1"
       }
     },
     {


### PR DESCRIPTION
- [x]  Make sure addWallet is blocking reassignment for the ffi function as well
- [x]  Adds new identity for all places where addresses were used
- [x]  Changes addMember, removeMember, createGroup, and newConversation to default to InboxId
- [x]  Enforces type on inboxId so address can't accidentally be passed.
- [x] Add a test to verify that an error gets thrown if an address is passed