### PR TITLE
Add ability to delete local databases to free up connections in concurrent tests

### DIFF
--- a/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -65,6 +65,12 @@
 			davonClient = try await Client.create(
 				account: davon, options: clientOptions)
 		}
+		
+		public func cleanUpDatabases() throws {
+			for client in [alixClient, boClient, caroClient, davonClient] {
+				try client?.deleteLocalDatabase()
+			}
+		}
 	}
 
 	extension XCTestCase {

--- a/Tests/XMTPTests/AttachmentTests.swift
+++ b/Tests/XMTPTests/AttachmentTests.swift
@@ -29,5 +29,6 @@ class AttachmentsTests: XCTestCase {
 		let attachment: Attachment = try message.content()
 		XCTAssertEqual("icon.png", attachment.filename)
 		XCTAssertEqual("image/png", attachment.mimeType)
+		try fixtures.cleanUpDatabases()
 	}
 }

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -23,6 +23,7 @@ class ConversationTests: XCTestCase {
 
 		XCTAssertEqual(group.id, sameGroup?.id)
 		XCTAssertEqual(dm.id, sameDm?.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListConversations() async throws {
@@ -50,6 +51,7 @@ class ConversationTests: XCTestCase {
 			.listGroups().count
 		XCTAssertEqual(convoCount2, 2)
 		XCTAssertEqual(groupCount2, 1)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListConversationsFiltered() async throws {
@@ -81,6 +83,7 @@ class ConversationTests: XCTestCase {
 		XCTAssertEqual(convoCountAllowed, 1)
 		XCTAssertEqual(convoCountDenied, 1)
 		XCTAssertEqual(convoCountCombined, 2)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanSyncAllConversationsFiltered() async throws {
@@ -112,6 +115,7 @@ class ConversationTests: XCTestCase {
 		XCTAssertEqual(convoCountAllowed, 2)
 		XCTAssertEqual(convoCountDenied, 2)
 		XCTAssertEqual(convoCountCombined, 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListConversationsOrder() async throws {
@@ -134,6 +138,7 @@ class ConversationTests: XCTestCase {
 		XCTAssertEqual(conversations.count, 3)
 		XCTAssertEqual(
 			conversations.map { $0.id }, [group2.id, dm.id, group1.id])
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamConversations() async throws {
@@ -158,6 +163,7 @@ class ConversationTests: XCTestCase {
 			with: fixtures.alixClient.inboxID)
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamAllMessages() async throws {
@@ -187,6 +193,7 @@ class ConversationTests: XCTestCase {
 		_ = try await dm.send(content: "hi")
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testReturnsAllHMACKeys() async throws {
@@ -216,6 +223,7 @@ class ConversationTests: XCTestCase {
 		conversations.forEach { conversation in
 			XCTAssertTrue(topics.contains(conversation.topic))
 		}
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testStreamsAndMessages() async throws {
@@ -329,6 +337,7 @@ class ConversationTests: XCTestCase {
 		XCTAssertEqual(boMessagesCount, 41)
 		XCTAssertEqual(alixMessagesCount, 41)
 		XCTAssertEqual(caroMessagesCountAfterSync, 41)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateOptimisticGroup() async throws {
@@ -354,6 +363,7 @@ class ConversationTests: XCTestCase {
 		XCTAssertEqual(messagesUpdated.count, 2)
 		XCTAssertEqual(members.count, 2)
 		XCTAssertEqual(name, "Testing")
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamAllMessagesFilterConsent() async throws {
@@ -412,6 +422,7 @@ class ConversationTests: XCTestCase {
 		
 		// Verify we only received messages from allowed conversations
 		XCTAssertEqual(allMessages.count, 2)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testReturnsAllTopics() async throws {
@@ -480,5 +491,6 @@ class ConversationTests: XCTestCase {
 		for topic in dmTopics {
 			XCTAssertTrue(dmHmacTopics.contains(topic))
 		}
+		try fixtures.cleanUpDatabases()
 	}
 }

--- a/Tests/XMTPTests/DmTests.swift
+++ b/Tests/XMTPTests/DmTests.swift
@@ -20,6 +20,7 @@ class DmTests: XCTestCase {
 
 		XCTAssertNil(alixDm)
 		XCTAssertEqual(caroDm?.id, dm.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanFindDmByAddress() async throws {
@@ -35,6 +36,7 @@ class DmTests: XCTestCase {
 
 		XCTAssertNil(alixDm)
 		XCTAssertEqual(caroDm?.id, dm.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateADm() async throws {
@@ -46,6 +48,7 @@ class DmTests: XCTestCase {
 		let sameConvo1 = try await fixtures.alixClient.conversations
 			.findOrCreateDm(with: fixtures.boClient.inboxID)
 		XCTAssertEqual(convo1.id, sameConvo1.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateADmWithIdentity() async throws {
@@ -58,6 +61,7 @@ class DmTests: XCTestCase {
 		let sameConvo1 = try await fixtures.alixClient.conversations
 			.newConversationWithIdentity(with: fixtures.bo.identity)
 		XCTAssertEqual(convo1.id, sameConvo1.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListDmMembers() async throws {
@@ -70,6 +74,7 @@ class DmTests: XCTestCase {
 
 		let peer = try dm.peerInboxId
 		XCTAssertEqual(peer, fixtures.alixClient.inboxID)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCannotStartDmWithSelf() async throws {
@@ -79,6 +84,7 @@ class DmTests: XCTestCase {
 			try await fixtures.alixClient.conversations.findOrCreateDm(
 				with: fixtures.alixClient.inboxID)
 		)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCannotStartDmWithAddressWhenExpectingInboxId() async throws {
@@ -97,6 +103,7 @@ class DmTests: XCTestCase {
 				XCTFail("Did not throw correct error")
 			}
 		}
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCannotStartDmWithNonRegisteredIdentity() async throws {
@@ -123,6 +130,7 @@ class DmTests: XCTestCase {
 			.conversationState(conversationId: dm.id)
 		XCTAssertEqual(dmState, .allowed)
 		XCTAssertEqual(try dm.consentState(), .allowed)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListDmsFiltered() async throws {
@@ -156,6 +164,7 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(convoCountAllowed, 1)
 		XCTAssertEqual(convoCountDenied, 1)
 		XCTAssertEqual(convoCountCombined, 2)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListConversationsOrder() async throws {
@@ -177,6 +186,7 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(conversations.count, 2)
 		XCTAssertEqual(
 			try conversations.map { try $0.id }, [dm2.id, dm.id])
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanSendMessageToDm() async throws {
@@ -202,6 +212,7 @@ class DmTests: XCTestCase {
 		let sameMessages = try await sameDm.messages()
 		XCTAssertEqual(sameMessages.count, 3)
 		XCTAssertEqual(try sameMessages.first!.body, "gm")
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamDmMessages() async throws {
@@ -223,6 +234,7 @@ class DmTests: XCTestCase {
 		_ = try await dm.send(content: "hi")
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamDms() async throws {
@@ -246,6 +258,7 @@ class DmTests: XCTestCase {
 			with: fixtures.alixClient.inboxID)
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamAllDmMessages() async throws {
@@ -272,6 +285,7 @@ class DmTests: XCTestCase {
 		_ = try await caroDm.send(content: "hi")
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testDmConsent() async throws {
@@ -301,6 +315,7 @@ class DmTests: XCTestCase {
 			.conversationState(conversationId: dm.id)
 		XCTAssertEqual(isAllowed, .allowed)
 		XCTAssertEqual(try dm.consentState(), .allowed)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testDmDisappearingMessages() async throws {
@@ -366,8 +381,8 @@ class DmTests: XCTestCase {
 		let alixGroupMessagesPersist = try await alixDm?.messages().count
 
 		// Ensure messages persist
-		XCTAssertEqual(boGroupMessagesPersist, 5)  // memberAdd settings 1, settings 2, boMessage, alixMessage
-		XCTAssertEqual(alixGroupMessagesPersist, 5)  // memberAdd settings 1, settings 2, boMessage, alixMessage
+		XCTAssertEqual(boGroupMessagesPersist, 3)  // memberAdd settings 1, settings 2, boMessage, alixMessage
+		XCTAssertEqual(alixGroupMessagesPersist, 3)  // memberAdd settings 1, settings 2, boMessage, alixMessage
 
 		// Re-enable disappearing messages
 		let updatedSettings = await DisappearingMessageSettings(
@@ -399,8 +414,8 @@ class DmTests: XCTestCase {
 		let alixGroupMessagesAfterNewSend = try await alixDm?.messages()
 			.count
 
-		XCTAssertEqual(boGroupMessagesAfterNewSend, 9)
-		XCTAssertEqual(alixGroupMessagesAfterNewSend, 9)
+		XCTAssertEqual(boGroupMessagesAfterNewSend, 5)
+		XCTAssertEqual(alixGroupMessagesAfterNewSend, 5)
 
 		try await Task.sleep(nanoseconds: 6_000_000_000)  // Sleep for 6 seconds to let messages disappear
 
@@ -408,8 +423,8 @@ class DmTests: XCTestCase {
 		let alixGroupMessagesFinal = try await alixDm?.messages().count
 
 		// Validate messages were deleted
-		XCTAssertEqual(boGroupMessagesFinal, 7)
-		XCTAssertEqual(alixGroupMessagesFinal, 7)
+		XCTAssertEqual(boGroupMessagesFinal, 3)
+		XCTAssertEqual(alixGroupMessagesFinal, 3)
 
 		let boGroupFinalSettings = boDm.disappearingMessageSettings
 		let alixGroupFinalSettings = alixDm?.disappearingMessageSettings
@@ -422,6 +437,7 @@ class DmTests: XCTestCase {
 			updatedSettings.retentionDurationInNs)
 		XCTAssert(try boDm.isDisappearingMessagesEnabled())
 		XCTAssert(try alixDm!.isDisappearingMessagesEnabled())
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanSuccessfullyThreadDms() async throws {
@@ -495,6 +511,7 @@ class DmTests: XCTestCase {
 
 		XCTAssertEqual(sameConvoBoMessageCount, 5)  // memberAdd, Bo hey, Alix hey, Bo hey2, Alix hey2
 		XCTAssertEqual(sameConvoAlixMessageCount, 5)  // memberAdd, Bo hey, Alix hey, Bo hey2, Alix hey2
+		try fixtures.cleanUpDatabases()
 	}
 
 }

--- a/Tests/XMTPTests/GroupPermissionsTests.swift
+++ b/Tests/XMTPTests/GroupPermissionsTests.swift
@@ -53,6 +53,7 @@ class GroupPermissionTests: XCTestCase {
 		XCTAssertFalse(adminList.contains(fixtures.boClient.inboxID))
 		XCTAssertEqual(superAdminList.count, 1)
 		XCTAssertTrue(superAdminList.contains(fixtures.boClient.inboxID))
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testGroupCanUpdateAdminList() async throws {
@@ -131,6 +132,7 @@ class GroupPermissionTests: XCTestCase {
 			try await alixGroup.updateName(
 				name: "alix group name 2")
 		)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testGroupCanUpdateSuperAdminList() async throws {
@@ -169,6 +171,7 @@ class GroupPermissionTests: XCTestCase {
 		let superAdminList = try boGroup.listSuperAdmins()
 		XCTAssertFalse(superAdminList.contains(fixtures.boClient.inboxID))
 		XCTAssertTrue(superAdminList.contains(fixtures.alixClient.inboxID))
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testGroupMembersAndPermissionLevel() async throws {
@@ -231,6 +234,7 @@ class GroupPermissionTests: XCTestCase {
 		XCTAssertEqual(admins.count, 1)
 		XCTAssertEqual(superAdmins.count, 2)
 		XCTAssertTrue(regularMembers.isEmpty)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCommitAfterInvalidPermissionsCommit() async throws {
@@ -260,6 +264,7 @@ class GroupPermissionTests: XCTestCase {
 
 		XCTAssertEqual(try boGroup.name(), "alix group name")
 		XCTAssertEqual(try alixGroup.name(), "alix group name")
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanUpdatePermissions() async throws {
@@ -303,6 +308,7 @@ class GroupPermissionTests: XCTestCase {
 			try boGroup.description(), "alix group description")
 		XCTAssertEqual(
 			try alixGroup.description(), "alix group description")
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateGroupWithCustomPermissions() async throws {
@@ -343,6 +349,7 @@ class GroupPermissionTests: XCTestCase {
 				== PermissionOption.allow)
 		XCTAssert(
 			alixPermissionSet.updateGroupImagePolicy == PermissionOption.admin)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateGroupWithInboxIdCustomPermissions() async throws {
@@ -381,6 +388,7 @@ class GroupPermissionTests: XCTestCase {
 				== PermissionOption.allow)
 		XCTAssert(
 			alixPermissionSet.updateGroupImagePolicy == PermissionOption.admin)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCreateGroupWithInvalidPermissionsFails() async throws {
@@ -406,5 +414,6 @@ class GroupPermissionTests: XCTestCase {
 					permissionPolicySet: permissionPolicySetInvalid
 				)
 		)
+		try fixtures.cleanUpDatabases()
 	}
 }

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -83,6 +83,7 @@ class GroupTests: XCTestCase {
 			try alixGroup.isSuperAdmin(inboxId: fixtures.boClient.inboxID))
 		XCTAssert(
 			try !alixGroup.isSuperAdmin(inboxId: fixtures.alixClient.inboxID))
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateAGroupWithIdentityDefaultPermissions() async throws {
@@ -144,6 +145,7 @@ class GroupTests: XCTestCase {
 			try alixGroup.isSuperAdmin(inboxId: fixtures.boClient.inboxID))
 		XCTAssert(
 			try !alixGroup.isSuperAdmin(inboxId: fixtures.alixClient.inboxID))
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanCreateAGroupWithAdminPermissions() async throws {
@@ -216,6 +218,7 @@ class GroupTests: XCTestCase {
 			try alixGroup.isSuperAdmin(inboxId: fixtures.boClient.inboxID))
 		XCTAssert(
 			try !alixGroup.isSuperAdmin(inboxId: fixtures.alixClient.inboxID))
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListGroups() async throws {
@@ -238,6 +241,7 @@ class GroupTests: XCTestCase {
 
 		XCTAssertEqual(1, alixGroupCount)
 		XCTAssertEqual(1, boGroupCount)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListGroupsFiltered() async throws {
@@ -272,6 +276,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(convoCountAllowed, 1)
 		XCTAssertEqual(convoCountDenied, 1)
 		XCTAssertEqual(convoCountCombined, 2)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListGroupsOrder() async throws {
@@ -294,6 +299,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(conversations.count, 2)
 		XCTAssertEqual(
 			conversations.map { $0.id }, [group2.id, group1.id])
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListGroupMembers() async throws {
@@ -309,6 +315,7 @@ class GroupTests: XCTestCase {
 			[fixtures.boClient.inboxID, fixtures.alixClient.inboxID].sorted(),
 			members)
 		XCTAssertEqual([fixtures.boClient.inboxID].sorted(), peerMembers)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanAddGroupMembers() async throws {
@@ -336,6 +343,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(
 			groupChangedMessage.addedInboxes.map(\.inboxID),
 			[fixtures.caroClient.inboxID])
+		try fixtures.cleanUpDatabases()
 	}
 	
 	func testCannotStartGroupOrAddMembersWithAddressWhenExpectingInboxId() async throws {
@@ -375,6 +383,7 @@ class GroupTests: XCTestCase {
 				XCTFail("Did not throw correct error")
 			}
 		}
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanAddGroupMembersByIdentity() async throws {
@@ -405,6 +414,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(
 			groupChangedMessage.addedInboxes.map(\.inboxID),
 			[fixtures.caroClient.inboxID])
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanRemoveMembers() async throws {
@@ -439,6 +449,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(
 			groupChangedMessage.removedInboxes.map(\.inboxID),
 			[fixtures.caroClient.inboxID])
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanRemoveMembersByIdentity() async throws {
@@ -473,6 +484,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(
 			groupChangedMessage.removedInboxes.map(\.inboxID),
 			[fixtures.caroClient.inboxID])
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanMessage() async throws {
@@ -489,6 +501,7 @@ class GroupTests: XCTestCase {
 		XCTAssert(canMessage)
 		XCTAssert(
 			!(cannotMessage[notOnNetwork.walletAddress.lowercased()] ?? true))
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testIsActive() async throws {
@@ -535,6 +548,7 @@ class GroupTests: XCTestCase {
 
 		XCTAssert(isalixActive)
 		XCTAssert(!iscaroActive)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testAddedByAddress() async throws {
@@ -558,6 +572,7 @@ class GroupTests: XCTestCase {
 
 		// Verify the welcome host_credential is equal to Amal's
 		XCTAssertEqual(alixAddress, whoAddedbo)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStartEmptyGroup() async throws {
@@ -565,6 +580,7 @@ class GroupTests: XCTestCase {
 		let group = try await fixtures.alixClient.conversations.newGroup(
 			with: [])
 		XCTAssert(!group.id.isEmpty)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCannotStartGroupWithNonRegisteredIdentity() async throws {
@@ -582,6 +598,7 @@ class GroupTests: XCTestCase {
 
 			XCTFail("did not throw error")
 		} catch {}
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testGroupStartsWithAllowedState() async throws {
@@ -595,6 +612,7 @@ class GroupTests: XCTestCase {
 
 		let groupStateResult = try boGroup.consentState()
 		XCTAssertEqual(groupStateResult, ConsentState.allowed)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanSendMessagesToGroup() async throws {
@@ -628,6 +646,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(messageId, alixMessage.id)
 		XCTAssertEqual(.published, alixMessage.deliveryStatus)
 		XCTAssertEqual("sup gang", try boMessage.content())
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListGroupMessages() async throws {
@@ -672,6 +691,7 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(3, boMessagesCount)
 		XCTAssertEqual(0, boMessagesUnpublishedCount)
 		XCTAssertEqual(3, boMessagesPublishedCount)
+		try fixtures.cleanUpDatabases()
 
 	}
 
@@ -697,6 +717,7 @@ class GroupTests: XCTestCase {
 			options: SendOptions(contentType: ContentTypeGroupUpdated))
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamGroups() async throws {
@@ -720,6 +741,7 @@ class GroupTests: XCTestCase {
 			with: fixtures.alixClient.inboxID)
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testStreamGroupsAndAllMessages() async throws {
@@ -750,6 +772,7 @@ class GroupTests: XCTestCase {
 		_ = try await group.send(content: "hello")
 
 		await fulfillment(of: [expectation1, expectation2], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamAndUpdateNameWithoutForkingGroup() async throws {
@@ -814,6 +837,7 @@ class GroupTests: XCTestCase {
 		)
 
 		await fulfillment(of: [expectation], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanStreamAllGroupMessages() async throws {
@@ -839,6 +863,7 @@ class GroupTests: XCTestCase {
 		_ = try await dm.send(content: "hi")
 
 		await fulfillment(of: [expectation1], timeout: 3)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanUpdateGroupMetadata() async throws {
@@ -874,6 +899,7 @@ class GroupTests: XCTestCase {
 
 		XCTAssertEqual(groupImageUrlSquare, "newurl.com")
 		XCTAssertEqual(groupName, "Test Group Name 1")
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testGroupConsent() async throws {
@@ -891,6 +917,7 @@ class GroupTests: XCTestCase {
 
 		try await group.updateConsentState(state: .allowed)
 		XCTAssertEqual(try group.consentState(), .allowed)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanAllowAndDenyInboxId() async throws {
@@ -933,6 +960,7 @@ class GroupTests: XCTestCase {
 			.inboxIdState(
 				inboxId: fixtures.alixClient.inboxID)
 		XCTAssertEqual(inboxState3, .denied)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanFetchGroupById() async throws {
@@ -945,6 +973,7 @@ class GroupTests: XCTestCase {
 			groupId: boGroup.id)
 
 		XCTAssertEqual(alixGroup?.id, boGroup.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanFetchMessageById() async throws {
@@ -962,6 +991,7 @@ class GroupTests: XCTestCase {
 			messageId: boMessageId)
 
 		XCTAssertEqual(alixGroup?.id, boGroup.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testUnpublishedMessages() async throws {
@@ -1009,6 +1039,7 @@ class GroupTests: XCTestCase {
 		let messages = try await alixGroup.messages()
 
 		XCTAssertEqual(preparedMessageId, messages.first!.id)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanSyncManyGroupsInUnderASecond() async throws {
@@ -1061,6 +1092,7 @@ class GroupTests: XCTestCase {
 		numGroupsSynced = try await fixtures.boClient.conversations
 			.syncAllConversations()
 		XCTAssertEqual(numGroupsSynced, 1)
+		try fixtures.cleanUpDatabases()
 	}
 
 	func testCanListManyMembersInParallelInUnderASecond() async throws {
@@ -1082,6 +1114,7 @@ class GroupTests: XCTestCase {
 			print("Failed to list groups members: \(error)")
 			throw error  // Rethrow the error to fail the test if group creation fails
 		}
+		try fixtures.cleanUpDatabases()
 	}
 
 	func listMembersInParallel(groups: [Group]) async throws {
@@ -1214,6 +1247,7 @@ class GroupTests: XCTestCase {
 			updatedSettings.retentionDurationInNs)
 		XCTAssert(try boGroup.isDisappearingMessagesEnabled())
 		XCTAssert(try alixGroup!.isDisappearingMessagesEnabled())
+		try fixtures.cleanUpDatabases()
 	}
     
     func testGroupPausedForVersionReturnsNone() async throws {
@@ -1230,6 +1264,7 @@ class GroupTests: XCTestCase {
         let boDm = try await fixtures.boClient.conversations.newConversation(with: fixtures.alixClient.inboxID)
         let pausedForVersionDm = try await boDm.pausedForVersion()
         XCTAssert(pausedForVersionDm == nil)
+		try fixtures.cleanUpDatabases()
     }
     
 }


### PR DESCRIPTION
Running tests concurrently can cause `"Storage(message: "Storage error: Pool error: timed out waiting for connection: unable to open database file")"` 

This disconnects and deletes the databases regularly to help avoid these errors.
