### PR TITLE
Fix legacy db paths

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -265,10 +265,20 @@ public final class Client {
 		} else {
 			directoryURL = URL.documentsDirectory
 		}
-
+		
 		let alias = "xmtp-\(options.api.env.rawValue)-\(inboxId).db3"
-		let dbURL = directoryURL.appendingPathComponent(alias).path
+		var dbURL = directoryURL.appendingPathComponent(alias).path
+		var fileExists = FileManager.default.fileExists(atPath: dbURL)
 
+		if !fileExists {
+			let legacyAlias = "xmtp-\(options.api.env.legacyRawValue)-\(inboxId).db3"
+			let legacyDbURL = directoryURL.appendingPathComponent(legacyAlias).path
+			let legacyFileExists = FileManager.default.fileExists(atPath: legacyDbURL)
+
+			if legacyFileExists {
+				dbURL = legacyDbURL
+			}
+		}
 		let ffiClient = try await LibXMTP.createClient(
 			api: connectToApiBackend(api: options.api),
 			db: dbURL,

--- a/Sources/XMTPiOS/XMTPEnvironment.swift
+++ b/Sources/XMTPiOS/XMTPEnvironment.swift
@@ -24,6 +24,17 @@ public enum XMTPEnvironment: String, Sendable {
 			return rawValue
 		}
 	}
+	
+	var legacyRawValue: String {
+		switch self {
+		case .local:
+			return "localhost:5556"
+		case .dev:
+			return "grpc.dev.xmtp.network:443"
+		case .production:
+			return "grpc.production.xmtp.network:443"
+		}
+	}
 
 	var url: String {
 		switch self {

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.0.4"
+  spec.version      = "4.0.5"
 
   spec.summary      = "XMTP SDK Cocoapod"
 

--- a/example/example.xcodeproj/project.pbxproj
+++ b/example/example.xcodeproj/project.pbxproj
@@ -73,7 +73,7 @@
 			name = example;
 			packageProductDependencies = (
 				0286B7F32D97E5C100984C0A /* XMTPiOS */,
- 				0286B7F92D9A840C00984C0A /* BigInt */,
+				0286B7F92D9A840C00984C0A /* BigInt */,
 			);
 			productName = example;
 			productReference = 02DE6ECE2D7BD2E7002FE4CD /* example.app */;
@@ -105,7 +105,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				0286B7F22D97E5C100984C0A /* XCLocalSwiftPackageReference "../../xmtp-ios" */,
- 				0286B7F82D9A840C00984C0A /* XCRemoteSwiftPackageReference "BigInt" */,
+				0286B7F82D9A840C00984C0A /* XCRemoteSwiftPackageReference "BigInt" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 02DE6ECF2D7BD2E7002FE4CD /* Products */;
@@ -265,7 +265,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 7EDMX855UW;
+				DEVELOPMENT_TEAM = FY4NZR34Z3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -294,7 +294,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 7EDMX855UW;
+				DEVELOPMENT_TEAM = FY4NZR34Z3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -364,7 +364,7 @@
 		0286B7F92D9A840C00984C0A /* BigInt */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0286B7F82D9A840C00984C0A /* XCRemoteSwiftPackageReference "BigInt" */;
-      productName = BigInt;
+			productName = BigInt;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
Allow legacy db paths to work as well.
Introduced in https://github.com/xmtp/xmtp-ios/pull/491
Previously we appended the port to the db path now we do not.

![image (1)](https://github.com/user-attachments/assets/b2df26b9-d248-43d1-8728-1256ab5594d3)

