### PR TITLE
Expose DecodedMessage kind

### DIFF
--- a/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift
+++ b/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift
@@ -75,6 +75,10 @@ public struct DecodedMessage: Identifiable {
 		ffiMessage.senderInboxId
 	}
 
+	public var kind: FfiConversationMessageKind {
+		ffiMessage.kind
+	}
+
 	public var sentAt: Date {
 		Date(
 			timeIntervalSince1970: TimeInterval(ffiMessage.sentAtNs)


### PR DESCRIPTION
> Any GroupUpdated message that has the .kind property set to GroupUpdated has been validated by us to be genuine.
So, the only check you need on your end is to make sure that the .kind property is not Application for group updated messages (which would indicate they are being spoofed).

In order for us to perform this check, we need access to the `.kind` property.