### PR TITLE
Release 4.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.3"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.3.0-rc2")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.3.0")
 	],
 	targets: [
 		.target(

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.3.0-rc2"
+  spec.version      = "4.3.0"
 
   spec.summary      = "XMTP SDK Cocoapod"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.3.0-rc2'
+  spec.dependency 'LibXMTP', '= 4.3.0'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "f70a3d6273eb5a3247846f3f3c8379137672aa5d",
-        "version" : "4.3.0-rc2"
+        "revision" : "f5e8891dd8f4656cb7c9ceba2c87a90559a90cf3",
+        "version" : "4.3.0"
       }
     },
     {


### PR DESCRIPTION
### Release version 4.3.0 by updating libxmtp-swift dependency and podspec version from 4.3.0-rc2 to 4.3.0
This pull request updates version numbers from release candidate 4.3.0-rc2 to final release 4.3.0 across multiple configuration files:

- Updates the `libxmtp-swift` dependency version in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/533/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e)
- Updates the spec version and `LibXMTP` dependency version in [XMTP.podspec](https://github.com/xmtp/xmtp-ios/pull/533/files#diff-e9237cf856d38a9701faf84ef515c0d8d2880b467403b12cbe0792edf2cda630)
- Updates Swift Package Manager dependency resolution in [Package.resolved](https://github.com/xmtp/xmtp-ios/pull/533/files#diff-add3b2102ccf924b8acf1f25e7b834d18f0ca5cdcec24007b33dfec923d7feed)

#### 📍Where to Start
Start with the version updates in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/533/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e) to see the main dependency version change from 4.3.0-rc2 to 4.3.0.

----

_[Macroscope](https://app.macroscope.com) summarized 44be289._