### PR TITLE
Update to libxmtp 4.6.0-dev.7bd1287

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
 			name: "LibXMTPSwiftFFI",
 			url:
 			"https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.3656d63/LibXMTPSwiftFFI.zip",
-			checksum: "d36b68a4520846c9bf4aee99425a681f1d2c18a8b15e3523c325621d6b7ede87"
+			checksum: "998d71ff5d57a66dfa0cc8ffaa25035e05ea3261fa12a6c4281305e21aa6a98f"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.0-dev"
+  spec.version      = "4.6.0-dev.7bd1287"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.6.0-dev.7bd1287. 
  
Changes:
- Updated XMTP.podspec version to 4.6.0-dev.7bd1287
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: 10-15-add_zed_support