### PR TITLE
Add ExcludeContentTypes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url:
-                "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.4.0a2e705/LibXMTPSwiftFFI.zip",
-            checksum: "d59392f586a3d80a4f2ba76c22228c48f08828eed18291edadbc8fdbc224d78b"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.3f76d5e/LibXMTPSwiftFFI.zip",
+            checksum: "a3c63fcaa57bcb1ab3cac659c56db4d2805de1274b819246eb8f6bb1053c078d"
         ),
         .target(
             name: "XMTPiOS",

--- a/Sources/XMTPiOS/Codecs/ContentTypeID.swift
+++ b/Sources/XMTPiOS/Codecs/ContentTypeID.swift
@@ -6,6 +6,7 @@
 //
 
 public typealias ContentTypeID = Xmtp_MessageContents_ContentTypeId
+public typealias StandardContentType = FfiContentType
 
 public extension ContentTypeID {
 	init(authorityID: String, typeID: String, versionMajor: Int, versionMinor: Int) {

--- a/Sources/XMTPiOS/Codecs/EncryptedEncodedContent.swift
+++ b/Sources/XMTPiOS/Codecs/EncryptedEncodedContent.swift
@@ -13,8 +13,8 @@ public struct EncryptedEncodedContent {
 	public var salt: Data
 	public var nonce: Data
 	public var payload: Data
-    public var filename: String?
-    public var contentLength: UInt32?
+	public var filename: String?
+	public var contentLength: UInt32?
 
 	public init(secret: Data, digest: String, salt: Data, nonce: Data, payload: Data, filename: String? = nil, contentLength: UInt32? = nil) {
 		self.secret = secret
@@ -22,7 +22,7 @@ public struct EncryptedEncodedContent {
 		self.salt = salt
 		self.nonce = nonce
 		self.payload = payload
-        self.filename = filename
-        self.contentLength = contentLength
+		self.filename = filename
+		self.contentLength = contentLength
 	}
 }

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -264,31 +264,34 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessage] {
 		switch self {
 		case let .group(group):
 			return try await group.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
-				direction: direction, deliveryStatus: deliveryStatus
+				direction: direction, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
 			)
 		case let .dm(dm):
 			return try await dm.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
-				direction: direction, deliveryStatus: deliveryStatus
+				direction: direction, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
 			)
 		}
 	}
 
-    // Returns null if conversation is not paused, otherwise the min version required to unpause this conversation
-    public func pausedForVersion() async throws -> String? {
-        switch self {
-        case let .group(group):
-            return try group.pausedForVersion()
-        case let .dm(dm):
-            return try dm.pausedForVersion()
-        }
-    }
+	// Returns null if conversation is not paused, otherwise the min version required to unpause this conversation
+	public func pausedForVersion() async throws -> String? {
+		switch self {
+		case let .group(group):
+			return try group.pausedForVersion()
+		case let .dm(dm):
+			return try dm.pausedForVersion()
+		}
+	}
 
 	public var client: Client {
 		switch self {
@@ -304,18 +307,21 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessage] {
 		switch self {
 		case let .group(group):
 			return try await group.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
-				direction: direction, deliveryStatus: deliveryStatus
+				direction: direction, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
 			)
 		case let .dm(dm):
 			return try await dm.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
-				direction: direction, deliveryStatus: deliveryStatus
+				direction: direction, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
 			)
 		}
 	}
@@ -325,34 +331,44 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessageV2] {
 		switch self {
 		case let .group(group):
 			return try await group.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
-				direction: direction, deliveryStatus: deliveryStatus
+				direction: direction, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
 			)
 		case let .dm(dm):
 			return try await dm.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
-				direction: direction, deliveryStatus: deliveryStatus
+				direction: direction, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
 			)
 		}
 	}
