### PR TITLE
4.0.0 Release

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "0d1fc3aa00b940a76e991255a81dc997c0b7d4e5",
-        "version" : "4.0.0-rc1"
+        "revision" : "bc1e1097f252a54ebaa81e52af9490f85ee3a30a",
+        "version" : "4.0.0"
       }
     },
     {

--- a/Tests/XMTPTests/HistorySyncTests.swift
+++ b/Tests/XMTPTests/HistorySyncTests.swift
@@ -175,7 +175,7 @@ class HistorySyncTests: XCTestCase {
 		sleep(1)
 		try await alixGroup2.updateConsentState(state: .denied)
 		let dm = try await alixClient2.conversations.newConversation(
-			with: fixtures.caro.walletAddress)
+            with: fixtures.caroClient.inboxID)
 		try await dm.updateConsentState(state: .denied)
 
 		sleep(5)

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.0.0-rc2"
+  spec.version      = "4.0.0"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
Bumps to version 4.0.0 that includes all new identity scheme to support future passkey authentication 🎉 

All tests green:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/9bcf4c3c-3e25-420b-a1d2-69aa0219247a" />
