### PR TITLE
Harden around forked groups 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-dev.38cf550")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-dev.59df9d1")
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-dev.59df9d1")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-dev.4132dcf")
 	],
 	targets: [
 		.target(

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -288,7 +288,8 @@ public final class Client {
 			accountIdentifier: accountIdentifier.ffiPrivate,
 			nonce: 0,
 			legacySignedPrivateKeyProto: nil,
-			historySyncUrl: options.historySyncUrl
+			historySyncUrl: options.historySyncUrl,
+			syncWorkerMode: .enabled
 		)
 
 		return (ffiClient, dbURL)
@@ -368,7 +369,8 @@ public final class Client {
 			accountIdentifier: identity.ffiPrivate,
 			nonce: 0,
 			legacySignedPrivateKeyProto: nil,
-			historySyncUrl: nil
+			historySyncUrl: nil,
+			syncWorkerMode: nil
 		)
 	}
 

--- a/Sources/XMTPiOS/PrivatePreferences.swift
+++ b/Sources/XMTPiOS/PrivatePreferences.swift
@@ -72,7 +72,12 @@ public actor PrivatePreferences {
 			entity: inboxId
 		).fromFFI
 	}
+	
+	public func sync() async throws {
+		try await ffiClient.syncPreferences()
+	}
 
+	@available(*, deprecated, message: "syncConsent is deprecated. Use `sync()` instead.")
 	public func syncConsent() async throws {
 		try await ffiClient.sendSyncRequest(kind: .consent)
 	}

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.2.0-dev"
+  spec.version      = "4.2.0-dev.59df9d1"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.2.0-dev.38cf550'
+  spec.dependency 'LibXMTP', '= 4.2.0-dev.59df9d1'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.2.0-dev.59df9d1"
+  spec.version      = "4.2.0-dev.4132dcf"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.2.0-dev.59df9d1'
+  spec.dependency 'LibXMTP', '= 4.2.0-dev.4132dcf'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "ce9dfc19acc9716eded839212e9aa95b4c26d29d",
-        "version" : "4.2.0-dev.59df9d1"
+        "revision" : "d189b16f430aabd79a3f0056edb8188252d07dad",
+        "version" : "4.2.0-dev.4132dcf"
       }
     },
     {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "b24a1abafebb2040711b56217e69a820bb12519d",
-        "version" : "4.2.0-dev.38cf550"
+        "revision" : "ce9dfc19acc9716eded839212e9aa95b4c26d29d",
+        "version" : "4.2.0-dev.59df9d1"
       }
     },
     {


### PR DESCRIPTION
This pulls in the latest libxmtp which includes two forked group fixes as well as the ability to sync a sync group.