### PR TITLE
Add paused for min version function

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "83f31b00f3dd616cdf127fb108725dcdd8c50bab",
-        "version" : "3.0.27"
+        "revision" : "0d1fc3aa00b940a76e991255a81dc997c0b7d4e5",
+        "version" : "4.0.0-rc1"
       }
     },
     {

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -253,6 +253,18 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			)
 		}
 	}
+    
+    // Returns null if group is not paused, otherwise the min version required to unpause this group
+    public func pausedForVersion() async throws -> String? {
+        switch self {
+        case let .group(group):
+            return try group.pausedForVersion()
+        case let .dm(dm):
+            return try dm.pausedForVersion()
+        }
+    }
+    
+    
 
 	public var client: Client {
 		switch self {

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -254,7 +254,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
     
-    // Returns null if group is not paused, otherwise the min version required to unpause this group
+    // Returns null if conversation is not paused, otherwise the min version required to unpause this conversation
     public func pausedForVersion() async throws -> String? {
         switch self {
         case let .group(group):

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -102,7 +102,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		try await ffiConversation.removeConversationMessageDisappearingSettings()
 	}
     
-    // Returns null if group is not paused, otherwise the min version required to unpause this group
+    // Returns null if dm is not paused, otherwise the min version required to unpause this dm
     public func pausedForVersion() throws -> String? {
         return try ffiConversation.pausedForVersion()
     }

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -101,6 +101,11 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	public func clearDisappearingMessageSettings() async throws {
 		try await ffiConversation.removeConversationMessageDisappearingSettings()
 	}
+    
+    // Returns null if group is not paused, otherwise the min version required to unpause this group
+    public func pausedForVersion() throws -> String? {
+        return try ffiConversation.pausedForVersion()
+    }
 
 	public func processMessage(messageBytes: Data) async throws -> DecodedMessage? {
 		let message =

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -274,11 +274,16 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public func clearDisappearingMessageSettings() async throws {
-		try await ffiGroup.removeConversationMessageDisappearingSettings()
-	}
-
-	public func updateConsentState(state: ConsentState) async throws {
+    public func clearDisappearingMessageSettings() async throws {
+        try await ffiGroup.removeConversationMessageDisappearingSettings()
+    }
+    
+    // Returns null if group is not paused, otherwise the min version required to unpause this group
+    public func pausedForVersion() throws -> String? {
+        return try ffiGroup.pausedForVersion()
+    }
+    
+    public func updateConsentState(state: ConsentState) async throws {
 		try ffiGroup.updateConsentState(state: state.toFFI)
 	}
 

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -1215,4 +1215,21 @@ class GroupTests: XCTestCase {
 		XCTAssert(try boGroup.isDisappearingMessagesEnabled())
 		XCTAssert(try alixGroup!.isDisappearingMessagesEnabled())
 	}
+    
+    func testGroupPausedForVersionReturnsNone() async throws {
+        let fixtures = try await fixtures()
+        
+        // Create group with disappearing messages enabled
+        let boGroup = try await fixtures.boClient.conversations.newGroup(
+            with: [fixtures.alixClient.inboxID]
+        )
+        
+        let pausedForVersionGroup = try boGroup.pausedForVersion()
+        XCTAssert(pausedForVersionGroup == nil)
+        
+        let boDm = try await fixtures.boClient.conversations.newConversation(with: fixtures.alixClient.inboxID)
+        let pausedForVersionDm = try boGroup.pausedForVersion()
+        XCTAssert(pausedForVersionDm == nil)
+    }
+    
 }

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -1228,7 +1228,7 @@ class GroupTests: XCTestCase {
         XCTAssert(pausedForVersionGroup == nil)
         
         let boDm = try await fixtures.boClient.conversations.newConversation(with: fixtures.alixClient.inboxID)
-        let pausedForVersionDm = try boGroup.pausedForVersion()
+        let pausedForVersionDm = try boDm.pausedForVersion()
         XCTAssert(pausedForVersionDm == nil)
     }
     


### PR DESCRIPTION
## Introduction 📟
<!-- Brief explanation of the problem to be solved / bug to be fixed. -->

For test branch simulating clients on different versions experiencing a paused group, see https://github.com/xmtp/xmtp-android/compare/cv/test-pause-for-min-version?expand=1

## Purpose ℹ️ 
<!-- What is the goal of the proposed change? -->

## Scope 🔭
<!-- What is the technical scope of the changes? -->

<!-- Beginning of comment block
From this point on, all the following titles are optional.
Move the ones you need out of the comment block and delete the rest of the template.
There is a table example included for screenshots

## Out of Scope ⚔️

## Testing 🧪

## TODOs ☑️
- [ ] [Change log] updated or ignored

## Discussion 🎙

End of comment block -->
