### PR TITLE
feat: manually encode ABI for ens resolver

### DIFF
--- a/example/example.xcodeproj/project.pbxproj
+++ b/example/example.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02359B752D8BF430001F7605 /* web3swift in Frameworks */ = {isa = PBXBuildFile; productRef = 02359B742D8BF430001F7605 /* web3swift */; };
-		025481C22D8BF5E900FF6343 /* XMTPiOS in Frameworks */ = {isa = PBXBuildFile; productRef = 025481C12D8BF5E900FF6343 /* XMTPiOS */; };
+		0286B7F42D97E5C100984C0A /* XMTPiOS in Frameworks */ = {isa = PBXBuildFile; productRef = 0286B7F32D97E5C100984C0A /* XMTPiOS */; };
+		0286B7FA2D9A840C00984C0A /* BigInt in Frameworks */ = {isa = PBXBuildFile; productRef = 0286B7F92D9A840C00984C0A /* BigInt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,8 +28,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				02359B752D8BF430001F7605 /* web3swift in Frameworks */,
-				025481C22D8BF5E900FF6343 /* XMTPiOS in Frameworks */,
+				0286B7F42D97E5C100984C0A /* XMTPiOS in Frameworks */,
+				0286B7FA2D9A840C00984C0A /* BigInt in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,8 +72,8 @@
 			);
 			name = example;
 			packageProductDependencies = (
-				02359B742D8BF430001F7605 /* web3swift */,
-				025481C12D8BF5E900FF6343 /* XMTPiOS */,
+				0286B7F32D97E5C100984C0A /* XMTPiOS */,
+ 				0286B7F92D9A840C00984C0A /* BigInt */,
 			);
 			productName = example;
 			productReference = 02DE6ECE2D7BD2E7002FE4CD /* example.app */;
@@ -104,8 +104,8 @@
 			mainGroup = 02DE6EC52D7BD2E7002FE4CD;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				02359B732D8BF430001F7605 /* XCRemoteSwiftPackageReference "web3swift" */,
-				025481C02D8BF5E900FF6343 /* XCLocalSwiftPackageReference "../../xmtp-ios" */,
+				0286B7F22D97E5C100984C0A /* XCLocalSwiftPackageReference "../../xmtp-ios" */,
+ 				0286B7F82D9A840C00984C0A /* XCRemoteSwiftPackageReference "BigInt" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 02DE6ECF2D7BD2E7002FE4CD /* Products */;
@@ -339,32 +339,32 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		025481C02D8BF5E900FF6343 /* XCLocalSwiftPackageReference "../../xmtp-ios" */ = {
+		0286B7F22D97E5C100984C0A /* XCLocalSwiftPackageReference "../../xmtp-ios" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../../xmtp-ios";
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		02359B732D8BF430001F7605 /* XCRemoteSwiftPackageReference "web3swift" */ = {
+		0286B7F82D9A840C00984C0A /* XCRemoteSwiftPackageReference "BigInt" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/web3swift-team/web3swift";
+			repositoryURL = "https://github.com/attaswift/BigInt.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.3.0;
+				minimumVersion = 5.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		02359B742D8BF430001F7605 /* web3swift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 02359B732D8BF430001F7605 /* XCRemoteSwiftPackageReference "web3swift" */;
-			productName = web3swift;
-		};
-		025481C12D8BF5E900FF6343 /* XMTPiOS */ = {
+		0286B7F32D97E5C100984C0A /* XMTPiOS */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XMTPiOS;
+		};
+		0286B7F92D9A840C00984C0A /* BigInt */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0286B7F82D9A840C00984C0A /* XCRemoteSwiftPackageReference "BigInt" */;
+      productName = BigInt;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/example/example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b0e2265cd299a76158aecd92f65691f082440fb697cd38b4000c0c07fdfe3d27",
+  "originHash" : "315cd607981566bf90ef6f86b6d8ce921b7e750d120a36d40a0dab749db8fe84",
   "pins" : [
     {
       "identity" : "bigint",
@@ -29,21 +29,21 @@
       }
     },
     {
+      "identity" : "csecp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tesseract-one/CSecp256k1.swift.git",
+      "state" : {
+        "revision" : "cfbd6f540d5084bc96a60af841121472fbe725a3",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "libxmtp-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
         "revision" : "9a901ea9ac39cb9a1fd0e0a1455b5f68fda627f8",
         "version" : "4.0.1"
-      }
-    },
-    {
-      "identity" : "secp256k1.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/GigaBitcoin/secp256k1.swift",
-      "state" : {
-        "revision" : "48fb20fce4ca3aad89180448a127d5bc16f0e44c",
-        "version" : "0.10.0"
       }
     },
     {
@@ -107,15 +107,6 @@
       "state" : {
         "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
         "version" : "1.4.2"
-      }
-    },
-    {
-      "identity" : "web3swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/web3swift-team/web3swift",
-      "state" : {
-        "revision" : "119d179305788687e80083671698b3f08c970e7f",
-        "version" : "3.3.0"
       }
     }
   ],

