### PR TITLE
Fix invalid key packages 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.0.1")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.0.2")
 	],
 	targets: [
 		.target(

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.0.2"
+  spec.version      = "4.0.3"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.0.1'
+  spec.dependency 'LibXMTP', '= 4.0.2'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "9a901ea9ac39cb9a1fd0e0a1455b5f68fda627f8",
-        "version" : "4.0.1"
+        "revision" : "685b4f0a34c1f2b2d900eeae1edc77a1c3b43a01",
+        "version" : "4.0.2"
       }
     },
     {


### PR DESCRIPTION
## Update libxmtp-swift and pod dependencies
Updated dependency versions for `libxmtp-swift` from 4.0.1 to 4.0.2 in Package.swift and XMTP.podspec. Bumped `XMTP` pod version from 4.0.2 to 4.0.3.

### 📍Where to Start
Start with [Package.swift](https://github.com/xmtp/xmtp-ios/pull/495/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR0) to review the Swift package dependency update, then check [XMTP.podspec](https://github.com/xmtp/xmtp-ios/pull/495/files#diff-e9237cf856d38a9701faf84ef515c0d8d2880b467403b12cbe0792edf2cda630R0) for the pod version changes.

----

_[Macroscope](https://app.macroscope.com) summarized 18d956b._