### PR TITLE
Update to libxmtp 4.6.0-dev.edf2bef

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.d474afa/LibXMTPSwiftFFI.zip",
-			checksum: "c7ad86de798ac9e00c80c3774e07ce37ed83d6bbefee9d546c04d0a377cd66e3"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.0-dev.edf2bef/LibXMTPSwiftFFI.zip",
+			checksum: "e613cf35bda7814b51b60532d917afd849152c32623ce238b18549585dbdb9fd"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -6217,16 +6217,18 @@ public struct FfiCreateGroupOptions {
     public var groupDescription: String?
     public var customPermissionPolicySet: FfiPermissionPolicySet?
     public var messageDisappearingSettings: FfiMessageDisappearingSettings?
+    public var appData: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(permissions: FfiGroupPermissionsOptions?, groupName: String?, groupImageUrlSquare: String?, groupDescription: String?, customPermissionPolicySet: FfiPermissionPolicySet?, messageDisappearingSettings: FfiMessageDisappearingSettings?) {
+    public init(permissions: FfiGroupPermissionsOptions?, groupName: String?, groupImageUrlSquare: String?, groupDescription: String?, customPermissionPolicySet: FfiPermissionPolicySet?, messageDisappearingSettings: FfiMessageDisappearingSettings?, appData: String?) {
         self.permissions = permissions
         self.groupName = groupName
         self.groupImageUrlSquare = groupImageUrlSquare
         self.groupDescription = groupDescription
         self.customPermissionPolicySet = customPermissionPolicySet
         self.messageDisappearingSettings = messageDisappearingSettings
+        self.appData = appData
     }
 }
 
@@ -6255,6 +6257,9 @@ extension FfiCreateGroupOptions: Equatable, Hashable {
         if lhs.messageDisappearingSettings != rhs.messageDisappearingSettings {
             return false
         }
+        if lhs.appData != rhs.appData {
+            return false
+        }
         return true
     }
 
@@ -6265,6 +6270,7 @@ extension FfiCreateGroupOptions: Equatable, Hashable {
         hasher.combine(groupDescription)
         hasher.combine(customPermissionPolicySet)
         hasher.combine(messageDisappearingSettings)
+        hasher.combine(appData)
     }
 }
 
@@ -6282,7 +6288,8 @@ public struct FfiConverterTypeFfiCreateGroupOptions: FfiConverterRustBuffer {
                 groupImageUrlSquare: FfiConverterOptionString.read(from: &buf), 
                 groupDescription: FfiConverterOptionString.read(from: &buf), 
                 customPermissionPolicySet: FfiConverterOptionTypeFfiPermissionPolicySet.read(from: &buf), 
-                messageDisappearingSettings: FfiConverterOptionTypeFfiMessageDisappearingSettings.read(from: &buf)
+                messageDisappearingSettings: FfiConverterOptionTypeFfiMessageDisappearingSettings.read(from: &buf), 
+                appData: FfiConverterOptionString.read(from: &buf)
         )
     }
 
@@ -6293,6 +6300,7 @@ public struct FfiConverterTypeFfiCreateGroupOptions: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.groupDescription, into: &buf)
         FfiConverterOptionTypeFfiPermissionPolicySet.write(value.customPermissionPolicySet, into: &buf)
         FfiConverterOptionTypeFfiMessageDisappearingSettings.write(value.messageDisappearingSettings, into: &buf)
+        FfiConverterOptionString.write(value.appData, into: &buf)
     }
 }
 

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.0-dev"
+  spec.version      = "4.6.0-dev.edf2bef"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.6.0-dev.edf2bef. 
  
Changes:
- Updated XMTP.podspec version to 4.6.0-dev.edf2bef
- Updated binary URLs in Package.swift to point to the new release
- Updated checksum in Package.swift
- Updated Swift source file (xmtpv3.swift) from the new release

Base branch: update-to-swift-bindings-1.6.0-dev.d474afa