### PR TITLE
Rename to enrichedMessages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp-swift.git",
       "state" : {
-        "revision" : "d6d6ba0f3151e85a25659d0c0626475e7e23f9e3",
-        "version" : "4.5.0-dev.891411c"
+        "revision" : "2708ce99f656352dbb0b50b79d85142ce71766c5",
+        "version" : "4.5.0-dev.b31478c"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e3f69fd321d0c9fcdc16fb576a0cdd956675face",
-        "version" : "1.31.0"
+        "revision" : "2547102afd04fe49f1b286090f13ebce07284980",
+        "version" : "1.31.1"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
-        "version" : "1.6.2"
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 		.package(url: "https://github.com/bufbuild/connect-swift", exact: "1.0.0"),
 		.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
 		.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", "1.8.4" ..< "2.0.0"),
-		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.5.0-dev.891411c")
+		.package(url: "https://github.com/xmtp/libxmtp-swift.git", exact: "4.5.0-dev.b31478c")
 	],
 	targets: [
 		.target(

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -321,7 +321,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public func messagesV2(
+	public func enrichedMessages(
 		limit: Int? = nil,
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
@@ -330,12 +330,12 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 	) async throws -> [DecodedMessageV2] {
 		switch self {
 		case let .group(group):
-			return try await group.findMessagesV2(
+			return try await group.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus
 			)
 		case let .dm(dm):
-			return try await dm.messagesV2(
+			return try await dm.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus
 			)

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -186,7 +186,7 @@ public class Conversations {
 		}
 	}
 
-	public func findMessageV2(messageId: String) throws -> DecodedMessageV2? {
+	public func findEnrichedMessage(messageId: String) throws -> DecodedMessageV2? {
 		do {
 			return DecodedMessageV2.create(ffiMessage: try ffiClient.messageV2(messageId: messageId.hexToData))
 		} catch {

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -393,7 +393,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public func messagesV2(
+	public func enrichedMessages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -575,7 +575,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 			}
 	}
 
-	public func findMessagesV2(
+	public func enrichedMessages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,

--- a/Tests/XMTPTests/CodecTests.swift
+++ b/Tests/XMTPTests/CodecTests.swift
@@ -64,7 +64,7 @@ class CodecTests: XCTestCase {
 			XCTAssertEqual(expectedContent, content)
 		}
         
-        let messagesV2 = try await alixConversation.messagesV2()
+        let messagesV2 = try await alixConversation.enrichedMessages()
         XCTAssertEqual(messagesV2.count, 2)
         if messages.count == 2 {
             let content: Double = try messages[0].content()

--- a/Tests/XMTPTests/HistorySyncTests.swift
+++ b/Tests/XMTPTests/HistorySyncTests.swift
@@ -158,12 +158,12 @@ class HistorySyncTests: XCTestCase {
 		try await alixGroup.send(content: "Hello")
 		try await alixClient.conversations.syncAllConversations()
 		try await alixClient2.conversations.syncAllConversations()
-		let alixGroup2 = try await alixClient2.conversations.findGroup(
+		let alixGroup2 = try alixClient2.conversations.findGroup(
 			groupId: alixGroup.id)!
 
 		var consentList = [ConsentRecord]()
 		let expectation = XCTestExpectation(description: "Stream Consent")
-		expectation.expectedFulfillmentCount = 3
+		expectation.expectedFulfillmentCount = 2
 
 		Task(priority: .userInitiated) {
 			for try await entry in await alixClient.preferences.streamConsent()
@@ -182,8 +182,7 @@ class HistorySyncTests: XCTestCase {
 		try await alixClient.conversations.syncAllConversations()
 		try await alixClient2.conversations.syncAllConversations()
 
-		await fulfillment(of: [expectation], timeout: 3)
-		print(consentList)
+		await fulfillment(of: [expectation], timeout:5)
 		XCTAssertEqual(try alixGroup.consentState(), .denied)
 	}
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'CSecp256k1', '~> 0.2'
   spec.dependency "Connect-Swift", "= 1.0.0"
-  spec.dependency 'LibXMTP', '= 4.5.0-dev.891411c'
+  spec.dependency 'LibXMTP', '= 4.5.0-dev.b31478c'
   spec.dependency 'CryptoSwift', '= 1.8.3'
   spec.dependency 'SQLCipher', '= 4.5.7'
   


### PR DESCRIPTION
### Rename Conversation.messagesV2, Dm.messagesV2, Group.findMessagesV2, and Conversations.findMessageV2 to enrichedMessages/findEnrichedMessage across XMTPiOS and update LibXMTP dependency to 4.5.0-dev.b31478c
This pull request renames the public message retrieval APIs to the `enrichedMessages` naming and updates the LibXMTP dependency pin. The changes propagate across conversation, DM, group, and conversation-collection surfaces, and update tests accordingly.

- Rename `Conversation.messagesV2(...)` to `Conversation.enrichedMessages(...)` and route to group/DM implementations in [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1)
- Rename `Dm.messagesV2(...)` to `Dm.enrichedMessages(...)` in [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6)
- Rename `Group.findMessagesV2(...)` to `Group.enrichedMessages(...)` in [Group.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83)
- Rename `Conversations.findMessageV2(messageId:)` to `Conversations.findEnrichedMessage(messageId:)` in [Conversations.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-b9587eee9f35d7dbdd1a43e110a8c85c63d9cb2d57da0a9850fa567d78fd7eec)
- Update tests to use `enrichedMessages` and adjust expectations and timeouts in [CodecTests.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-999abcddf9bcbdaf9fb588ec1177956239a7225aa5aad646a74fefc3dc284d70), [EnrichedMessagesTests.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-b723b91fe26a263ff41a178c8d3865a54a0c74ab695659bf3012fd0ffdba0e0a), and [HistorySyncTests.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-f797724d0e773469dd7e0c7e0d1463a4ef12484f3316e7bb2d29f5a70526576f)
- Bump lib dependency from `4.5.0-dev.891411c` to `4.5.0-dev.b31478c` in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e), [Package.resolved](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-3b22d20b6ae7cdf1e2591c647bcae94a3db9ab955f497aeb9d0715f468e6e6ce), and [XMTP.podspec](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-e9237cf856d38a9701faf84ef515c0d8d2880b467403b12cbe0792edf2cda630)

#### 📍Where to Start
Start with the public API surface in `Conversation.enrichedMessages(...)` in [Sources/XMTPiOS/Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/565/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1), then follow calls into `Group.enrichedMessages(...)` and `Dm.enrichedMessages(...)`.

----

_[Macroscope](https://app.macroscope.com) summarized d236ac7._