### PR TITLE
Pass through shouldPush flag to libxmtp

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
 			url:
-			"https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.3f76d5e/LibXMTPSwiftFFI.zip",
-			checksum: "a3c63fcaa57bcb1ab3cac659c56db4d2805de1274b819246eb8f6bb1053c078d"
+			"https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.3656d63/LibXMTPSwiftFFI.zip",
+			checksum: "d36b68a4520846c9bf4aee99425a681f1d2c18a8b15e3523c325621d6b7ede87"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/Sources/XMTPiOS/Codecs/GroupUpdatedCodec.swift
+++ b/Sources/XMTPiOS/Codecs/GroupUpdatedCodec.swift
@@ -27,7 +27,7 @@ public struct GroupUpdatedCodec: ContentCodec {
 		var encodedContent = EncodedContent()
 
 		encodedContent.type = ContentTypeGroupUpdated
-		encodedContent.content = try content.serializedData()
+		encodedContent.content = try content.serializedBytes()
 
 		return encodedContent
 	}

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -139,16 +139,20 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public func prepareMessage(encodedContent: EncodedContent) async throws
+	public func prepareMessage(
+		encodedContent: EncodedContent, visibilityOptions: MessageVisibilityOptions? = nil
+	) async throws
 		-> String
 	{
 		switch self {
 		case let .group(group):
 			return try await group.prepareMessage(
-				encodedContent: encodedContent
+				encodedContent: encodedContent, visibilityOptions: visibilityOptions
 			)
 		case let .dm(dm):
-			return try await dm.prepareMessage(encodedContent: encodedContent)
+			return try await dm.prepareMessage(
+				encodedContent: encodedContent, visibilityOptions: visibilityOptions
+			)
 		}
 	}
 
@@ -224,15 +228,17 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 	}
 
 	@discardableResult public func send(
-		encodedContent: EncodedContent
+		encodedContent: EncodedContent, visibilityOptions: MessageVisibilityOptions? = nil
 	) async throws -> String {
 		switch self {
 		case let .group(group):
 			return try await group.send(
-				encodedContent: encodedContent
+				encodedContent: encodedContent, visibilityOptions: visibilityOptions
 			)
 		case let .dm(dm):
-			return try await dm.send(encodedContent: encodedContent)
+			return try await dm.send(
+				encodedContent: encodedContent, visibilityOptions: visibilityOptions
+			)
 		}
 	}
 
@@ -273,20 +279,23 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) async throws -> [DecodedMessage] {
 		switch self {
 		case let .group(group):
 			return try await group.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		case let .dm(dm):
 			return try await dm.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		}
 	}
@@ -316,20 +325,23 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) async throws -> [DecodedMessage] {
 		switch self {
 		case let .group(group):
 			return try await group.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		case let .dm(dm):
 			return try await dm.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		}
 	}
@@ -340,20 +352,23 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) async throws -> [DecodedMessageV2] {
 		switch self {
 		case let .group(group):
 			return try await group.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		case let .dm(dm):
 			return try await dm.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		}
 	}
