### PR TITLE
Update to libxmtp 4.6.0-dev.3656d63

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.5.6.fe6e305/LibXMTPSwiftFFI.zip",
-			checksum: "866a6091be3c85d69d9c0ea1a43f08d44450afd914ceb4c8179116660c23444e"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.3656d63/LibXMTPSwiftFFI.zip",
+			checksum: "d36b68a4520846c9bf4aee99425a681f1d2c18a8b15e3523c325621d6b7ede87"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.5.6"
+  spec.version      = "4.6.0-dev.3656d63"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.6.0-dev.3656d63. 
  
Changes:
- Updated XMTP.podspec version to 4.6.0-dev.3656d63
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: main