### PR TITLE
4.2.0-rc2 build incorporating latest libxmtp main (1.2.0-rc2)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-dev.4ba3b55")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-rc1")
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-rc1")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.0-rc2")
 	],
 	targets: [
 		.target(

--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -294,8 +294,8 @@ public final class Client {
 			accountIdentifier: accountIdentifier.ffiPrivate,
 			nonce: 0,
 			legacySignedPrivateKeyProto: nil,
-			historySyncUrl: options.historySyncUrl,
-			syncWorkerMode: .enabled
+			deviceSyncServerUrl: options.historySyncUrl,
+            deviceSyncMode: .enabled
 		)
 
 		return (ffiClient, dbURL)
@@ -375,8 +375,8 @@ public final class Client {
 			accountIdentifier: identity.ffiPrivate,
 			nonce: 0,
 			legacySignedPrivateKeyProto: nil,
-			historySyncUrl: nil,
-			syncWorkerMode: nil
+			deviceSyncServerUrl: nil,
+			deviceSyncMode: nil
 		)
 	}
 

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -305,6 +305,15 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
+    public func getPushTopics() throws -> [String] {
+        switch self {
+        case let .group(group):
+            return try await group.getPushTopics()
+        case let .dm(dm):
+            return try await dm.getPushTopics()
+        }
+    }
+
 	public func getDebugInformation() async throws -> ConversationDebugInfo  {
 		switch self {
 		case let .group(group):

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -295,4 +295,13 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			)
 		}
 	}
+
+	public func getHmacKeys() throws -> Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse {
+		switch self {
+		case let .group(group):
+			return try group.getHmacKeys()
+		case let .dm(dm):
+			return try dm.getHmacKeys()
+		}
+	}
 }

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -304,4 +304,13 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			return try dm.getHmacKeys()
 		}
 	}