@@ -362,18 +377,21 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) throws -> Int64 {
 		switch self {
 		case let .group(group):
 			return try group.countMessages(
 				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		case let .dm(dm):
 			return try dm.countMessages(
 				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		}
 	}

--- a/Sources/XMTPiOS/Conversations.swift
+++ b/Sources/XMTPiOS/Conversations.swift
@@ -199,7 +199,9 @@ public class Conversations {
 
 	public func findEnrichedMessage(messageId: String) throws -> DecodedMessageV2? {
 		do {
-			return try DecodedMessageV2.create(ffiMessage: ffiClient.messageV2(messageId: messageId.hexToData))
+			return try DecodedMessageV2.create(
+				ffiMessage: ffiClient.enrichedMessage(messageId: messageId.hexToData)
+			)
 		} catch {
 			return nil
 		}
@@ -424,7 +426,9 @@ public class Conversations {
 				.findOrCreateDm(
 					targetIdentity: peerIdentity.ffiPrivate,
 					opts: FfiCreateDmOptions(
-						messageDisappearingSettings: toFfiDisappearingMessageSettings(disappearingMessageSettings)
+						messageDisappearingSettings: toFfiDisappearingMessageSettings(
+							disappearingMessageSettings
+						)
 					)
 				)
 
@@ -457,7 +461,9 @@ public class Conversations {
 				.findOrCreateDmByInboxId(
 					inboxId: peerInboxId,
 					opts: FfiCreateDmOptions(
-						messageDisappearingSettings: toFfiDisappearingMessageSettings(disappearingMessageSettings)
+						messageDisappearingSettings: toFfiDisappearingMessageSettings(
+							disappearingMessageSettings
+						)
 					)
 				)
 		return dm.dmFromFFI(client: client)
@@ -523,7 +529,9 @@ public class Conversations {
 				groupImageUrlSquare: imageUrl,
 				groupDescription: description,
 				customPermissionPolicySet: permissionPolicySet,
-				messageDisappearingSettings: toFfiDisappearingMessageSettings(disappearingMessageSettings)
+				messageDisappearingSettings: toFfiDisappearingMessageSettings(
+					disappearingMessageSettings
+				)
 			)
 		).groupFromFFI(client: client)
 		return group
@@ -590,7 +598,9 @@ public class Conversations {
 				groupImageUrlSquare: imageUrl,
 				groupDescription: description,
 				customPermissionPolicySet: permissionPolicySet,
-				messageDisappearingSettings: toFfiDisappearingMessageSettings(disappearingMessageSettings)
+				messageDisappearingSettings: toFfiDisappearingMessageSettings(
+					disappearingMessageSettings
+				)
 			)
 		).groupFromFFI(client: client)
 		return group
@@ -612,7 +622,9 @@ public class Conversations {
 			groupImageUrlSquare: groupImageUrlSquare,
 			groupDescription: groupDescription,
 			customPermissionPolicySet: nil,
-			messageDisappearingSettings: toFfiDisappearingMessageSettings(disappearingMessageSettings)
+			messageDisappearingSettings: toFfiDisappearingMessageSettings(
+				disappearingMessageSettings
+			)
 		)
 
 		let ffiGroup = try ffiConversations.createGroupOptimistic(opts: ffiOpts)

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -343,16 +343,20 @@ public struct Group: Identifiable, Equatable, Hashable {
 	public func send<T>(content: T, options: SendOptions? = nil) async throws
 		-> String
 	{
-		let encodeContent = try await encodeContent(
+		let (encodeContent, visibilityOptions) = try await encodeContent(
 			content: content, options: options
 		)
-		return try await send(encodedContent: encodeContent)
+		return try await send(encodedContent: encodeContent, visibilityOptions: visibilityOptions)
 	}
 
-	public func send(encodedContent: EncodedContent) async throws -> String {
+	public func send(
+		encodedContent: EncodedContent, visibilityOptions: MessageVisibilityOptions? = nil
+	) async throws -> String {
 		do {
+			let opts = visibilityOptions?.toFfi() ?? FfiSendMessageOpts(shouldPush: true)
 			let messageId = try await ffiGroup.send(
-				contentBytes: encodedContent.serializedData()
+				contentBytes: encodedContent.serializedData(),
+				opts: opts
 			)
 			return messageId.toHex
 		} catch {
@@ -361,7 +365,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 	}
 
 	public func encodeContent<T>(content: T, options: SendOptions?) async throws
-		-> EncodedContent
+		-> (EncodedContent, MessageVisibilityOptions)
 	{
 		let codec = Client.codecRegistry.find(for: options?.contentType)
 
@@ -395,14 +399,32 @@ public struct Group: Identifiable, Equatable, Hashable {
 			encoded = try encoded.compress(compression)
 		}
 
-		return encoded
+		func shouldPush<Codec: ContentCodec>(codec: Codec, content: Any) throws
+			-> Bool
+		{
+			if let content = content as? Codec.T {
+				return try codec.shouldPush(content: content)
+			} else {
+				throw CodecError.invalidContent
+			}
+		}
+
+		let visibilityOptions = try MessageVisibilityOptions(
+			shouldPush: shouldPush(codec: codec, content: content)
+		)
+
+		return (encoded, visibilityOptions)
 	}
 
-	public func prepareMessage(encodedContent: EncodedContent) async throws
+	public func prepareMessage(
+		encodedContent: EncodedContent, visibilityOptions: MessageVisibilityOptions? = nil
+	) async throws
 		-> String
 	{
+		let opts = visibilityOptions?.toFfi() ?? FfiSendMessageOpts(shouldPush: true)
 		let messageId = try ffiGroup.sendOptimistic(
-			contentBytes: encodedContent.serializedData()
+			contentBytes: encodedContent.serializedData(),
+			opts: opts
 		)
 		return messageId.toHex
 	}
@@ -410,11 +432,12 @@ public struct Group: Identifiable, Equatable, Hashable {
 	public func prepareMessage<T>(content: T, options: SendOptions? = nil)
 		async throws -> String
 	{
-		let encodeContent = try await encodeContent(
+		let (encodeContent, visibilityOptions) = try await encodeContent(
 			content: content, options: options
 		)
 		return try ffiGroup.sendOptimistic(
-			contentBytes: encodeContent.serializedData()
+			contentBytes: encodeContent.serializedData(),
+			opts: visibilityOptions.toFfi()
 		).toHex
 	}
 
@@ -482,7 +505,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -491,7 +515,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			deliveryStatus: nil,
 			direction: nil,
 			contentTypes: nil,
-			excludeContentTypes: nil
+			excludeContentTypes: nil,
+			excludeSenderInboxIds: nil
 		)
 
 		if let beforeNs {
@@ -532,6 +557,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
+		options.excludeSenderInboxIds = excludeSenderInboxIds
 
 		return try await ffiGroup.findMessages(opts: options).compactMap {
 			ffiMessage in
@@ -545,7 +571,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -554,7 +581,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			deliveryStatus: nil,
 			direction: nil,
 			contentTypes: nil,
-			excludeContentTypes: nil
+			excludeContentTypes: nil,
+			excludeSenderInboxIds: nil
 		)
 
 		if let beforeNs {
@@ -595,6 +623,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
+		options.excludeSenderInboxIds = excludeSenderInboxIds
 
 		return try ffiGroup.findMessagesWithReactions(opts: options)
 			.compactMap {
@@ -611,7 +640,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) async throws -> [DecodedMessageV2] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -620,7 +650,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 			deliveryStatus: nil,
 			direction: nil,
 			contentTypes: nil,
-			excludeContentTypes: nil
+			excludeContentTypes: nil,
+			excludeSenderInboxIds: nil
 		)
 
 		if let beforeNs {
@@ -661,15 +692,18 @@ public struct Group: Identifiable, Equatable, Hashable {
 
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
+		options.excludeSenderInboxIds = excludeSenderInboxIds
 
-		return try await ffiGroup.findMessagesV2(opts: options).compactMap { ffiDecodedMessage in
+		return try await ffiGroup.findEnrichedMessages(opts: options).compactMap {
+			ffiDecodedMessage in
 			DecodedMessageV2(ffiMessage: ffiDecodedMessage)
 		}
 	}
 
 	public func countMessages(
 		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
-		excludeContentTypes: [StandardContentType]? = nil
+		excludeContentTypes: [StandardContentType]? = nil,
+		excludeSenderInboxIds: [String]? = nil
 	) throws -> Int64 {
 		try ffiGroup.countMessages(
 			opts: FfiListMessagesOptions(
@@ -679,7 +713,8 @@ public struct Group: Identifiable, Equatable, Hashable {
 				deliveryStatus: deliveryStatus.toFfi(),
 				direction: .descending,
 				contentTypes: nil,
-				excludeContentTypes: excludeContentTypes
+				excludeContentTypes: excludeContentTypes,
+				excludeSenderInboxIds: excludeSenderInboxIds
 			)
 		)
 	}

--- a/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -851,9 +851,9 @@ public protocol FfiConversationProtocol: AnyObject, Sendable {
     
     func findDuplicateDms() async throws  -> [FfiConversation]
     
-    func findMessages(opts: FfiListMessagesOptions) async throws  -> [FfiMessage]
+    func findEnrichedMessages(opts: FfiListMessagesOptions) throws  -> [FfiDecodedMessage]
     
-    func findMessagesV2(opts: FfiListMessagesOptions) throws  -> [FfiDecodedMessage]
+    func findMessages(opts: FfiListMessagesOptions) async throws  -> [FfiMessage]
     
     func findMessagesWithReactions(opts: FfiListMessagesOptions) throws  -> [FfiMessageWithReactions]
     
@@ -902,12 +902,12 @@ public protocol FfiConversationProtocol: AnyObject, Sendable {
     
     func removeSuperAdmin(inboxId: String) async throws 
     
-    func send(contentBytes: Data) async throws  -> Data
+    func send(contentBytes: Data, opts: FfiSendMessageOpts) async throws  -> Data
     
     /**
      * send a message without immediately publishing to the delivery service.
      */
-    func sendOptimistic(contentBytes: Data) throws  -> Data
+    func sendOptimistic(contentBytes: Data, opts: FfiSendMessageOpts) throws  -> Data
     
     func sendText(text: String) async throws  -> Data
     
@@ -1141,6 +1141,14 @@ open func findDuplicateDms()async throws  -> [FfiConversation]  {
         )
 }
     
+open func findEnrichedMessages(opts: FfiListMessagesOptions)throws  -> [FfiDecodedMessage]  {
+    return try  FfiConverterSequenceTypeFfiDecodedMessage.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_method_fficonversation_find_enriched_messages(self.uniffiClonePointer(),
+        FfiConverterTypeFfiListMessagesOptions_lower(opts),$0
+    )
+})
+}
+    
 open func findMessages(opts: FfiListMessagesOptions)async throws  -> [FfiMessage]  {
     return
         try  await uniffiRustCallAsync(
@@ -1156,14 +1164,6 @@ open func findMessages(opts: FfiListMessagesOptions)async throws  -> [FfiMessage
             liftFunc: FfiConverterSequenceTypeFfiMessage.lift,
             errorHandler: FfiConverterTypeGenericError_lift
         )
-}
-    
-open func findMessagesV2(opts: FfiListMessagesOptions)throws  -> [FfiDecodedMessage]  {
-    return try  FfiConverterSequenceTypeFfiDecodedMessage.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
-    uniffi_xmtpv3_fn_method_fficonversation_find_messages_v2(self.uniffiClonePointer(),
-        FfiConverterTypeFfiListMessagesOptions_lower(opts),$0
-    )
-})
 }
     
 open func findMessagesWithReactions(opts: FfiListMessagesOptions)throws  -> [FfiMessageWithReactions]  {
@@ -1416,13 +1416,13 @@ open func removeSuperAdmin(inboxId: String)async throws   {
         )
 }
     
-open func send(contentBytes: Data)async throws  -> Data  {
+open func send(contentBytes: Data, opts: FfiSendMessageOpts)async throws  -> Data  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_xmtpv3_fn_method_fficonversation_send(
                     self.uniffiClonePointer(),
-                    FfiConverterData.lower(contentBytes)
+                    FfiConverterData.lower(contentBytes),FfiConverterTypeFfiSendMessageOpts_lower(opts)
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_rust_buffer,
@@ -1436,10 +1436,11 @@ open func send(contentBytes: Data)async throws  -> Data  {
     /**
      * send a message without immediately publishing to the delivery service.
      */
-open func sendOptimistic(contentBytes: Data)throws  -> Data  {
+open func sendOptimistic(contentBytes: Data, opts: FfiSendMessageOpts)throws  -> Data  {
     return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
     uniffi_xmtpv3_fn_method_fficonversation_send_optimistic(self.uniffiClonePointer(),
-        FfiConverterData.lower(contentBytes),$0
+        FfiConverterData.lower(contentBytes),
+        FfiConverterTypeFfiSendMessageOpts_lower(opts),$0
     )
 })
 }
@@ -4302,6 +4303,8 @@ public protocol FfiXmtpClientProtocol: AnyObject, Sendable {
     
     func dmConversation(targetInboxId: String) throws  -> FfiConversation
     
+    func enrichedMessage(messageId: Data) throws  -> FfiDecodedMessage
+    
     func findInboxId(identifier: FfiIdentifier) async throws  -> String?
     
     func getConsentState(entityType: FfiConsentEntityType, entity: String) async throws  -> FfiConsentState
@@ -4328,8 +4331,6 @@ public protocol FfiXmtpClientProtocol: AnyObject, Sendable {
     func installationId()  -> Data
     
     func message(messageId: Data) throws  -> FfiMessage
-    
-    func messageV2(messageId: Data) throws  -> FfiDecodedMessage
     
     func registerIdentity(signatureRequest: FfiSignatureRequest) async throws 
     
@@ -4648,6 +4649,14 @@ open func dmConversation(targetInboxId: String)throws  -> FfiConversation  {
 })
 }
     
+open func enrichedMessage(messageId: Data)throws  -> FfiDecodedMessage  {
+    return try  FfiConverterTypeFfiDecodedMessage_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_method_ffixmtpclient_enriched_message(self.uniffiClonePointer(),
+        FfiConverterData.lower(messageId),$0
+    )
+})
+}
+    
 open func findInboxId(identifier: FfiIdentifier)async throws  -> String?  {
     return
         try  await uniffiRustCallAsync(
@@ -4776,14 +4785,6 @@ open func installationId() -> Data  {
 open func message(messageId: Data)throws  -> FfiMessage  {
     return try  FfiConverterTypeFfiMessage_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
     uniffi_xmtpv3_fn_method_ffixmtpclient_message(self.uniffiClonePointer(),
-        FfiConverterData.lower(messageId),$0
-    )
-})
-}
-    
-open func messageV2(messageId: Data)throws  -> FfiDecodedMessage  {
-    return try  FfiConverterTypeFfiDecodedMessage_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
-    uniffi_xmtpv3_fn_method_ffixmtpclient_message_v2(self.uniffiClonePointer(),
         FfiConverterData.lower(messageId),$0
     )
 })
@@ -7121,10 +7122,11 @@ public struct FfiListMessagesOptions {
     public var direction: FfiDirection?
     public var contentTypes: [FfiContentType]?
     public var excludeContentTypes: [FfiContentType]?
+    public var excludeSenderInboxIds: [String]?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(sentBeforeNs: Int64?, sentAfterNs: Int64?, limit: Int64?, deliveryStatus: FfiDeliveryStatus?, direction: FfiDirection?, contentTypes: [FfiContentType]?, excludeContentTypes: [FfiContentType]?) {
+    public init(sentBeforeNs: Int64?, sentAfterNs: Int64?, limit: Int64?, deliveryStatus: FfiDeliveryStatus?, direction: FfiDirection?, contentTypes: [FfiContentType]?, excludeContentTypes: [FfiContentType]?, excludeSenderInboxIds: [String]?) {
         self.sentBeforeNs = sentBeforeNs
         self.sentAfterNs = sentAfterNs
         self.limit = limit
@@ -7132,6 +7134,7 @@ public struct FfiListMessagesOptions {
         self.direction = direction
         self.contentTypes = contentTypes
         self.excludeContentTypes = excludeContentTypes
+        self.excludeSenderInboxIds = excludeSenderInboxIds
     }
 }
 
@@ -7163,6 +7166,9 @@ extension FfiListMessagesOptions: Equatable, Hashable {
         if lhs.excludeContentTypes != rhs.excludeContentTypes {
             return false
         }
+        if lhs.excludeSenderInboxIds != rhs.excludeSenderInboxIds {
+            return false
+        }
         return true
     }
 
@@ -7174,6 +7180,7 @@ extension FfiListMessagesOptions: Equatable, Hashable {
         hasher.combine(direction)
         hasher.combine(contentTypes)
         hasher.combine(excludeContentTypes)
+        hasher.combine(excludeSenderInboxIds)
     }
 }
 
@@ -7192,7 +7199,8 @@ public struct FfiConverterTypeFfiListMessagesOptions: FfiConverterRustBuffer {
                 deliveryStatus: FfiConverterOptionTypeFfiDeliveryStatus.read(from: &buf), 
                 direction: FfiConverterOptionTypeFfiDirection.read(from: &buf), 
                 contentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf), 
-                excludeContentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf)
+                excludeContentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf), 
+                excludeSenderInboxIds: FfiConverterOptionSequenceString.read(from: &buf)
         )
     }
 
@@ -7204,6 +7212,7 @@ public struct FfiConverterTypeFfiListMessagesOptions: FfiConverterRustBuffer {
         FfiConverterOptionTypeFfiDirection.write(value.direction, into: &buf)
         FfiConverterOptionSequenceTypeFfiContentType.write(value.contentTypes, into: &buf)
         FfiConverterOptionSequenceTypeFfiContentType.write(value.excludeContentTypes, into: &buf)
+        FfiConverterOptionSequenceString.write(value.excludeSenderInboxIds, into: &buf)
     }
 }
 
@@ -8291,6 +8300,68 @@ public func FfiConverterTypeFfiReply_lift(_ buf: RustBuffer) throws -> FfiReply 
 #endif
 public func FfiConverterTypeFfiReply_lower(_ value: FfiReply) -> RustBuffer {
     return FfiConverterTypeFfiReply.lower(value)
+}
+
+
+public struct FfiSendMessageOpts {
+    public var shouldPush: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(shouldPush: Bool) {
+        self.shouldPush = shouldPush
+    }
+}
+
+#if compiler(>=6)
+extension FfiSendMessageOpts: Sendable {}
+#endif
+
+
+extension FfiSendMessageOpts: Equatable, Hashable {
+    public static func ==(lhs: FfiSendMessageOpts, rhs: FfiSendMessageOpts) -> Bool {
+        if lhs.shouldPush != rhs.shouldPush {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(shouldPush)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiSendMessageOpts: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiSendMessageOpts {
+        return
+            try FfiSendMessageOpts(
+                shouldPush: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiSendMessageOpts, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.shouldPush, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiSendMessageOpts_lift(_ buf: RustBuffer) throws -> FfiSendMessageOpts {
+    return try FfiConverterTypeFfiSendMessageOpts.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiSendMessageOpts_lower(_ value: FfiSendMessageOpts) -> RustBuffer {
+    return FfiConverterTypeFfiSendMessageOpts.lower(value)
 }
 
 
@@ -12441,6 +12512,30 @@ fileprivate struct FfiConverterOptionTypeFfiSyncWorkerMode: FfiConverterRustBuff
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionSequenceString: FfiConverterRustBuffer {
+    typealias SwiftType = [String]?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterSequenceString.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterSequenceString.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionSequenceTypeFfiConsentState: FfiConverterRustBuffer {
     typealias SwiftType = [FfiConsentState]?
 
@@ -13720,10 +13815,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversation_find_duplicate_dms() != 15813) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_find_messages() != 19931) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_find_enriched_messages() != 4573) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_find_messages_v2() != 4772) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_find_messages() != 19931) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversation_find_messages_with_reactions() != 46761) {
@@ -13792,10 +13887,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversation_remove_super_admin() != 46017) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_send() != 7954) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_send() != 12477) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_send_optimistic() != 5885) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_send_optimistic() != 22242) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversation_send_text() != 55684) {
@@ -14068,6 +14163,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_dm_conversation() != 23917) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_method_ffixmtpclient_enriched_message() != 37575) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_find_inbox_id() != 17517) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -14093,9 +14191,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_message() != 26932) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_xmtpv3_checksum_method_ffixmtpclient_message_v2() != 17937) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_register_identity() != 42003) {

--- a/Sources/XMTPiOS/MessageVisibilityOptions.swift
+++ b/Sources/XMTPiOS/MessageVisibilityOptions.swift
@@ -1,0 +1,26 @@
+//
+//  MessageVisibilityOptions.swift
+//
+//
+//  Created by XMTP on 1/15/25.
+//
+
+import Foundation
+
+/// Options that control the visibility and notification behavior of a message
+public struct MessageVisibilityOptions {
+	/// Whether this message should trigger a push notification
+	public var shouldPush: Bool
+
+	/// Creates message visibility options
+	/// - Parameter shouldPush: Whether this message should trigger a push notification (default: true)
+	public init(shouldPush: Bool = true) {
+		self.shouldPush = shouldPush
+	}
+
+	/// Converts the visibility options to FFI send message options
+	/// - Returns: FfiSendMessageOpts instance with the appropriate settings
+	public func toFfi() -> FfiSendMessageOpts {
+		FfiSendMessageOpts(shouldPush: shouldPush)
+	}
+}

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
 
   spec.platform      	= :ios, '14.0', :macos, '11.0'
 
-  spec.swift_version  = '5.3'
+  spec.swift_version  = '5.6'
 
   # Release archive contains libxmtp uniffi bindings Sources/** and LibXMTPSwiftFFI.xcframework
   spec.source       	= { :http => "https://github.com/xmtp/xmtp-ios/releases/download/#{spec.version}/XMTP-#{spec.version}.zip", :type => :zip }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Pass push notification visibility through `Group.encodeContent`, `Dm.encodeContent`, and `Conversation.send/prepare` to libxmtp via `MessageVisibilityOptions.shouldPush` and `FfiSendMessageOpts` in [Group.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83), [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6), and [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1)
Introduce push visibility control derived from codecs and propagate it to libxmtp send/prepare calls, and add message query filters and counting APIs.

- Add `MessageVisibilityOptions` with `shouldPush` and convert to `FfiSendMessageOpts` in [MessageVisibilityOptions.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-6e0827f343b65eeac328bf9bac7404a065cfea4bfa3d6242faa80baa66042fd4); update `Group.encodeContent`, `Dm.encodeContent`, `Conversation.send/prepare` to derive and pass `shouldPush` via `FfiSendMessageOpts` in [Group.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83), [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6), and [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1)

- Extend find APIs with `excludeContentTypes` and `excludeSenderInboxIds` and switch enriched queries to `findEnrichedMessages`; add `countMessages` in group/dm/conversation

- Update libxmtp bindings to include `FfiSendMessageOpts`, `countMessages`, `findEnrichedMessages`, and exclusion filters in list options in [xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0)

- Add codec `shouldPush` implementations and tests verifying push behavior and FFI option mapping

#### 📍Where to Start
Start with the codec-derived push flow in `Group.encodeContent` and `Dm.encodeContent` in [Group.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83) and [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6), then follow how `MessageVisibilityOptions.toFfi()` is passed into `sendMessage`/`prepareMessage`; cross-check FFI changes in [xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/594/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0).

----


<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 17ecf0d. 6 files reviewed, 14 issues evaluated, 13 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Sources/XMTPiOS/Dm.swift — 0 comments posted, 8 evaluated, 7 filtered</summary>

- [line 162](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L162): `send(encodedContent:visibilityOptions:)` defaults to `shouldPush = true` when `visibilityOptions` is `nil`, which can cause inconsistent push notification behavior compared to `send<T>(content:options:)`. The generic path computes `shouldPush` via the content codec's `shouldPush(content:)`, but the pre-encoded path ignores codec semantics unless the caller explicitly supplies `visibilityOptions`. This asymmetry means that the same logical content (e.g., a Reaction or ReadReceipt, which should default to `shouldPush = false`) could trigger a push when sent via the pre-encoded API, but not when sent via the typed API. This is an externally visible behavioral discrepancy and can lead to unintended push notifications. <b>[ Low confidence ]</b>
- [line 227](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L227): `prepareMessage(encodedContent:visibilityOptions:)` also defaults to `shouldPush = true` when `visibilityOptions` is `nil`, while `prepareMessage<T>(content:options:)` computes `shouldPush` using the codec. This mirrors the inconsistency present in `send(...)` and can lead to unintended push notifications when using the pre-encoded prepare path compared to the typed prepare path. <b>[ Low confidence ]</b>
- [line 351](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L351): Ambiguous direction handling: The `direction` parameter is optional (`SortDirection? = .descending`), but the code maps `nil` to `.descending` rather than leaving `options.direction` as `nil`. This prevents callers from expressing an "unspecified" sort that defers to a backend default and can change behavior when `nil` is intentionally passed. Consider honoring `nil` by setting `options.direction = nil` when the parameter is `nil`. <b>[ Low confidence ]</b>
- [line 364](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L364): Silent data loss: `messages(...)` uses `compactMap` to turn `[FfiMessage]` into `[DecodedMessage]`. When `DecodedMessage.create(ffiMessage:)` returns `nil` (e.g., due to decode errors), the message is silently dropped with no error or signal to the caller. This can hide decoding problems and yield incomplete results without visibility. Consider returning errors, including a companion error/result structure, or at least logging/reporting per-message failures so every input reaches a visible terminal state. <b>[ Low confidence ]</b>
- [line 404](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L404): Ambiguous direction handling: The `direction` parameter is optional, yet mapping treats `nil` as `.descending` rather than leaving `options.direction` as `nil`. This prevents a caller from deferring sort semantics to the backend by passing `nil`. Consider mapping `nil` to `options.direction = nil` to preserve the optional contract. <b>[ Low confidence ]</b>
- [line 417](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L417): Silent data loss: `messagesWithReactions(...)` uses `compactMap` when converting `[FfiMessageWithReactions]` to `[DecodedMessage]`. When `DecodedMessage.create(ffiMessage: FfiMessageWithReactions)` returns `nil`, the message is silently omitted without notifying the caller. This can result in incomplete results and hides underlying decode errors. <b>[ Low confidence ]</b>
- [line 492](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Dm.swift#L492): Ambiguous direction handling: The optional `direction` parameter is mapped such that `nil` becomes `.descending`, disallowing the possibility of leaving `options.direction` unspecified. If the FFI backend treats `nil` differently (e.g., a default or natural ordering), this code forces descending order even when the caller passes `nil`. Consider setting `options.direction = nil` when the parameter is `nil`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Sources/XMTPiOS/Group.swift — 0 comments posted, 6 evaluated, 6 filtered</summary>

- [line 530](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Group.swift#L530): No validation of `limit` allows negative values to be passed through to FFI (`options.limit = Int64(limit)`). If a caller supplies a negative `limit`, the backend might misinterpret it or error, and no local guard provides a clear failure mode. Consider validating `limit` to ensure it is positive and, if necessary, within reasonable bounds, returning a clear error for invalid inputs. <b>[ Out of scope ]</b>
- [line 549](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Group.swift#L549): Optional `direction` parameter cannot be passed through as `nil` to preserve server-default behavior. The code maps any value, including `nil`, to a concrete `FfiDirection` (`descending` by default) and sets `options.direction = direction`. This removes the ability to leave the sort unspecified at the FFI boundary and may change semantics if the backend treats `nil` differently from an explicit order. Consider mapping `.some(.ascending)`/`.some(.descending)` explicitly and passing `nil` through when the caller supplies `nil`. <b>[ Out of scope ]</b>
- [line 562](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Group.swift#L562): Silent data loss in `messages(...)`: undecodable messages are dropped without surfacing any error because the result is built with `compactMap` over `DecodedMessage.create(ffiMessage:)`, which returns `nil` on decode error. This silently filters out messages, potentially causing mismatches with counts (e.g., `countMessages`) and making failures opaque to callers. Consider propagating a clear error or including an error/placeholder entry to preserve observable contract, or at least logging per-message failures and allowing the caller to choose whether to skip. <b>[ Out of scope ]</b>
- [line 628](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Group.swift#L628): Dropping entire parent message when a single child reaction fails to decode in `messagesWithReactions(...)`. `DecodedMessage.create(ffiMessage: FfiMessageWithReactions)` maps child reactions with a throwing `map`; any decode failure for a reaction throws and causes the entire parent to be filtered out by `compactMap`. This results in data loss for otherwise valid parent messages. A safer approach is to catch per-reaction decode errors, skip only failing reactions, and return the parent message with whatever children decoded successfully. <b>[ Out of scope ]</b>
- [line 628](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Group.swift#L628): Silent data loss in `messagesWithReactions(...)`: undecodable parent messages or any thrown error during `DecodedMessage.create(ffiMessage: FfiMessageWithReactions)` are fully dropped due to `compactMap`. As with `messages(...)`, failures are not surfaced to callers, which can lead to inconsistent results and hard-to-debug situations. Consider explicit error reporting or including an error state for the affected entries. <b>[ Out of scope ]</b>
- [line 684](https://github.com/xmtp/xmtp-ios/blob/17ecf0dde01d5444f1b73faf0901b4fcb2368864/Sources/XMTPiOS/Group.swift#L684): In `enrichedMessages(...)`, optional `direction` is always mapped to a concrete `FfiDirection` (descending by default) and set in options (lines 684–693), preventing callers from passing `nil` through to preserve any backend default semantics. Align with optional intent by mapping `.some(.ascending)`/`.some(.descending)` only and leaving `options.direction` as `nil` when the caller supplies `nil`. <b>[ Out of scope ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->