### PR TITLE
Update to libxmtp 4.5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.0-rc3.7ee9e36/LibXMTPSwiftFFI.zip",
-			checksum: "99edb914464867fddd72f600b524fbcdecaa34c8ecf75e6f17373cdbea52a46b"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.0.7b0a784/LibXMTPSwiftFFI.zip",
+			checksum: "8093d7e3b275283f54b88e40d962b92ce5775137416c466c08a83206d34c040f"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.5.0-rc3"
+  spec.version      = "4.5.0"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.5.0. 
  
Changes:
- Updated XMTP.podspec version to 4.5.0
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: main