+
+	public func getDebugInformation() async throws -> ConversationDebugInfo  {
+		switch self {
+		case let .group(group):
+			return try await group.getDebugInformation()
+		case let .dm(dm):
+			return try await dm.getDebugInformation()
+		}
+	}
 }

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -305,10 +305,10 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
-    public func getPushTopics() throws -> [String] {
+    public func getPushTopics() async throws -> [String] {
         switch self {
         case let .group(group):
-            return try await group.getPushTopics()
+            return try group.getPushTopics()
         case let .dm(dm):
             return try await dm.getPushTopics()
         }

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -518,6 +518,31 @@ public actor Conversations {
 		return group
 	}
 
+	public func newGroupOptimistic(
+		permissions: GroupPermissionPreconfiguration = .allMembers,
+		groupName: String = "",
+		groupImageUrlSquare: String = "",
+		groupDescription: String = "",
+		disappearingMessageSettings: DisappearingMessageSettings? = nil
+	) throws -> Group {
+		let ffiOpts = FfiCreateGroupOptions(
+            permissions: GroupPermissionPreconfiguration.toFfiGroupPermissionOptions(option: permissions),
+			groupName: groupName,
+			groupImageUrlSquare: groupImageUrlSquare,
+			groupDescription: groupDescription,
+			customPermissionPolicySet: nil,
+			messageDisappearingSettings: disappearingMessageSettings.map { settings in
+				FfiMessageDisappearingSettings(
+					fromNs: settings.disappearStartingAtNs,
+					inNs: settings.retentionDurationInNs
+				)
+			}
+		)
+		
+		let ffiGroup = try ffiConversations.createGroupOptimistic(opts: ffiOpts)
+		return Group(ffiGroup: ffiGroup, client: client)
+	}
+
 	public func streamAllMessages(type: ConversationFilterType = .all, consentStates: [ConsentState] = [])
 		-> AsyncThrowingStream<DecodedMessage, Error>
 	{

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -518,7 +518,7 @@ public actor Conversations {
 		return group
 	}
 
-	public func streamAllMessages(type: ConversationFilterType = .all)
+	public func streamAllMessages(type: ConversationFilterType = .all, consentStates: [ConsentState] = [])
 		-> AsyncThrowingStream<DecodedMessage, Error>
 	{
 		AsyncThrowingStream { continuation in
@@ -537,21 +537,24 @@ public actor Conversations {
 					continuation.yield(message)
 				}
 			}
-
+            
 			let task = Task {
 				let stream: FfiStreamCloser
 				switch type {
 				case .groups:
 					stream = await ffiConversations.streamAllGroupMessages(
-						messageCallback: messageCallback
+						messageCallback: messageCallback,
+                        consentStates: consentStates.toFFI
 					)
 				case .dms:
 					stream = await ffiConversations.streamAllDmMessages(
-						messageCallback: messageCallback
+						messageCallback: messageCallback,
+                        consentStates: consentStates.toFFI
 					)
 				case .all:
 					stream = await ffiConversations.streamAllMessages(
-						messageCallback: messageCallback
+						messageCallback: messageCallback,
+                        consentStates: consentStates.toFFI
 					)
 				}
 				await ffiStreamActor.setFfiStream(stream)

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -543,7 +543,7 @@ public actor Conversations {
 		return Group(ffiGroup: ffiGroup, client: client)
 	}
 
-	public func streamAllMessages(type: ConversationFilterType = .all, consentStates: [ConsentState] = [])
+	public func streamAllMessages(type: ConversationFilterType = .all, consentStates: [ConsentState]? = nil)
 		-> AsyncThrowingStream<DecodedMessage, Error>
 	{
 		AsyncThrowingStream { continuation in
@@ -569,17 +569,17 @@ public actor Conversations {
 				case .groups:
 					stream = await ffiConversations.streamAllGroupMessages(
 						messageCallback: messageCallback,
-                        consentStates: consentStates.toFFI
+                        consentStates: consentStates?.toFFI
 					)
 				case .dms:
 					stream = await ffiConversations.streamAllDmMessages(
 						messageCallback: messageCallback,
-                        consentStates: consentStates.toFFI
+                        consentStates: consentStates?.toFFI
 					)
 				case .all:
 					stream = await ffiConversations.streamAllMessages(
 						messageCallback: messageCallback,
-                        consentStates: consentStates.toFFI
+                        consentStates: consentStates?.toFFI
 					)
 				}
 				await ffiStreamActor.setFfiStream(stream)

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -627,5 +627,18 @@ public actor Conversations {
 
 		return hmacKeysResponse
 	}
+    
+    public func allPushTopics() async throws -> [String] {
+        let options = FfiListConversationsOptions(
+            createdAfterNs: nil,
+            createdBeforeNs: nil,
+            limit: nil,
+            consentStates: nil,
+            includeDuplicateDms: true
+        )
+        
+        let conversations = try ffiConversations.list(opts: options)
+        return conversations.map { Topic.groupMessage($0.conversation().id().toHex).description }
+    }
 
 }

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -385,8 +385,14 @@ public struct Dm: Identifiable, Equatable, Hashable {
         return hmacKeysResponse
     }
     
+    public func getPushTopics() async throws -> [String] {
+        var duplicates = try await ffiConversation.findDuplicateDms()
+        var topicIds = duplicates.map { $0.id().toHex }
+        topicIds.append(id)
+        return topicIds.map { Topic.groupMessage($0).description }
+    }
+    
     public func getDebugInformation() async throws -> ConversationDebugInfo {
         return ConversationDebugInfo(ffiConversationDebugInfo: try await ffiConversation.conversationDebugInfo())
     }
-	
 }

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -368,4 +368,21 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			return DecodedMessage.create(ffiMessage: ffiMessageWithReactions)
 		}
 	}
+
+    public func getHmacKeys() throws
+    -> Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse {
+        var hmacKeysResponse = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse()
+        let keys = try ffiConversation.getHmacKeys()
+        for key in keys {
+            var hmacKeys = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse.HmacKeys()
+            var hmacKeyData = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse.HmacKeyData()
+            hmacKeyData.hmacKey = key.key
+            hmacKeyData.thirtyDayPeriodsSinceEpoch = Int32(key.epoch)
+            hmacKeys.values.append(hmacKeyData)
+            hmacKeysResponse.hmacKeys[
+                Topic.groupMessage(ffiConversation.id().toHex).description] = hmacKeys
+        }
+        return hmacKeysResponse
+    }
+	
 }

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -7,6 +7,21 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	var client: Client
 	let streamHolder = StreamHolder()
 
+    public enum ConversationError: Error, CustomStringConvertible, LocalizedError {
+        case missingPeerInboxId
+        
+        public var description: String {
+            switch self {
+            case .missingPeerInboxId:
+                return "ConversationError.missingPeerInboxId: The direct message is missing a peer inbox ID"
+            }
+        }
+        
+        public var errorDescription: String? {
+            return description
+        }
+    }
+    
 	public var id: String {
 		ffiConversation.id().toHex
 	}
@@ -65,10 +80,13 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	}
 
 	public var peerInboxId: InboxId {
-		get throws {
-			try ffiConversation.dmPeerInboxId()
-		}
-	}
+        get throws {
+            guard let inboxId = ffiConversation.dmPeerInboxId() else {
+                throw ConversationError.missingPeerInboxId
+            }
+            return inboxId
+        }
+    }
 
 	public var createdAt: Date {
 		Date(millisecondsSinceEpoch: ffiConversation.createdAtNs())

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -384,5 +384,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
         }
         return hmacKeysResponse
     }
+    
+    public func getDebugInformation() async throws -> ConversationDebugInfo {
+        return ConversationDebugInfo(ffiConversationDebugInfo: try await ffiConversation.conversationDebugInfo())
+    }
 	
 }

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -551,4 +551,8 @@ public struct Group: Identifiable, Equatable, Hashable {
         }
         return hmacKeysResponse
     }
+    
+    public func getDebugInformation() async throws -> ConversationDebugInfo {
+        return ConversationDebugInfo(ffiConversationDebugInfo: try await ffiGroup.conversationDebugInfo())
+    }
 }

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -552,6 +552,10 @@ public struct Group: Identifiable, Equatable, Hashable {
         return hmacKeysResponse
     }
     