-    
-    public func countMessages(
-        beforeNs: Int64? = nil,
-        afterNs: Int64? = nil,
-        deliveryStatus: MessageDeliveryStatus = .all
-    ) throws -> Int64 {
-        switch self {
-        case let .group(group):
-            return try group.countMessages(beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus)
-        case let .dm(dm):
-            return try dm.countMessages(beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus)
-        }
-    }
+
+	public func countMessages(
+		beforeNs: Int64? = nil,
+		afterNs: Int64? = nil,
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
+	) throws -> Int64 {
+		switch self {
+		case let .group(group):
+			return try group.countMessages(
+				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
+			)
+		case let .dm(dm):
+			return try dm.countMessages(
+				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
+				excludeContentTypes: excludeContentTypes
+			)
+		}
+	}
 
 	public func getHmacKeys() throws -> Xmtp_KeystoreApi_V1_GetConversationHmacKeysResponse {
 		switch self {

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -274,7 +274,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -282,7 +283,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			limit: nil,
 			deliveryStatus: nil,
 			direction: nil,
-			contentTypes: nil
+			contentTypes: nil,
+			excludeContentTypes: nil
 		)
 
 		if let beforeNs {
@@ -322,11 +324,11 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}()
 
 		options.direction = direction
+		options.excludeContentTypes = excludeContentTypes
 
-		return try await ffiConversation.findMessages(opts: options).compactMap
-		{
+		return try await ffiConversation.findMessages(opts: options).compactMap {
 			ffiMessage in
-			return DecodedMessage.create(ffiMessage: ffiMessage)
+			DecodedMessage.create(ffiMessage: ffiMessage)
 		}
 	}
 
@@ -335,7 +337,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -343,7 +346,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			limit: nil,
 			deliveryStatus: nil,
 			direction: nil,
-			contentTypes: nil
+			contentTypes: nil,
+			excludeContentTypes: nil
 		)
 
 		if let beforeNs {
@@ -370,33 +374,40 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}()
 
 		options.direction = direction
+		options.excludeContentTypes = excludeContentTypes
 
 		return try ffiConversation.findMessagesWithReactions(
 			opts: options
 		).compactMap {
 			ffiMessageWithReactions in
-			return DecodedMessage.create(ffiMessage: ffiMessageWithReactions)
+			DecodedMessage.create(ffiMessage: ffiMessageWithReactions)
 		}
 	}
-    
-    // Count the number of messages in the conversation according to the provided filters
-    public func countMessages(beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all) throws -> Int64 {
-        return try ffiConversation.countMessages(opts: FfiListMessagesOptions(
-            sentBeforeNs: beforeNs,
-            sentAfterNs: afterNs,
-            limit: nil,
-            deliveryStatus: deliveryStatus.toFfi(),
-            direction: .descending,
-            contentTypes: nil
-        ))
-    }
+
+	// Count the number of messages in the conversation according to the provided filters
+	public func countMessages(
+		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
+	) throws -> Int64 {
+		return try ffiConversation.countMessages(
+			opts: FfiListMessagesOptions(
+				sentBeforeNs: beforeNs,
+				sentAfterNs: afterNs,
+				limit: nil,
+				deliveryStatus: deliveryStatus.toFfi(),
+				direction: .descending,
+				contentTypes: nil,
+				excludeContentTypes: excludeContentTypes
+			))
+	}
 
 	public func enrichedMessages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessageV2] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -404,7 +415,8 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			limit: nil,
 			deliveryStatus: nil,
 			direction: nil,
-			contentTypes: nil
+			contentTypes: nil,
+			excludeContentTypes: nil
 		)
 
 		if let beforeNs {
@@ -444,10 +456,11 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}()
 
 		options.direction = direction
+		options.excludeContentTypes = excludeContentTypes
 
 		return try await ffiConversation.findMessagesV2(opts: options).compactMap {
 			ffiDecodedMessage in
-			return DecodedMessageV2(ffiMessage: ffiDecodedMessage)
+			DecodedMessageV2(ffiMessage: ffiDecodedMessage)
 		}
 	}
 

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -466,7 +466,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -474,7 +475,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			limit: nil,
 			deliveryStatus: nil,
 			direction: nil,
-			contentTypes: nil
+			contentTypes: nil,
+			excludeContentTypes: nil
 		)
 
 		if let beforeNs {
@@ -514,6 +516,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}()
 
 		options.direction = direction
+		options.excludeContentTypes = excludeContentTypes
 
 		return try await ffiGroup.findMessages(opts: options).compactMap {
 			ffiMessage in
@@ -526,7 +529,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -534,7 +538,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			limit: nil,
 			deliveryStatus: nil,
 			direction: nil,
-			contentTypes: nil
+			contentTypes: nil,
+			excludeContentTypes: nil
 		)
 
 		if let beforeNs {
@@ -574,6 +579,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}()
 
 		options.direction = direction
