### PR TITLE
Add zed support

### DIFF
--- a/.github/workflows/tag_and_deploy_to_cocoapods.yml
+++ b/.github/workflows/tag_and_deploy_to_cocoapods.yml
@@ -8,77 +8,77 @@ jobs:
     runs-on: macos-13
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    
-    - name: Install Cocoapods
-      run: gem install cocoapods
-    
-    - name: Extract version from podspec
-      id: extract_version
-      run: |
-        SPEC_VERSION=$(grep 'spec.version' XMTP.podspec | sed -n 's/.*spec\.version *= *"\([^"]*\)".*/\1/p')
-        echo "SPEC_VERSION=$SPEC_VERSION" >> $GITHUB_ENV
-        echo "Original version: $SPEC_VERSION"
-    
-    - name: Update version if dev release
-      id: update_version
-      run: |
-        SHORT_SHA=$(git rev-parse --short=7 HEAD)
-        if [[ "$SPEC_VERSION" == *"dev"* ]]; then
-          UPDATED_VERSION="${SPEC_VERSION}.$SHORT_SHA"
-        else
-          UPDATED_VERSION="$SPEC_VERSION"
-        fi
-        echo "UPDATED_VERSION=$UPDATED_VERSION" >> $GITHUB_ENV
-        echo "Updated version: $UPDATED_VERSION"
-    
-    - name: Update podspec with new version
-      run: |
-        sed -i '' "s/spec\.version *= *\"$SPEC_VERSION\"/spec.version = \"$UPDATED_VERSION\"/" XMTP.podspec
-        echo "Updated podspec with version: $UPDATED_VERSION"
-    
-    - name: Create and push tag
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git tag -a "$UPDATED_VERSION" -m "Release $UPDATED_VERSION"
-        git push origin "$UPDATED_VERSION"
-        echo "Created and pushed tag: $UPDATED_VERSION"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Extract LibXMTPSwiftFFI URL from Package.swift
-      id: extract_url
-      run: |
-        ZIP_URL=$(grep -A 2 'name: "LibXMTPSwiftFFI"' Package.swift | grep 'url:' | sed -n 's/.*url: *"\([^"]*\)".*/\1/p')
-        echo "ZIP_URL=$ZIP_URL" >> $GITHUB_ENV
-        echo "Extracted URL: $ZIP_URL"
+      - name: Install Cocoapods
+        run: gem install cocoapods
 
-    - name: Build release archive (Sources + LibXMTPSwiftFFI.xcframework)
-      run: |
-        set -euo pipefail
-        curl -L "$ZIP_URL" -o LibXMTPSwiftFFI.zip
-        rm -rf LibXMTPSwiftFFI.xcframework
-        unzip -qo LibXMTPSwiftFFI.zip 'LibXMTPSwiftFFI.xcframework/*' -d .
-        rm -f LibXMTPSwiftFFI.zip
-        rm -rf bundle && mkdir -p bundle
-        rsync -a --exclude 'LibXMTPSwiftFFI.xcframework' Sources/ bundle/Sources/
-        mv LibXMTPSwiftFFI.xcframework bundle/
-        (cd bundle && zip -qry ../XMTP-${UPDATED_VERSION}.zip .)
+      - name: Extract version from podspec
+        id: extract_version
+        run: |
+          SPEC_VERSION=$(grep 'spec.version' XMTP.podspec | sed -n 's/.*spec\.version *= *"\([^"]*\)".*/\1/p')
+          echo "SPEC_VERSION=$SPEC_VERSION" >> $GITHUB_ENV
+          echo "Original version: $SPEC_VERSION"
 