+    public func getPushTopics() throws -> [String] {
+        return [topic]
+    }
+    
     public func getDebugInformation() async throws -> ConversationDebugInfo {
         return ConversationDebugInfo(ffiConversationDebugInfo: try await ffiGroup.conversationDebugInfo())
     }

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -535,4 +535,20 @@ public struct Group: Identifiable, Equatable, Hashable {
 				return DecodedMessage.create(ffiMessage: ffiMessageWithReactions)
 			}
 	}
+    
+    public func getHmacKeys() throws
+    -> Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse {
+        var hmacKeysResponse = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse()
+        let keys = try ffiGroup.getHmacKeys()
+        for key in keys {
+            var hmacKeys = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse.HmacKeys()
+            var hmacKeyData = Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse.HmacKeyData()
+            hmacKeyData.hmacKey = key.key
+            hmacKeyData.thirtyDayPeriodsSinceEpoch = Int32(key.epoch)
+            hmacKeys.values.append(hmacKeyData)
+            hmacKeysResponse.hmacKeys[
+                Topic.groupMessage(ffiGroup.id().toHex).description] = hmacKeys
+        }
+        return hmacKeysResponse
+    }
 }

--- a/Sources/XMTPiOS/Libxmtp/ConversationDebugInfo.swift
+++ b/Sources/XMTPiOS/Libxmtp/ConversationDebugInfo.swift
@@ -1,0 +1,21 @@
+import LibXMTP
+
+public struct ConversationDebugInfo {
+	let ffiConversationDebugInfo: FfiConversationDebugInfo
+	
+	public init(ffiConversationDebugInfo: FfiConversationDebugInfo) {
+		self.ffiConversationDebugInfo = ffiConversationDebugInfo
+	}
+
+	public var epoch: UInt64 {
+		ffiConversationDebugInfo.epoch
+	}
+
+	public var maybeForked: Bool {
+		ffiConversationDebugInfo.maybeForked
+	}
+
+	public var forkDetails: String {
+		ffiConversationDebugInfo.forkDetails
+	}
+}

--- a/Sources/XMTPiOS/PrivatePreferences.swift
+++ b/Sources/XMTPiOS/PrivatePreferences.swift
@@ -79,7 +79,7 @@ public actor PrivatePreferences {
 
 	@available(*, deprecated, message: "syncConsent is deprecated. Use `sync()` instead.")
 	public func syncConsent() async throws {
-		try await ffiClient.sendSyncRequest(kind: .consent)
+		try await ffiClient.sendSyncRequest()
 	}
 
 	public func streamConsent()

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.2.0-dev"
+  spec.version      = "4.2.0-rc1"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.2.0-dev.4ba3b55'
+  spec.dependency 'LibXMTP', '= 4.2.0-rc1'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.2.0-rc1"
+  spec.version      = "4.2.0-rc2"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.2.0-rc1'
+  spec.dependency 'LibXMTP', '= 4.2.0-rc2'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "ce2f27d5e29ef10dd7bc1d293d6612a2791bafa9",
-        "version" : "4.2.0-rc1"
+        "revision" : "8871931f9d9257d12de7da8a3fc3d6962074bc7d",
+        "version" : "4.2.0-rc2"
       }
     },
     {

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "e9893f6449cf3b3b8d91c059a7372d099cc75d35",
-        "version" : "4.2.0-dev.4ba3b55"
+        "revision" : "ce2f27d5e29ef10dd7bc1d293d6612a2791bafa9",
+        "version" : "4.2.0-rc1"
       }
     },
     {


### PR DESCRIPTION
## Introduction 📟
<!-- Brief explanation of the problem to be solved / bug to be fixed. -->

- [x] Adds the ability to optimistically create groups
- [x] Adds the ability to get all topics including duplicate dms for conversations
- [x] Adds ability to get all topics for a individual conversation
- [x] Adds ability to filter consent state from streamAll
- [x] Adds extra logging to signingkey errors
- [x] Adds ability to get HmacKeys for a individual conversation
- [x] Bumps bindings to latest
- [x] Add conversation debug information

Tests
- [ ] Add history sync testing - leaving out for now
- [x] optimistic group creation
- [x] testCanStreamAllMessagesFilterConsent
- [x] testReturnsAllTopics
- [ ] maybeForked debug info - leaving out for now


related android prs:
- https://github.com/xmtp/xmtp-android/pull/361
- https://github.com/xmtp/xmtp-android/pull/421

## Purpose ℹ️ 
<!-- What is the goal of the proposed change? -->

## Scope 🔭
<!-- What is the technical scope of the changes? -->

<!-- Beginning of comment block
From this point on, all the following titles are optional.
Move the ones you need out of the comment block and delete the rest of the template.
There is a table example included for screenshots

## Out of Scope ⚔️

## Testing 🧪

## TODOs ☑️
- [ ] [Change log] updated or ignored

## Discussion 🎙

End of comment block -->
