### PR TITLE
Update GitHub Action for caching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
           ruby-version: 3.0
 
       - name: Cache Ruby gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
The "Deploy docs content" job currently fails because it is using a deprecated version of GitHub's caching action ([see announcement](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)). This PR upgrades `actions/cache` to the most recent version.