+		options.excludeContentTypes = excludeContentTypes
 
 		return try ffiGroup.findMessagesWithReactions(opts: options)
 			.compactMap {
@@ -588,7 +594,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
-		deliveryStatus: MessageDeliveryStatus = .all
+		deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
 	) async throws -> [DecodedMessageV2] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -596,7 +603,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			limit: nil,
 			deliveryStatus: nil,
 			direction: nil,
-			contentTypes: nil
+			contentTypes: nil,
+			excludeContentTypes: nil
 		)
 
 		if let beforeNs {
@@ -636,6 +644,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}()
 
 		options.direction = direction
+		options.excludeContentTypes = excludeContentTypes
 
 		return try ffiGroup.findMessagesV2(opts: options).compactMap {
 			ffiDecodedMessage in
@@ -643,15 +652,20 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public func countMessages(beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all) throws -> Int64 {
-		return try ffiGroup.countMessages(opts: FfiListMessagesOptions(
-			sentBeforeNs: beforeNs,
-			sentAfterNs: afterNs,
-			limit: nil,
-			deliveryStatus: deliveryStatus.toFfi(),
-			direction: .descending,
-			contentTypes: nil
-		))
+	public func countMessages(
+		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
+		excludeContentTypes: [StandardContentType]? = nil
+	) throws -> Int64 {
+		return try ffiGroup.countMessages(
+			opts: FfiListMessagesOptions(
+				sentBeforeNs: beforeNs,
+				sentAfterNs: afterNs,
+				limit: nil,
+				deliveryStatus: deliveryStatus.toFfi(),
+				direction: .descending,
+				contentTypes: nil,
+				excludeContentTypes: excludeContentTypes
+			))
 	}
 
 	public func getHmacKeys() throws

--- a/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -3711,7 +3711,7 @@ public protocol FfiSignatureRequestProtocol: AnyObject, Sendable {
     func isReady() async  -> Bool
     
     /**
-     * missing signatures that are from [MemberKind::Address]
+     * missing signatures that are from `MemberKind::Address`
      */
     func missingAddressSignatures() async throws  -> [String]
     
@@ -3840,7 +3840,7 @@ open func isReady()async  -> Bool  {
 }
     
     /**
-     * missing signatures that are from [MemberKind::Address]
+     * missing signatures that are from `MemberKind::Address`
      */
 open func missingAddressSignatures()async throws  -> [String]  {
     return
@@ -7112,16 +7112,18 @@ public struct FfiListMessagesOptions {
     public var deliveryStatus: FfiDeliveryStatus?
     public var direction: FfiDirection?
     public var contentTypes: [FfiContentType]?
+    public var excludeContentTypes: [FfiContentType]?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(sentBeforeNs: Int64?, sentAfterNs: Int64?, limit: Int64?, deliveryStatus: FfiDeliveryStatus?, direction: FfiDirection?, contentTypes: [FfiContentType]?) {
+    public init(sentBeforeNs: Int64?, sentAfterNs: Int64?, limit: Int64?, deliveryStatus: FfiDeliveryStatus?, direction: FfiDirection?, contentTypes: [FfiContentType]?, excludeContentTypes: [FfiContentType]?) {
         self.sentBeforeNs = sentBeforeNs
         self.sentAfterNs = sentAfterNs
         self.limit = limit
         self.deliveryStatus = deliveryStatus
         self.direction = direction
         self.contentTypes = contentTypes
+        self.excludeContentTypes = excludeContentTypes
     }
 }
 
@@ -7150,6 +7152,9 @@ extension FfiListMessagesOptions: Equatable, Hashable {
         if lhs.contentTypes != rhs.contentTypes {
             return false
         }
+        if lhs.excludeContentTypes != rhs.excludeContentTypes {
+            return false
+        }
         return true
     }
 
@@ -7160,6 +7165,7 @@ extension FfiListMessagesOptions: Equatable, Hashable {
         hasher.combine(deliveryStatus)
         hasher.combine(direction)
         hasher.combine(contentTypes)
+        hasher.combine(excludeContentTypes)
     }
 }
 
@@ -7177,7 +7183,8 @@ public struct FfiConverterTypeFfiListMessagesOptions: FfiConverterRustBuffer {
                 limit: FfiConverterOptionInt64.read(from: &buf), 
                 deliveryStatus: FfiConverterOptionTypeFfiDeliveryStatus.read(from: &buf), 
                 direction: FfiConverterOptionTypeFfiDirection.read(from: &buf), 
-                contentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf)
+                contentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf), 
+                excludeContentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf)
         )
     }
 
