### PR TITLE
getLastReadTimes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "809aaf54c224978154e2c29f82c742d763498b59",
-        "version" : "4.5.0-dev.c3c2697"
+        "revision" : "189fb0d0734fda1f4afaaf37399a89a7fc425e0e",
+        "version" : "4.5.0-dev.f05d304"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", "1.8.4" ..< "2.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.5.0-dev.c3c2697")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.5.0-dev.f05d304")
 	],
 	targets: [
 		.target(

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -359,4 +359,15 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			return try dm.isActive()
 		}
 	}
+    
+    // Returns a dictionary where the keys are inbox IDs and the values
+    // are the timestamp in nanoseconds of their last read receipt
+    public func getLastReadTimes() throws -> Dictionary<String, Int64> {
+        switch self {
+            case let .group(group):
+            return try group.getLastReadTimes()
+        case let .dm(dm):
+            return try dm.getLastReadTimes()
+        }
+    }
 }

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -479,4 +479,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
     public func getDebugInformation() async throws -> ConversationDebugInfo {
         return ConversationDebugInfo(ffiConversationDebugInfo: try await ffiConversation.conversationDebugInfo())
     }
+    
+    public func getLastReadTimes() throws -> Dictionary<String, Int64> {
+        return try ffiConversation.getLastReadTimes()
+    }
 }

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -661,4 +661,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			ffiConversationDebugInfo: try await ffiGroup.conversationDebugInfo()
 		)
 	}
+    
+    public func getLastReadTimes() throws -> Dictionary<String, Int64> {
+        return try ffiGroup.getLastReadTimes()
+    }
 }

--- a/Tests/XMTPTests/DmTests.swift
+++ b/Tests/XMTPTests/DmTests.swift
@@ -513,4 +513,23 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(sameConvoAlixMessageCount, 5)  // memberAdd, Bo hey, Alix hey, Bo hey2, Alix hey2
 		try fixtures.cleanUpDatabases()
 	}
+    
+    func testLastReadTimes() async throws {
+        let fixtures = try await fixtures()
+        
+        let convoBo = try await fixtures.boClient.conversations.findOrCreateDm(
+            with: fixtures.alixClient.inboxID)
+        
+        Client.register(codec: ReadReceiptCodec())
+        let messageID = try await convoBo.send(
+            content: ReadReceipt(),
+            options: .init(contentType: ReadReceiptCodec().contentType))
+        
+        let message = try fixtures.boClient.conversations.findMessage(messageId: messageID)
+        
+        let lastReadTimes = try convoBo.getLastReadTimes()
+        
+        XCTAssertEqual(lastReadTimes.count, 1)
+        XCTAssertEqual(lastReadTimes[fixtures.boClient.inboxID], message?.sentAtNs)
+    }
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.5.0-dev.c3c2697'
+  spec.dependency 'LibXMTP', '= 4.5.0-dev.f05d304'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   

--- a/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XMTPiOSExample/XMTPiOSExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "6bbb0aacd82070cdef041e808402836c768e2f0e",
-        "version" : "4.4.0"
+        "revision" : "810215151922c1a34cd795e613cd1ce1c0967ba1",
+        "version" : "4.5.0-dev.4d117dc"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin.git",
       "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "914081701062b11e3bb9e21accc379822621995e",
-        "version" : "2.76.1"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "eaa71bb6ae082eee5a07407b1ad0cbd8f48f9dca",
-        "version" : "1.34.1"
+        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
+        "version" : "1.38.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "c7e95421334b1068490b5d41314a50e70bab23d1",
-        "version" : "2.29.0"
+        "revision" : "385f5bd783ffbfff46b246a7db7be8e4f04c53bd",
+        "version" : "2.33.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+        "revision" : "e3f69fd321d0c9fcdc16fb576a0cdd956675face",
+        "version" : "1.31.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
+        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
+        "version" : "1.6.2"
       }
     }
   ],


### PR DESCRIPTION
### Add `Conversation.getLastReadTimes()` to return per-participant last-read timestamps for DM and group conversations

- In [Group.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83), add `Group.getLastReadTimes()` but invoke `ffiConversation.getLastReadTimes()` instead of `ffiGroup.getLastReadTimes()`, introducing an undefined identifier compile-time error.
- In [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1), add public `Conversation.getLastReadTimes()` that returns `Dictionary<String, Int64>` by delegating to the underlying `Group` or `Dm` instance.
- In [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6), add public `Dm.getLastReadTimes()` that throws and returns `Dictionary<String, Int64>` via `ffiConversation.getLastReadTimes()`.
- In [Package.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e) and [XMTP.podspec](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-e9237cf856d38a9701faf84ef515c0d8d2880b467403b12cbe0792edf2cda630), update `LibXMTP` pin from `4.5.0-dev.c3c2697` to `4.5.0-dev.4d117dc`.
- In [Package.resolved](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-3b22d20b6ae7cdf1e2591c647bcae94a3db9ab955f497aeb9d0715f468e6e6ce), update the generated lockfile to match the new dependency resolution.

#### 📍Where to Start

Start with `Conversation.getLastReadTimes()` in [Sources/XMTPiOS/Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1), then review `Group.getLastReadTimes()` in [Sources/XMTPiOS/Group.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83) to address the `ffiConversation` vs `ffiGroup` identifier, followed by `Dm.getLastReadTimes()` in [Sources/XMTPiOS/Dm.swift](https://github.com/xmtp/xmtp-ios/pull/560/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6).

---

[_Macroscope](https://app.macroscope.com) summarized 305c872._