### PR TITLE
Update to libxmtp 4.5.0-rc2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.0-rc1.e5c3c75/LibXMTPSwiftFFI.zip",
-			checksum: "4dce1d93cfb02250add40fa6b33a839736057a32d497d1a56c7a5482456a2978"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.0-rc2.e5ff534/LibXMTPSwiftFFI.zip",
+			checksum: "f1854d443053463b5846091b57a275133c1d8ea85765ac303955ca7c3abd71c1"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.5.0-rc1"
+  spec.version      = "4.5.0-rc2"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.5.0-rc2. 
  
Changes:
- Updated XMTP.podspec version to 4.5.0-rc2
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: main