@@ -7188,6 +7195,7 @@ public struct FfiConverterTypeFfiListMessagesOptions: FfiConverterRustBuffer {
         FfiConverterOptionTypeFfiDeliveryStatus.write(value.deliveryStatus, into: &buf)
         FfiConverterOptionTypeFfiDirection.write(value.direction, into: &buf)
         FfiConverterOptionSequenceTypeFfiContentType.write(value.contentTypes, into: &buf)
+        FfiConverterOptionSequenceTypeFfiContentType.write(value.excludeContentTypes, into: &buf)
     }
 }
 
@@ -13404,19 +13412,15 @@ public func isConnected(api: XmtpApiClient)async  -> Bool  {
 /**
  * * Static revoke a list of installations
  */
-public func revokeInstallations(api: XmtpApiClient, recoveryIdentifier: FfiIdentifier, inboxId: String, installationIds: [Data])async throws  -> FfiSignatureRequest  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_xmtpv3_fn_func_revoke_installations(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterTypeFfiIdentifier_lower(recoveryIdentifier),FfiConverterString.lower(inboxId),FfiConverterSequenceData.lower(installationIds)
-                )
-            },
-            pollFunc: ffi_xmtpv3_rust_future_poll_pointer,
-            completeFunc: ffi_xmtpv3_rust_future_complete_pointer,
-            freeFunc: ffi_xmtpv3_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeFfiSignatureRequest_lift,
-            errorHandler: FfiConverterTypeGenericError_lift
-        )
+public func revokeInstallations(api: XmtpApiClient, recoveryIdentifier: FfiIdentifier, inboxId: String, installationIds: [Data])throws  -> FfiSignatureRequest  {
+    return try  FfiConverterTypeFfiSignatureRequest_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_revoke_installations(
+        FfiConverterTypeXmtpApiClient_lower(api),
+        FfiConverterTypeFfiIdentifier_lower(recoveryIdentifier),
+        FfiConverterString.lower(inboxId),
+        FfiConverterSequenceData.lower(installationIds),$0
+    )
+})
 }
 
 private enum InitializationResult {
@@ -13521,7 +13525,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_is_connected() != 17295) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_func_revoke_installations() != 23629) {
+    if (uniffi_xmtpv3_checksum_func_revoke_installations() != 39546) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonsentcallback_on_consent_update() != 12532) {
@@ -13854,7 +13858,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_ffisignaturerequest_is_ready() != 65051) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_ffisignaturerequest_missing_address_signatures() != 34688) {
+    if (uniffi_xmtpv3_checksum_method_ffisignaturerequest_missing_address_signatures() != 55383) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffisignaturerequest_signature_text() != 60472) {

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -626,4 +626,110 @@ class ConversationTests: XCTestCase {
 
         try fixtures.cleanUpDatabases()
     }
+	
+	func testMessagesWithExcludedContentTypes() async throws {
+		let fixtures = try await fixtures()
+		Client.register(codec: ReactionCodec())
+
+		// Create a group
+		let group = try await fixtures.boClient.conversations.newGroup(with: [
+			fixtures.caroClient.inboxID
+		])
+
+		// Send different types of messages
+		_ = try await group.send(content: "Text message 1")
+		_ = try await group.send(content: "Text message 2")
+
+		// Send a reaction
+		let textMessageId = try await group.send(content: "Message to react to")
+		_ = try await group.send(
+			content: Reaction(
+				reference: textMessageId,
+				action: .added,
+				content: "👍",
+				schema: .unicode
+			),
+			options: SendOptions(contentType: ContentTypeReaction)
+		)
+
+		// Wait a bit for messages to sync
+		try await Task.sleep(nanoseconds: 100_000_000)
+		try await group.sync()
+
+		// Get all messages
+		let allMessages = try await group.messages()
+
+		// Get messages excluding reactions
+		let messagesWithoutReactions = try await group.messages(
+			excludeContentTypes: [.reaction]
+		)
+
+		// Should have fewer messages when excluding reactions
+		XCTAssertGreaterThan(allMessages.count, messagesWithoutReactions.count)
+
+		// Verify no reactions in the filtered list
+		for message in messagesWithoutReactions {
+			XCTAssertNotEqual(try message.encodedContent.type.typeID, "reaction")
+		}
+
+		try fixtures.cleanUpDatabases()
+	}
+
+	func testCountMessagesWithExcludedContentTypes() async throws {
+		let fixtures = try await fixtures()
+		Client.register(codec: ReactionCodec())
+
+		// Create a DM
+		let dm = try await fixtures.boClient.conversations.findOrCreateDm(
+			with: fixtures.caroClient.inboxID)
+
+		// Send different types of messages
+		_ = try await dm.send(content: "Text message 1")
+		_ = try await dm.send(content: "Text message 2")
+		_ = try await dm.send(content: "Text message 3")
+
+		// Send reactions
+		let textMessageId = try await dm.send(content: "Message to react to")
+		_ = try await dm.send(
+			content: Reaction(
+				reference: textMessageId,
+				action: .added,
+				content: "👍",
+				schema: .unicode
+			),
+			options: SendOptions(contentType: ContentTypeReaction)
+		)
+		_ = try await dm.send(
+			content: Reaction(
+				reference: textMessageId,
+				action: .added,
+				content: "❤️",
+				schema: .unicode
+			),
+			options: SendOptions(contentType: ContentTypeReaction)
+		)
+
+		// Wait a bit for messages to sync
+		try await Task.sleep(nanoseconds: 100_000_000)
+		try await dm.sync()
+
+		// Count all messages
+		let totalCount = try dm.countMessages()
+
+		// Count messages excluding reactions
+		let countWithoutReactions = try dm.countMessages(
+			excludeContentTypes: [.reaction]
+		)
+
+		// Should have 6 total (4 text + 2 reactions)
+		XCTAssertEqual(totalCount, 6)
+
+		// Should have 4 without reactions
+		XCTAssertEqual(countWithoutReactions, 4)
+
+		// Verify the difference equals the number of reactions
+		XCTAssertEqual(totalCount - countWithoutReactions, 2)
+
+		try fixtures.cleanUpDatabases()
+	}
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.0-dev.ced7b19"
+  spec.version      = "4.6.0-dev"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add exclusion of content types to `Conversation.messages`, `Conversation.messagesWithReactions`, `Conversation.enrichedMessages`, and `Conversation.countMessages` to support ExcludeContentTypes
This change introduces an `excludeContentTypes` parameter across conversation and message retrieval/count APIs and wires it through DM and Group implementations to FFI options, alongside minor typealias additions and binding updates.

- Extend `Conversation` APIs to accept `excludeContentTypes: [StandardContentType]?` and forward to group/DM implementations in [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1)
- Add `excludeContentTypes` handling to FFI list options in DM and Group message/reaction/enriched queries and counts in [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6) and [Group.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83)
- Update generated FFI bindings to include `excludeContentTypes` in `FfiListMessagesOptions` and adjust related documentation and function signatures in [xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0)
- Introduce `StandardContentType` typealias in [ContentTypeID.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-0cda97e25cb7dfc74128915d47b742b6a95af79f1e473ec1584f37619fbd6c1e)
- Add tests validating exclusion behavior in [ConversationTests.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-0b84b85e6be2785ab6134d824b4cd47043449b0f1bd7862ddb661646dc76cbe3)
- Update package manifest and podspec in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e) and [XMTP.podspec](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-e9237cf856d38a9701faf84ef515c0d8d2880b467403b12cbe0792edf2cda630)

#### 📍Where to Start
Start with the propagation of `excludeContentTypes` in `Conversation.messages` and related APIs in [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1), then follow into `Dm` and `Group` implementations in [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6) and [Group.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83), and finally confirm FFI option handling in [xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/587/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0).

----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 468c5ab.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->