-    - name: Create GitHub Release and upload asset
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: ${{ env.UPDATED_VERSION }}
-        name: ${{ env.UPDATED_VERSION }}
-        files: XMTP-${{ env.UPDATED_VERSION }}.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-    - name: Deploy to Cocoapods
-      run: |
-        set -eo pipefail
-        pod spec lint XMTP.podspec --quick --platforms=ios --allow-warnings
-        pod trunk push XMTP.podspec --allow-warnings --skip-import-validation
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      - name: Update version if dev release
+        id: update_version
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          if [[ "$SPEC_VERSION" == *"dev"* ]]; then
+            UPDATED_VERSION="${SPEC_VERSION}.$SHORT_SHA"
+          else
+            UPDATED_VERSION="$SPEC_VERSION"
+          fi
+          echo "UPDATED_VERSION=$UPDATED_VERSION" >> $GITHUB_ENV
+          echo "Updated version: $UPDATED_VERSION"
+
+      - name: Update podspec with new version
+        run: |
+          sed -i '' "s/spec\.version *= *\"$SPEC_VERSION\"/spec.version = \"$UPDATED_VERSION\"/" XMTP.podspec
+          echo "Updated podspec with version: $UPDATED_VERSION"
+
+      - name: Create and push tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a "$UPDATED_VERSION" -m "Release $UPDATED_VERSION"
+          git push origin "$UPDATED_VERSION"
+          echo "Created and pushed tag: $UPDATED_VERSION"
+
+      - name: Extract LibXMTPSwiftFFI URL from Package.swift
+        id: extract_url
+        run: |
+          ZIP_URL=$(grep -A 3 'name: "LibXMTPSwiftFFI"' Package.swift | grep -o 'https://[^"]*')
+          echo "ZIP_URL=$ZIP_URL" >> $GITHUB_ENV
+          echo "Extracted URL: $ZIP_URL"
+
+      - name: Build release archive (Sources + LibXMTPSwiftFFI.xcframework)
+        run: |
+          set -euo pipefail
+          curl -L "$ZIP_URL" -o LibXMTPSwiftFFI.zip
+          rm -rf LibXMTPSwiftFFI.xcframework
+          unzip -qo LibXMTPSwiftFFI.zip 'LibXMTPSwiftFFI.xcframework/*' -d .
+          rm -f LibXMTPSwiftFFI.zip
+          rm -rf bundle && mkdir -p bundle
+          rsync -a --exclude 'LibXMTPSwiftFFI.xcframework' Sources/ bundle/Sources/
+          mv LibXMTPSwiftFFI.xcframework bundle/
+          (cd bundle && zip -qry ../XMTP-${UPDATED_VERSION}.zip .)
+
+      - name: Create GitHub Release and upload asset
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.UPDATED_VERSION }}
+          name: ${{ env.UPDATED_VERSION }}
+          files: XMTP-${{ env.UPDATED_VERSION }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to Cocoapods
+        run: |
+          set -eo pipefail
+          pod spec lint XMTP.podspec --quick --platforms=ios --allow-warnings
+          pod trunk push XMTP.podspec --allow-warnings --skip-import-validation
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,15 @@
+{
+  "languages": {
+    "Swift": {
+      "enable_language_server": true,
+      "language_servers": ["sourcekit-lsp"],
+      "formatter": {
+        "external": {
+          "command": "swiftformat",
+          "arguments": ["--stdinpath", "{buffer_path}"]
+        }
+      },
+      "format_on_save": "on"
+    }
+  }
+}

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,21 @@
+[
+  {
+    "label": "Run All Tests",
+    "command": "set -o pipefail && swift test 2>&1 | xcbeautify --disable-logging",
+    "tags": ["swift-test"]
+  },
+  {
+    "label": "Run Test Suite $ZED_STEM",
+    "command": "set -o pipefail && swift test --filter \"$ZED_STEM\" 2>&1 | xcbeautify --disable-logging",
+    "tags": ["swift-test-suite"]
+  },
+  {
+    "label": "Run test $ZED_SELECTED_TEXT",
+    "command": "swift test --filter \"$ZED_SELECTED_TEXT\"",
+    "tags": ["swift-test-func"]
+  },
+  {
+    "label": "Build package",
+    "command": "swift build --build-tests -q"
+  }
+]

--- a/Tests/XMTPTests/GroupPermissionsTests.swift
+++ b/Tests/XMTPTests/GroupPermissionsTests.swift
@@ -3,7 +3,7 @@ import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)
-class GroupPermissionTests: XCTestCase {
+class GroupPermissionsTests: XCTestCase {
 	override func setUp() {
 		super.setUp()
 		setupLocalEnv()
@@ -37,7 +37,7 @@ class GroupPermissionTests: XCTestCase {
 			with: [fixtures.alixClient.inboxID]
 		)
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		XCTAssertFalse(
@@ -72,7 +72,7 @@ class GroupPermissionTests: XCTestCase {
 			permissions: .adminOnly
 		)
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		XCTAssertFalse(
@@ -159,7 +159,7 @@ class GroupPermissionTests: XCTestCase {
 			permissions: .adminOnly
 		)
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		XCTAssertTrue(
@@ -204,7 +204,7 @@ class GroupPermissionTests: XCTestCase {
 			permissions: .adminOnly
 		)
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		// Initial checks for group members and their permissions
@@ -268,7 +268,7 @@ class GroupPermissionTests: XCTestCase {
 			permissions: .allMembers
 		)
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		// Verify that alix can NOT add an admin
@@ -299,7 +299,7 @@ class GroupPermissionTests: XCTestCase {
 			permissions: .adminOnly
 		)
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		// Verify that alix cannot update group description
@@ -364,7 +364,7 @@ class GroupPermissionTests: XCTestCase {
 			)
 
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		let alixPermissionSet = try alixGroup.permissionPolicySet()
@@ -408,7 +408,7 @@ class GroupPermissionTests: XCTestCase {
 			)
 
 		try await fixtures.alixClient.conversations.sync()
-		let alixGroup = try await fixtures.alixClient.conversations
+		let alixGroup = try fixtures.alixClient.conversations
 			.listGroups().first!
 
 		let alixPermissionSet = try alixGroup.permissionPolicySet()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->

### Add Zed editor support and adjust Cocoapods deploy workflow URL parsing in [tag_and_deploy_to_cocoapods.yml](https://github.com/xmtp/xmtp-ios/pull/596/files#diff-1dce6b6fc696b8be56bbe0ba38998880c72743d099fdee6ecd5d5993e8dfe955)

- Re-indent all steps and change LibXMTPSwiftFFI URL extraction to `grep -A 3 ... | grep -o "https://[^"]*"` in [tag_and_deploy_to_cocoapods.yml](https://github.com/xmtp/xmtp-ios/pull/596/files#diff-1dce6b6fc696b8be56bbe0ba38998880c72743d099fdee6ecd5d5993e8dfe955)
- Add Zed editor settings for SourceKit-LSP and `swiftformat` with format-on-save in [settings.json](https://github.com/xmtp/xmtp-ios/pull/596/files#diff-abb804d570c3104a261c81b34f0ad1c1d5edb2f62e1318fa5030dbe6ffbdf3d4)
- Add Zed tasks for tests and build in [tasks.json](https://github.com/xmtp/xmtp-ios/pull/596/files#diff-cca76a97851939b294b54ea43654ee178fcb3d4619e10281df8dad3fbc41dbcf)
- Rename `GroupPermissionTests` to `GroupPermissionsTests` and remove `await` from conversation access in [GroupPermissionsTests.swift](https://github.com/xmtp/xmtp-ios/pull/596/files#diff-95014118be1cf079e571d18c43102d85aafb1d8c6de15ea3688106a9dbaba18a)

#### 📍Where to Start

Start with the workflow changes, focusing on the LibXMTPSwiftFFI URL extraction step in [tag_and_deploy_to_cocoapods.yml](https://github.com/xmtp/xmtp-ios/pull/596/files#diff-1dce6b6fc696b8be56bbe0ba38998880c72743d099fdee6ecd5d5993e8dfe955).

---

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 Macroscope summarized 2dec69c. 1 files reviewed, 9 issues evaluated, 9 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues

<details>
<summary>Tests/XMTPTests/GroupPermissionsTests.swift — 0 comments posted, 9 evaluated, 9 filtered</summary>

- [line 75](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L75): Unsafe force unwrap of optional in `let alixGroup = try fixtures.alixClient.conversations.listGroups().first!`. The call to `listGroups()` returns an array and `.first` is an optional that will be `nil` if the list is empty (e.g., due to propagation delay or sync not completing as expected). Using `!` will crash the test at runtime. This is reachable because there is no guard ensuring the list is non-empty before force-unwrapping. Replace with a safe unwrap (e.g., `guard let alixGroup = try fixtures.alixClient.conversations.listGroups().first else { XCTFail("No groups found"); return }`). **[ Test / Mock code ]**
- [line 163](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L163): The test force-unwraps the first element of `listGroups()` via `try fixtures.alixClient.conversations.listGroups().first!`. If `listGroups()` returns an empty array (e.g., due to sync timing, creation failure, or membership not yet reflected), this will crash the test rather than producing a defined failure outcome. Replace the force-unwrap with a guarded fetch and a clear failure message, e.g., `guard let alixGroup = try fixtures.alixClient.conversations.listGroups().first else { XCTFail("Expected at least one group for alix"); return }`. **[ Out of scope ]**
- [line 197](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L197): Resource cleanup (`try fixtures.cleanUpDatabases()`) is only invoked at the end of the test and is not guaranteed to run on early failure paths. Any thrown error or assertion failure before this point will skip cleanup, potentially leaving local databases in a dirty state and causing cross-test interference. Use `defer { try? fixtures.cleanUpDatabases() }` immediately after creating `fixtures` to guarantee cleanup on all exit paths. **[ Out of scope ]**
- [line 207](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L207): The test force-unwraps the first element of `listGroups()` via `try fixtures.alixClient.conversations.listGroups().first!`. If the groups list is empty (e.g., due to eventual consistency or failed sync), this will crash the test. Replace with guarded unwrapping and a clear failure message. **[ Test / Mock code ]**
- [line 261](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L261): Cleanup is not guaranteed on failure paths. `try fixtures.cleanUpDatabases()` is called only at the end. If any preceding `try`/`await` throws or an assertion fails, cleanup will be skipped, potentially leaving local databases in a dirty state and affecting subsequent tests. Add `defer { try? fixtures.cleanUpDatabases() }` immediately after acquiring `fixtures`. **[ Out of scope ]**
- [line 271](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L271): Unsafe force unwrap of optional in `let alixGroup = try fixtures.alixClient.conversations.listGroups().first!`. As above, `.first` can be `nil` if `listGroups()` returns an empty array; force-unwrapping will crash at runtime. Use a safe unwrap with a test failure instead of a crash. **[ Test / Mock code ]**
- [line 302](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L302): The test force-unwraps the first element of `listGroups()` using `try fixtures.alixClient.conversations.listGroups().first!`. This can crash if the list is empty (e.g., due to sync race or creation failure). Use a guarded unwrap with a clear XCTFail fallback instead. **[ Test / Mock code ]**
- [line 343](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L343): Cleanup (`try fixtures.cleanUpDatabases()`) is not guaranteed if the test throws or fails before reaching the end. This can leave persistent state and cause flakiness across tests. Add `defer { try? fixtures.cleanUpDatabases() }` right after obtaining `fixtures`. **[ Out of scope ]**
- [line 413](https://github.com/xmtp/xmtp-ios/blob/2dec69ca3ddf13cb2f8c27f2f6b8360775430ae1/Tests/XMTPTests/GroupPermissionsTests.swift#L413): The test force-unwraps the result of `listGroups().first!` without verifying that the array is non-empty. Since `Conversations.listGroups()` can legitimately return an empty array (e.g., due to sync races or transient failures), this will crash the test at runtime with a fatal error instead of producing a controlled assertion failure. Replace the force-unwrap with a safe guard, e.g., `guard let alixGroup = try fixtures.alixClient.conversations.listGroups().first else { XCTFail("No groups found for alix") ; return }`, so the test reaches a defined terminal state. **[ Test / Mock code ]**

</details>

</details>

\<!-- MACROSCOPE_FOOTER_END -->\<!-- Macroscope's pull request summary ends here -->