### PR TITLE
Update to libxmtp 4.5.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.3.22dfeb4/LibXMTPSwiftFFI.zip",
-			checksum: "9f1d9e8409ee78a03816ad8e9b351092460ae02419300dca5ea99270e4b488e1"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.4.0a2e705/LibXMTPSwiftFFI.zip",
+			checksum: "d59392f586a3d80a4f2ba76c22228c48f08828eed18291edadbc8fdbc224d78b"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.5.3"
+  spec.version      = "4.5.4"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.5.4. 
  
Changes:
- Updated XMTP.podspec version to 4.5.4
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: main