--- a/example/example/EnsResolver.swift
+++ b/example/example/EnsResolver.swift
@@ -1,32 +1,32 @@
-import Web3Core
+import BigInt
 import Foundation
-import web3swift
 
 // Convert between ENS names and addresses.
 // .resolveAddress(forName: "dmccartney.eth") -> "0x359b0ceb2dabcbb6588645de3b480c8203aa5b76"
 // .resolveName(forAddress: "0x359b0ceb2dabcbb6588645de3b480c8203aa5b76") -> "dmccartney.eth"
 //
+// Note: to avoid dependencies this does its own ABI encoding of call data.
+//       Consider using a more robust ABI encoder if you have one handy.
+//
+// ref:
 // https://docs.ens.domains/resolvers/universal#reverse-resolution
 class EnsResolver {
-    private let provider: Web3Provider
-    private let addrContract: EthereumContract
-    private let resolverContract: EthereumContract
-    
+    private let rpcUrl: URL
+
     // ref: https://docs.ens.domains/learn/deployments
-    private let resolverAddress = EthereumAddress("0xce01f8eee7E479C928F8919abD53E553a36CeF67")!
+    private let resolverAddress = "0xce01f8eee7E479C928F8919abD53E553a36CeF67".lowercased()
+
 
     // This works with any mainnet RPC provider
     //  e.g. `https://eth-mainnet.g.alchemy.com/v2/...`
     convenience init(rpcUrlString: String) {
-        self.init(provider: Web3HttpProvider(url: URL(string: rpcUrlString)!, network: .Mainnet))
+        self.init(rpcUrl: URL(string: rpcUrlString)!)
     }
 
-    init(provider: Web3Provider) {
-        self.provider = provider
-        self.resolverContract = try! EthereumContract(resolverAbi, at: resolverAddress)
-        self.addrContract = try! EthereumContract(addrAbi)
+    init(rpcUrl: URL) {
+        self.rpcUrl = rpcUrl
     }
-    
+
     // Get the `name` specified by the `address`'s reverse record.
     //
     // Note: the universal resolver also forward-resolves to ensure a proper claims.
@@ -34,33 +34,95 @@ class EnsResolver {
     // https://docs.ens.domains/resolvers/universal#reverse-resolution
     func resolveName(forAddress address: String) async throws -> String? {
         // TODO: consider supporting batch resolution via multicall3.
-        let reverseName = dnsPacketToBytes("\(address.dropFirst(2)).addr.reverse")
-        let res = try await resolverContract.callStatic(
-            "reverse",
-            parameters: [reverseName],
-            provider: provider
+
+        // Produce the dns-packed edition of the reverse record name.
+        var reverseName = dnsPacketToBytes("\(address.dropFirst(2)).addr.reverse")
+
+        // This performs extremely lightweight ABI encoding of the expected input/output.
+        // ref: universalResolverReverseAbi
+        // ref: https://github.com/wevm/viem/blob/main/src/constants/abis.ts
+        //     "name":"reverse",
+        //     "inputs":[{"type":"bytes","name":"reverseName"}],
+        //     "outputs": [
+        //         {"type":"string","name":"resolvedName"},
+        //         {"type":"address","name":"resolvedAddress"},
+        //         {"type":"address","name":"reverseResolver"},
+        //         {"type":"address","name":"resolver"}
+        //     ]
+        let reverseCallEncoded = Data(hex: "ec11c823") + // 8-byte method identifier for reverse(bytes)
+            BigUInt(32).serialize().wordPaddedLeft() +
+            BigUInt(reverseName.count).serialize().wordPaddedLeft() +
+            reverseName.wordPaddedRight()
+
+        let result = try await EthereumRPCRequest.ethCall(
+            using: rpcUrl,
+            to: resolverAddress,
+            data: reverseCallEncoded
         )
-        return res["resolvedName"] as! String?
+
+        let resolvedNameLength = UInt64(BigUInt(result[128 ..< 160]))
+        let resolvedNameData = result[160 ..< 160+resolvedNameLength]
+        if let resolvedName = String(data: resolvedNameData, encoding: .utf8) {
+            return resolvedName
+        }
+        return nil
     }
-    
+
     // Get the address specified by the addr record for the specified `name`.
     //
     // https://docs.ens.domains/resolvers/universal#forward-resolution
-    func resolveAddress(forName name: String) async throws -> EthereumAddress? {
+    func resolveAddress(forName name: String) async throws -> String? {
         // TODO: consider supporting batch resolution via multicall3.
+
         // TODO: fully normalize it https://github.com/adraffy/ens-normalize.js
         let encodedName = dnsPacketToBytes(name.lowercased())
-        let hashedName = NameHash.nameHash(name)!
-        let encodedAddrCall = addrContract.method("addr", parameters: [hashedName], extraData: nil)!
-        let res = try await resolverContract.callStatic(
-            "resolve",
-            parameters: [encodedName, encodedAddrCall],
-            provider: provider
+
+        // This encodes the nested call to addr(name)
+        //  ref: addressResolverAbi
+        //  ref: https://github.com/wevm/viem/blob/main/src/constants/abis.ts
+        //     "name":"addr",
+        //     "inputs":[{"type":"bytes32","name":"name"}],
+        //     "outputs": [{"type":"address","name":""}]
+        let encodedAddrCall = Data(hex: "3b3b57de") + namehash(name.lowercased())!
+
+        // This performs extremely lightweight ABI encoding of the expected input/output.
+        //  ref: universalResolverResolveAbi
+        //  ref: https://github.com/wevm/viem/blob/main/src/constants/abis.ts
+        //     "name":"resolve",
+        //     "inputs":[
+        //         {"type":"bytes","name":"name"},
+        //         {"type":"bytes","name":"data"}
+        //     ],
+        //     "outputs": [
+        //         {"type":"bytes","name":""},
+        //         {"type":"address","name":"address"}
+        //     ]
+
+        // The byte-offsets where each of `encodedName` and `encodedAddrCall` begin in the encoding.
+        let encodedNameOffset = 32 * (2)
+        let encodedAddrCallOffset = 32 * (3 + encodedName.count.requiredWords()) // i.e. after the encodedName
+
+        // Bring it all together (with the offsets in the header)
+        let encodedResolveCall = Data(hex: "9061b923") + // 8-byte signature for resolve(bytes,bytes)
+            BigUInt(encodedNameOffset).serialize().wordPaddedLeft() +
+            BigUInt(encodedAddrCallOffset).serialize().wordPaddedLeft() +
+            // encodedName bytes (length-prefixed):
+            BigUInt(encodedName.count).serialize().wordPaddedLeft() +
+            encodedName.wordPaddedRight() +
+            // encodedAddrCall bytes (length-prefixed):
+            BigUInt(encodedAddrCall.count).serialize().wordPaddedLeft() +
+            encodedAddrCall.wordPaddedRight()
+
+        let result = try await EthereumRPCRequest.ethCall(
+            using: rpcUrl,
+            to: resolverAddress,
+            data: encodedResolveCall
         )
-        let addressBytes = res["0"] as! Data
-        return EthereumAddress("0x\(addressBytes.suffix(20).toHexString())")
+
+        // Note: this works because the address is encoded in the last bytes of the output.
+        return "0x\(result.suffix(20).toHexString())".lowercased()
     }
-    
+
     // Encodes a DNS packet into a byte array for the ENS contracts.
     //
     // ref: https://docs.ens.domains/resolution/names#dns
@@ -86,50 +148,136 @@ class EnsResolver {
             bytes.replaceSubrange(offset + 1..<offset + 1 + encoded.count, with: encoded)
             offset += encoded.count + 1
         }
-        
+
         if (bytes.count != offset + 1) {
             return bytes[0..<offset + 1]
         }
         return bytes
     }
-    
-    // ref: https://github.com/wevm/viem/blob/main/src/constants/abis.ts
-    private let resolverAbi = """
-[{
-    "name":"resolve",
-    "type":"function",
-    "stateMutability":"view",
-    "inputs":[
-        {"type":"bytes","name":"name"},
-        {"type":"bytes","name":"data"}
-    ],
-    "outputs": [
-      {"type":"bytes","name":""},
-      {"type":"address","name":"address"}
-    ]
-},{
-    "name":"reverse",
-    "type":"function",
-    "stateMutability":"view",
-    "inputs":[{"type":"bytes","name":"reverseName"}],
-    "outputs": [
-        {"type":"string","name":"resolvedName"},
-        {"type":"address","name":"resolvedAddress"},
-        {"type":"address","name":"reverseResolver"},
-        {"type":"address","name":"resolver"}
-    ]
-}]
-"""
-    
-    private let addrAbi = """
-[{
-    "name":"addr",
-    "type":"function",
-    "stateMutability":"view",
-    "inputs": [{"name":"name","type":"bytes32" }],
-    "outputs": [
-        {"name":"","type":"address"}
-    ]
-}]
-"""
+
+    // ref: https://docs.ens.domains/resolution/names#namehash
+    private func namehash(_ name: String) -> Data? {
+        if name.isEmpty {
+            return Data(repeating: 0x00, count: 32)
+        }
+        let parts = name.split(separator: ".")
+        guard let label = parts.first?.data(using: .utf8) else {
+            return nil
+        }
+        guard let remainder = namehash(parts[1...].joined(separator: ".")) else {
+            return nil
+        }
+        return (remainder + label.sha3(.keccak256)).sha3(.keccak256)
+    }
+}
+
+private struct EthereumRPCRequest: Encodable {
+    var jsonrpc = "2.0"
+    var id: Int
+    var method: String
+    var params: [Encodable]
+
+    enum EthereumRPCError: Error {
+        case error(String)
+    }
+
+    static func ethCall(using providerUrl: URL, to: String, data: Data) async throws -> Data {
+        var ethRpcRequest = EthereumRPCRequest(
+            jsonrpc: "2.0",
+            id: Int.random(in: 0..<Int.max),
+            method: "eth_call",
+            params: [
+                Call(
+                    from: "0x0000000000000000000000000000000000000000",
+                    to: to,
+                    data: "0x\(data.toHexString())"
+                ),
+                "latest"
+            ]
+        )
+        var req = URLRequest(
+            url: providerUrl,
+            cachePolicy: .reloadIgnoringCacheData
+        )
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.httpMethod = "POST"
+        req.httpBody = ethRpcRequest.encoded
+
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode,
+              200 ..< 400 ~= statusCode,
+              let res = try? JSONDecoder().decode(EthereumRPCResponse.self, from: data) else {
+            throw URLError(.badServerResponse)
+        }
+        guard let resultHex = res.result else {
+            throw EthereumRPCError.error(res.error ?? "")
+        }
+        return Data(hex: resultHex)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case method
+        case params
+    }
+
+    struct Call: Codable {
+        let from: String
+        let to: String
+        let data: String
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(jsonrpc, forKey: .jsonrpc)
+        try container.encode(id, forKey: .id)
+        try container.encode(method, forKey: .method)
+
+        var paramsContainer = container.superEncoder(forKey: .params).unkeyedContainer()
+        try params.forEach { a in
+            try paramsContainer.encode(a)
+        }
+    }
+
+    public var encoded: Data {
+        try! JSONEncoder().encode(self)
+    }
+}
+
+private struct EthereumRPCResponse: Decodable {
+    var id: Int
+    var jsonrpc = "2.0"
+    var result: String?
+    var error: String?
+}
+
+private extension Data {
+    func paddingLeft(_ toLength: Int, padding: UInt8 = 0x00) -> Data {
+        if self.count >= toLength {
+            return Data(self)
+        }
+        return Data(repeating: 0x00, count: toLength - self.count) + self
+    }
+    func paddingRight(_ toLength: Int, padding: UInt8 = 0x00) -> Data {
+        if self.count >= toLength {
+            return Data(self)
+        }
+        return self + Data(repeating: 0x00, count: toLength - self.count)
+    }
+
+    func wordPaddedLeft(_ wordSize: UInt8 = 32) -> Data {
+        self.paddingLeft(Int(wordSize) * self.count.requiredWords(wordSize))
+    }
+
+    func wordPaddedRight(_ wordSize: UInt8 = 32) -> Data {
+        self.paddingRight(Int(wordSize) * self.count.requiredWords(wordSize))
+    }
+}
+
+private extension Int {
+    func requiredWords(_ wordSize: UInt8 = 32) -> Int {
+        ((self - 1) / Int(wordSize)) + 1
+    }
 }

--- a/example/example/NameResolver.swift
+++ b/example/example/NameResolver.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 import XMTPiOS
-import web3swift
-import Web3Core
 
 // A name resolver for XMTP identities.
 //
@@ -15,7 +13,7 @@ class NameResolver {
         return "\(identifier.prefix(6))...\(identifier.suffix(4))"
     })
 
-    
+
     // Note: replace this with your own RPC provider URL.
     private let ensResolver = EnsResolver(
         rpcUrlString: "https://eth-mainnet.g.alchemy.com/v2/WV-bLot1hKjjCfpPq603Ro-jViFzwYX8")
@@ -23,7 +21,7 @@ class NameResolver {
     init() {
         ethereum.loader = self.resolveEthereumName
     }
-    
+
     subscript(_ identity: PublicIdentity?) -> ObservableItem<String> {
         if identity == nil {
             return ObservableItem(identifier: "") // nil-ish
@@ -38,7 +36,7 @@ class NameResolver {
             defaultValue: identity!.abbreviated
         )
     }
-    
+
     func resolveEthereumName(_ identifier: String) async throws -> String {
         if let name = try? await ensResolver.resolveName(forAddress: identifier) {
             return name


### PR DESCRIPTION
This adds manual ABI encoding to the `EnsResolver` in the `example/` app.

I added this so we could cut the `web3swift` dependency which had transitive conflicts with SDK itself.