### PR TITLE
Add lock to CodecRegistry for thread safety

### DIFF
--- a/Sources/XMTPiOS/CodecRegistry.swift
+++ b/Sources/XMTPiOS/CodecRegistry.swift
@@ -7,16 +7,22 @@
 
 import Foundation
 
-struct CodecRegistry {
-	var codecs: [String: any ContentCodec] = [
+class CodecRegistry {
+	private let lock = NSLock()
+	private var codecs: [String: any ContentCodec] = [
 		TextCodec().id: TextCodec(),
 	]
 
-	mutating func register(codec: any ContentCodec) {
+	func register(codec: any ContentCodec) {
+		lock.lock()
+		defer { lock.unlock() }
 		codecs[codec.id] = codec
 	}
 
 	func find(for contentType: ContentTypeID?) -> any ContentCodec {
+		lock.lock()
+		defer { lock.unlock() }
+
 		guard let contentType else {
 			return TextCodec()
 		}
@@ -29,6 +35,9 @@ struct CodecRegistry {
 	}
 
 	func find(for contentTypeString: String) -> any ContentCodec {
+		lock.lock()
+		defer { lock.unlock() }
+
 		for (_, codec) in codecs {
 			if codec.description == contentTypeString {
 				return codec
@@ -41,10 +50,20 @@ struct CodecRegistry {
 
 extension CodecRegistry {
     func isRegistered(codec: any ContentCodec) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
         return codecs[codec.id] != nil
     }
-    
+
     func isRegistered(codecId: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
         return codecs[codecId] != nil
+    }
+
+    func removeCodec(for id: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        codecs.removeValue(forKey: id)
     }
 }

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -77,7 +77,7 @@ class CodecTests: XCTestCase {
 			options: .init(contentType: NumberCodec().contentType))
 
 		// Remove number codec from registry
-		Client.codecRegistry.codecs.removeValue(forKey: NumberCodec().id)
+		Client.codecRegistry.removeCodec(for: NumberCodec().id)
 
 		let messages = try await alixConversation.messages()
 		XCTAssertEqual(messages.count, 2)


### PR DESCRIPTION
## Introduction 📟
In my tests I was creating a bunch of clients and frequently saw a `EXC_BAD_ACCESS` crash on `CodecRegistry`

## Purpose ℹ️ 
Make `CodecRegistry` thread safe

## Scope 🔭
Adds a lock to `CodecRegistry` and replaces `codecs.remove()` with `removeCodec(for:)`
