### PR TITLE
Update to libxmtp 4.6.0-dev.7bd1287

### DIFF
--- a/.github/workflows/tag_and_deploy_to_cocoapods.yml
+++ b/.github/workflows/tag_and_deploy_to_cocoapods.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Extract LibXMTPSwiftFFI URL from Package.swift
         id: extract_url
         run: |
+          set -eu
           ZIP_URL=$(grep -A 3 'name: "LibXMTPSwiftFFI"' Package.swift | grep -o 'https://[^"]*')
           echo "ZIP_URL=$ZIP_URL" >> $GITHUB_ENV
           echo "Extracted URL: $ZIP_URL"

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
 			url:
-			"https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.3656d63/LibXMTPSwiftFFI.zip",
-			checksum: "d36b68a4520846c9bf4aee99425a681f1d2c18a8b15e3523c325621d6b7ede87"
+			"https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.7bd1287/LibXMTPSwiftFFI.zip",
+			checksum: "998d71ff5d57a66dfa0cc8ffaa25035e05ea3261fa12a6c4281305e21aa6a98f"
 		),
 		.target(
 			name: "XMTPiOS",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update dependency to libxmtp 4.6.0-dev.7bd1287 and modify `Sources/XMTPiOS/Libxmtp/xmtpv3.swift` to expose `FfiConversationDebugInfo.cursor` as `[FfiCursor]` and require non-optional `FfiMessage.sequenceId`
The package updates to the `swift-bindings-1.6.0-dev.7bd1287` binary with checksum `998d71ff5d57a66dfa0cc8ffaa25035e05ea3261fa12a6c4281305e21aa6a98f` in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e) and adjusts FFI models and converters in [Sources/XMTPiOS/Libxmtp/xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0).

- Change `FfiConversationDebugInfo.cursor` from `Int64` to `[FfiCursor]` and update `FfiConverterTypeFfiConversationDebugInfo` to read/write a sequence using `FfiConverterSequenceTypeFfiCursor` in [Sources/XMTPiOS/Libxmtp/xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0)
- Add `FfiCursor` with `originatorId: UInt32` and `sequenceId: UInt64`, including converter and sequence helpers in [Sources/XMTPiOS/Libxmtp/xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0)
- Make `FfiMessage.sequenceId` non-optional and update `FfiConverterTypeFfiMessage` to use `FfiConverterUInt64` in [Sources/XMTPiOS/Libxmtp/xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0)
- Update dependency resolution in [Package.resolved](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-3b22d20b6ae7cdf1e2591c647bcae94a3db9ab955f497aeb9d0715f468e6e6ce) and binary target URL in [Package.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e)

#### 📍Where to Start
Start with the FFI type and converter changes in `FfiConversationDebugInfo` and `FfiMessage` within [Sources/XMTPiOS/Libxmtp/xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/598/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0), reviewing `FfiConverterSequenceTypeFfiCursor.read()` and `.write()` and the updated `FfiConverterTypeFfiMessage` implementations.

----














<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 382f50c. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->