### PR TITLE
Fix retain cycle in Client

### DIFF
--- a/Sources/XMTPiOS/Client.swift
+++ b/Sources/XMTPiOS/Client.swift
@@ -88,23 +88,23 @@ public struct ClientOptions {
 }
 
 actor ApiClientCache {
-	private var apiClientCache: [String: XmtpApiClient] = [:]
-	private var syncApiClientCache: [String: XmtpApiClient] = [:]
+    private var apiClientCache: NSMapTable<NSString, XmtpApiClient> = .weakToWeakObjects()
+	private var syncApiClientCache: NSMapTable<NSString, XmtpApiClient> = .weakToWeakObjects()
 
 	func getClient(forKey key: String) -> XmtpApiClient? {
-		return apiClientCache[key]
+        return apiClientCache.object(forKey: key as NSString)
 	}
 
 	func setClient(_ client: XmtpApiClient, forKey key: String) {
-		apiClientCache[key] = client
+        apiClientCache.setObject(client, forKey: key as NSString)
 	}
 
 	func getSyncClient(forKey key: String) -> XmtpApiClient? {
-		return syncApiClientCache[key]
+        return syncApiClientCache.object(forKey: key as NSString)
 	}
 
 	func setSyncClient(_ client: XmtpApiClient, forKey key: String) {
-		syncApiClientCache[key] = client
+        syncApiClientCache.setObject(client, forKey: key as NSString)
 	}
 }
 

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -73,7 +73,7 @@ actor FfiStreamActor {
 
 /// Handles listing and creating Conversations.
 public class Conversations {
-	var client: Client
+	unowned var client: Client
 	var ffiConversations: FfiConversations
 	var ffiClient: FfiXmtpClient
 

--- a/Sources/XMTPiOS/Libxmtp/XMTPDebugInformation.swift
+++ b/Sources/XMTPiOS/Libxmtp/XMTPDebugInformation.swift
@@ -9,7 +9,7 @@ import Foundation
 import LibXMTP
 
 public class XMTPDebugInformation {
-    private let client: Client
+    private unowned let client: Client
     private let ffiClient: FfiXmtpClient
     
     public init(client: Client, ffiClient: FfiXmtpClient) {

--- a/Sources/XMTPiOS/PrivatePreferences.swift
+++ b/Sources/XMTPiOS/PrivatePreferences.swift
@@ -45,7 +45,7 @@ public struct ConsentRecord: Codable, Hashable {
 
 /// Provides access to contact bundles.
 public actor PrivatePreferences {
-	var client: Client
+	unowned var client: Client
 	var ffiClient: FfiXmtpClient
 
 	init(client: Client, ffiClient: FfiXmtpClient) {


### PR DESCRIPTION
## Introduction 📟
`Client` kept a strong reference to `Conversations`, `PrivatePreferences`, and `XMTPDebugInformation`, all which kept a strong reference to `Client`. I also noticed that `XmtpApiClient` objects hung around because of `ApiClientCache` so I changed `ApiClientCache` so it holds weak references only.

## Purpose ℹ️ 
Fix retain cycle in `Client`

## Testing 🧪
Ran tests and checked the memory graph in the `example` app

