### PR TITLE
Update to libxmtp 1.5.5 and add creationSignatureKind

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.4.0a2e705/LibXMTPSwiftFFI.zip",
-			checksum: "d59392f586a3d80a4f2ba76c22228c48f08828eed18291edadbc8fdbc224d78b"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.5.34eed53/LibXMTPSwiftFFI.zip",
+			checksum: "b647c95ddf30c1ece5d916f3591aa83055c473b89c2058319e71d35517bfa843"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/Sources/XMTPiOS/Libxmtp/InboxState.swift
+++ b/Sources/XMTPiOS/Libxmtp/InboxState.swift
@@ -7,27 +7,35 @@
 
 import Foundation
 
-public struct InboxState {
-	var ffiInboxState: FfiInboxState
-	
-	init(ffiInboxState: FfiInboxState) {
-		self.ffiInboxState = ffiInboxState
-	}
+public typealias SignatureKind = FfiSignatureKind
 
-	public var inboxId: InboxId {
-		ffiInboxState.inboxId
-	}
-	
-	public var identities: [PublicIdentity] {
-		ffiInboxState.accountIdentities.map { PublicIdentity(ffiPrivate: $0) }
-	}
-	
-	public var installations: [Installation] {
-		ffiInboxState.installations.map { Installation(ffiInstallation: $0) }
-	}
-	
-	public var recoveryIdentity: PublicIdentity {
-		PublicIdentity(ffiPrivate: ffiInboxState.recoveryIdentity)
-	}
+public struct InboxState {
+    var ffiInboxState: FfiInboxState
+
+    init(ffiInboxState: FfiInboxState) {
+        self.ffiInboxState = ffiInboxState
+    }
+
+    public var inboxId: InboxId {
+        ffiInboxState.inboxId
+    }
+
+    public var identities: [PublicIdentity] {
+        ffiInboxState.accountIdentities.map { PublicIdentity(ffiPrivate: $0) }
+    }
+
+    public var installations: [Installation] {
+        ffiInboxState.installations.map { Installation(ffiInstallation: $0) }
+    }
+
+    public var recoveryIdentity: PublicIdentity {
+        PublicIdentity(ffiPrivate: ffiInboxState.recoveryIdentity)
+    }
+
+    /// The type of signature that was used to create the inbox initially.
+    /// Future signatures from this identity must be of the same kind
+    public var creationSignatureKind: SignatureKind? {
+        ffiInboxState.creationSignatureKind
+    }
 
 }

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.5.4"
+  spec.version      = "4.5.5"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
### TL;DR

Update LibXMTPSwiftFFI to version 1.5.5 and expose signature kind information in InboxState.

### What changed?

- Updated LibXMTPSwiftFFI binary from version 1.5.4.0a2e705 to 1.5.5.34eed53
- Added `creationSignatureKind` property to `InboxState` to expose the type of signature used to create an inbox
- Created a public typealias `SignatureKind` that maps to `FfiSignatureKind`
- Bumped the pod version from 4.5.4 to 4.5.5

### How to test?

1. Create a new inbox and check that the `creationSignatureKind` property is populated with the correct signature type
2. Verify that existing code using `InboxState` continues to work as expected
3. Test with different signature types to ensure the property correctly reflects the signature kind used

### Why make this change?

This change exposes important information about how an inbox was created, specifically the signature type used. This is necessary because future signatures from the same identity must use the same signature kind. By exposing this information, client applications can ensure they use the correct signature method when interacting with existing inboxes.