### PR TITLE
Allow LOCAL with a custom string

### DIFF
--- a/Sources/XMTPiOS/XMTPEnvironment.swift
+++ b/Sources/XMTPiOS/XMTPEnvironment.swift
@@ -9,18 +9,20 @@ import Foundation
 
 /// Contains hosts an `ApiClient` can connect to
 public enum XMTPEnvironment: String, Sendable {
-	case dev = "grpc.dev.xmtp.network:443",
-	     production = "grpc.production.xmtp.network:443",
-	     local = "localhost:5556"
+	case dev = "grpc.dev.xmtp.network:443"
+	case production = "grpc.production.xmtp.network:443"
+	case local = "localhost:5556"
+
+	// Optional override for the local environment
+	public static var customLocalAddress: String?
 
 	var url: String {
 		switch self {
-		case .dev:
-			return "https://\(rawValue)"
-		case .production:
+		case .dev, .production:
 			return "https://\(rawValue)"
 		case .local:
-			return "http://\(rawValue)"
+			let address = XMTPEnvironment.customLocalAddress ?? rawValue
+			return "http://\(address)"
 		}
 	}
 

--- a/Sources/XMTPiOS/XMTPEnvironment.swift
+++ b/Sources/XMTPiOS/XMTPEnvironment.swift
@@ -9,20 +9,28 @@ import Foundation
 
 /// Contains hosts an `ApiClient` can connect to
 public enum XMTPEnvironment: String, Sendable {
-	case dev = "grpc.dev.xmtp.network:443"
-	case production = "grpc.production.xmtp.network:443"
-	case local = "localhost:5556"
+	case dev = "grpc.dev.xmtp.network"
+	case production = "grpc.production.xmtp.network"
+	case local = "localhost"
 
 	// Optional override for the local environment
 	public static var customLocalAddress: String?
 
+	var address: String {
+		switch self {
+		case .local:
+			return XMTPEnvironment.customLocalAddress ?? rawValue
+		default:
+			return rawValue
+		}
+	}
+
 	var url: String {
 		switch self {
 		case .dev, .production:
-			return "https://\(rawValue)"
+			return "https://\(address):443"
 		case .local:
-			let address = XMTPEnvironment.customLocalAddress ?? rawValue
-			return "http://\(address)"
+			return "http://\(address):5556"
 		}
 	}
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.0.1"
+  spec.version      = "4.0.2"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
iOS side of https://github.com/xmtp/xmtp-android/pull/170

You can call this now with `XMTPEnvironment.customLocalAddress = "string"`

Gives the ability to run a physical android app pointing at a local environment.
