### PR TITLE
README formatting issue: Missing tilde, breaking formatting + readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can save your encryptionKey for the local database and build the client via 
 // Create the client with a `SigningKey` from your app
 let options = ClientOptions(api: ClientOptions.Api(env: .production, isSecure: true), dbEncryptionKey: encryptionKey, appContext: context)
 let client = try Client().build(address: account.address, options: options)
-``
+```
 ### Configure the client
 
 You can configure the client with these parameters of `Client.create`:


### PR DESCRIPTION
## Introduction 📟
Missing tilde, breaking formatting in README

## Purpose ℹ️ 
README more readable now.

## Scope 🔭
None, really

## Testing 🧪

Open README preview