### PR TITLE
Release for query improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.5")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.2.6")
 	],
 	targets: [
 		.target(

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.2.3"
+  spec.version      = "4.2.4"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.2.5'
+  spec.dependency 'LibXMTP', '= 4.2.6'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "50184ea9a5f2a6e7113d9089fbb8de0297ea6d65",
-        "version" : "4.2.5"
+        "revision" : "f1f7e801af14df0912b5b527e0af5a597e61b07d",
+        "version" : "4.2.6"
       }
     },
     {


### PR DESCRIPTION
### Update XMTP iOS SDK and libxmtp-swift dependency versions for query improvements
Updates dependency versions across the XMTP iOS project configuration files. The changes include updating `libxmtp-swift` from version 4.2.5 to 4.2.6 in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/527/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e), updating the XMTP pod version from 4.2.3 to 4.2.4 and its `LibXMTP` dependency from 4.2.5 to 4.2.6 in [XMTP.podspec](https://github.com/xmtp/xmtp-ios/pull/527/files#diff-e9237cf856d38a9701faf84ef515c0d8d2880b467403b12cbe0792edf2cda630), and regenerating the Swift Package Manager dependency resolution file [Package.resolved](https://github.com/xmtp/xmtp-ios/pull/527/files#diff-add3b2102ccf924b8acf1f25e7b834d18f0ca5cdcec24007b33dfec923d7feed).

#### 📍Where to Start
Start with the version updates in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/527/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e) to see the primary dependency changes.

----

_[Macroscope](https://app.macroscope.com) summarized 2d1a70a._