### PR TITLE
Update to libxmtp 4.6.0-dev.630501c

### DIFF
--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.0-dev.630501c"
+  spec.version      = "4.6.0-dev"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.6.0-dev.630501c. 
  
Changes:
- Updated XMTP.podspec version to 4.6.0-dev.630501c
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: d14z-client-prerelease