### PR TITLE
Update to libxmtp 4.7.0-dev.f5bec47

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.1-rc2.5597847/LibXMTPSwiftFFI.zip",
-			checksum: "760d953d565f7070e76941b955647118f21950f3877d80d1ae9395f88bef0d8c"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.7.0-dev.f5bec47/LibXMTPSwiftFFI.zip",
+			checksum: "29d7aef74978d8c2c45a028ce80e7bce92b4a5b9b2470606b7798632bbf9bd6b"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/Sources/XMTPiOS/Conversation.swift
+++ b/Sources/XMTPiOS/Conversation.swift
@@ -280,7 +280,10 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessage] {
 		switch self {
 		case let .group(group):
@@ -288,14 +291,20 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: sortBy,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		case let .dm(dm):
 			return try await dm.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: sortBy,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		}
 	}
@@ -326,7 +335,10 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessage] {
 		switch self {
 		case let .group(group):
@@ -334,14 +346,20 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: sortBy,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		case let .dm(dm):
 			return try await dm.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: sortBy,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		}
 	}
@@ -353,7 +371,10 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessageV2] {
 		switch self {
 		case let .group(group):
@@ -361,14 +382,20 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: sortBy,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		case let .dm(dm):
 			return try await dm.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: sortBy,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		}
 	}
@@ -378,20 +405,26 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) throws -> Int64 {
 		switch self {
 		case let .group(group):
 			return try group.countMessages(
 				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		case let .dm(dm):
 			return try dm.countMessages(
 				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		}
 	}

--- a/Sources/XMTPiOS/Dm.swift
+++ b/Sources/XMTPiOS/Dm.swift
@@ -308,7 +308,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -318,7 +321,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			direction: nil,
 			contentTypes: nil,
 			excludeContentTypes: nil,
-			excludeSenderInboxIds: nil
+			excludeSenderInboxIds: nil,
+			sortBy: nil,
+			insertedAfterNs: nil,
+			insertedBeforeNs: nil
 		)
 
 		if let beforeNs {
@@ -360,6 +366,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
+		options.sortBy = sortBy?.toFfi()
+		options.insertedAfterNs = insertedAfterNs
+		options.insertedBeforeNs = insertedBeforeNs
 
 		return try await ffiConversation.findMessages(opts: options).compactMap {
 			ffiMessage in
@@ -374,7 +383,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -384,7 +396,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			direction: nil,
 			contentTypes: nil,
 			excludeContentTypes: nil,
-			excludeSenderInboxIds: nil
+			excludeSenderInboxIds: nil,
+			sortBy: nil,
+			insertedAfterNs: nil,
+			insertedBeforeNs: nil
 		)
 
 		if let beforeNs {
@@ -413,6 +428,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
+		options.sortBy = sortBy?.toFfi()
+		options.insertedAfterNs = insertedAfterNs
+		options.insertedBeforeNs = insertedBeforeNs
 
 		return try ffiConversation.findMessagesWithReactions(
 			opts: options
@@ -426,7 +444,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	public func countMessages(
 		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) throws -> Int64 {
 		try ffiConversation.countMessages(
 			opts: FfiListMessagesOptions(
@@ -437,7 +457,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 				direction: .descending,
 				contentTypes: nil,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: nil,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		)
 	}
@@ -449,7 +472,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessageV2] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -459,7 +485,10 @@ public struct Dm: Identifiable, Equatable, Hashable {
 			direction: nil,
 			contentTypes: nil,
 			excludeContentTypes: nil,
-			excludeSenderInboxIds: nil
+			excludeSenderInboxIds: nil,
+			sortBy: nil,
+			insertedAfterNs: nil,
+			insertedBeforeNs: nil
 		)
 
 		if let beforeNs {
@@ -501,6 +530,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
+		options.sortBy = sortBy?.toFfi()
+		options.insertedAfterNs = insertedAfterNs
+		options.insertedBeforeNs = insertedBeforeNs
 
 		return try await ffiConversation.findEnrichedMessages(opts: options).compactMap {
 			ffiDecodedMessage in

--- a/Sources/XMTPiOS/Group.swift
+++ b/Sources/XMTPiOS/Group.swift
@@ -506,7 +506,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -516,7 +519,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 			direction: nil,
 			contentTypes: nil,
 			excludeContentTypes: nil,
-			excludeSenderInboxIds: nil
+			excludeSenderInboxIds: nil,
+			sortBy: nil,
+			insertedAfterNs: nil,
+			insertedBeforeNs: nil
 		)
 
 		if let beforeNs {
@@ -558,6 +564,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
+		options.sortBy = sortBy?.toFfi()
+		options.insertedAfterNs = insertedAfterNs
+		options.insertedBeforeNs = insertedBeforeNs
 
 		return try await ffiGroup.findMessages(opts: options).compactMap {
 			ffiMessage in
@@ -572,7 +581,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessage] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -582,7 +594,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 			direction: nil,
 			contentTypes: nil,
 			excludeContentTypes: nil,
-			excludeSenderInboxIds: nil
+			excludeSenderInboxIds: nil,
+			sortBy: nil,
+			insertedAfterNs: nil,
+			insertedBeforeNs: nil
 		)
 
 		if let beforeNs {
@@ -624,6 +639,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
+		options.sortBy = sortBy?.toFfi()
+		options.insertedAfterNs = insertedAfterNs
+		options.insertedBeforeNs = insertedBeforeNs
 
 		return try ffiGroup.findMessagesWithReactions(opts: options)
 			.compactMap {
@@ -641,7 +659,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		sortBy: MessageSortBy? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) async throws -> [DecodedMessageV2] {
 		var options = FfiListMessagesOptions(
 			sentBeforeNs: nil,
@@ -651,7 +672,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 			direction: nil,
 			contentTypes: nil,
 			excludeContentTypes: nil,
-			excludeSenderInboxIds: nil
+			excludeSenderInboxIds: nil,
+			sortBy: nil,
+			insertedAfterNs: nil,
+			insertedBeforeNs: nil
 		)
 
 		if let beforeNs {
@@ -693,6 +717,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 		options.direction = direction
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
+		options.sortBy = sortBy?.toFfi()
+		options.insertedAfterNs = insertedAfterNs
+		options.insertedBeforeNs = insertedBeforeNs
 
 		return try await ffiGroup.findEnrichedMessages(opts: options).compactMap {
 			ffiDecodedMessage in
@@ -703,7 +730,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 	public func countMessages(
 		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
 		excludeContentTypes: [StandardContentType]? = nil,
-		excludeSenderInboxIds: [String]? = nil
+		excludeSenderInboxIds: [String]? = nil,
+		insertedAfterNs: Int64? = nil,
+		insertedBeforeNs: Int64? = nil
 	) throws -> Int64 {
 		try ffiGroup.countMessages(
 			opts: FfiListMessagesOptions(
@@ -714,7 +743,10 @@ public struct Group: Identifiable, Equatable, Hashable {
 				direction: .descending,
 				contentTypes: nil,
 				excludeContentTypes: excludeContentTypes,
-				excludeSenderInboxIds: excludeSenderInboxIds
+				excludeSenderInboxIds: excludeSenderInboxIds,
+				sortBy: nil,
+				insertedAfterNs: insertedAfterNs,
+				insertedBeforeNs: insertedBeforeNs
 			)
 		)
 	}

--- a/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift
+++ b/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift
@@ -58,6 +58,29 @@ public enum SortDirection {
 	}
 }
 
+public enum MessageSortBy {
+	case sentAt
+	case insertedAt
+
+	func toFfi() -> FfiSortBy {
+		switch self {
+		case .sentAt:
+			return .sentAt
+		case .insertedAt:
+			return .insertedAt
+		}
+	}
+
+	static func fromFfi(_ ffiSortBy: FfiSortBy) -> MessageSortBy {
+		switch ffiSortBy {
+		case .sentAt:
+			return .sentAt
+		case .insertedAt:
+			return .insertedAt
+		}
+	}
+}
+
 public struct DecodedMessage: Identifiable {
 	let ffiMessage: FfiMessage
 	private let decodedContent: Any?
@@ -88,6 +111,17 @@ public struct DecodedMessage: Identifiable {
 
 	public var sentAtNs: Int64 {
 		ffiMessage.sentAtNs
+	}
+
+	public var insertedAt: Date {
+		Date(
+			timeIntervalSince1970: TimeInterval(ffiMessage.insertedAtNs)
+				/ 1_000_000_000
+		)
+	}
+
+	public var insertedAtNs: Int64 {
+		ffiMessage.insertedAtNs
 	}
 
 	public var deliveryStatus: MessageDeliveryStatus {

--- a/Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift
+++ b/Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+public typealias Intent = FfiIntent
+public typealias Actions = FfiActions
+
 public struct DecodedMessageV2: Identifiable {
 	private let ffiMessage: FfiDecodedMessage
 
@@ -21,6 +24,14 @@ public struct DecodedMessageV2: Identifiable {
 
 	public var sentAtNs: Int64 {
 		ffiMessage.sentAtNs()
+	}
+
+	public var insertedAt: Date {
+		Date(timeIntervalSince1970: TimeInterval(ffiMessage.insertedAtNs()) / 1_000_000_000)
+	}
+
+	public var insertedAtNs: Int64 {
+		ffiMessage.insertedAtNs()
 	}
 
 	public var deliveryStatus: MessageDeliveryStatus {
@@ -134,6 +145,12 @@ public struct DecodedMessageV2: Identifiable {
 			let encoded = try mapFfiEncodedContent(ffiEncodedContent)
 			let codec = Client.codecRegistry.find(for: encoded.type)
 			return try codec.decode(content: encoded)
+
+		case let .intent(intent):
+			return intent
+
+		case let .actions(actions):
+			return actions
 		}
 	}
 
@@ -182,6 +199,10 @@ public struct DecodedMessageV2: Identifiable {
 			let encoded = try mapFfiEncodedContent(ffiEncodedContent)
 			let codec = Client.codecRegistry.find(for: encoded.type)
 			return try codec.decode(content: encoded)
+		case let .intent(intent):
+			return intent as Intent
+		case let .actions(actions):
+			return actions as Actions
 		}
 	}
 
@@ -222,6 +243,20 @@ public struct DecodedMessageV2: Identifiable {
 				// Return a default content type if none is specified
 				return ContentTypeText
 			}
+		case .intent:
+			return ContentTypeID(
+				authorityID: "coinbase.com",
+				typeID: "intent",
+				versionMajor: 1,
+				versionMinor: 0
+			)
+		case .actions:
+			return ContentTypeID(
+				authorityID: "coinbase.com",
+				typeID: "actions",
+				versionMajor: 1,
+				versionMinor: 0
+			)
 		}
 	}
 

--- a/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -2220,6 +2220,12 @@ public protocol FfiConversationsProtocol: AnyObject, Sendable {
     
     func streamGroups(callback: FfiConversationCallback) async  -> FfiStreamCloser
     
+    /**
+     * Get notified when a message is deleted by the disappearing messages worker.
+     * The callback receives the message ID of each deleted message.
+     */
+    func streamMessageDeletions(callback: FfiMessageDeletionCallback) async  -> FfiStreamCloser
+    
     func streamMessages(messageCallback: FfiMessageCallback, conversationType: FfiConversationType?, consentStates: [FfiConsentState]?) async  -> FfiStreamCloser
     
     /**
@@ -2539,6 +2545,28 @@ open func streamGroups(callback: FfiConversationCallback)async  -> FfiStreamClos
         )
 }
     
+    /**
+     * Get notified when a message is deleted by the disappearing messages worker.
+     * The callback receives the message ID of each deleted message.
+     */
+open func streamMessageDeletions(callback: FfiMessageDeletionCallback)async  -> FfiStreamCloser  {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_method_fficonversations_stream_message_deletions(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeFfiMessageDeletionCallback_lower(callback)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_pointer,
+            completeFunc: ffi_xmtpv3_rust_future_complete_pointer,
+            freeFunc: ffi_xmtpv3_rust_future_free_pointer,
+            liftFunc: FfiConverterTypeFfiStreamCloser_lift,
+            errorHandler: nil
+            
+        )
+}
+    
 open func streamMessages(messageCallback: FfiMessageCallback, conversationType: FfiConversationType?, consentStates: [FfiConsentState]?)async  -> FfiStreamCloser  {
     return
         try!  await uniffiRustCallAsync(
@@ -2687,6 +2715,8 @@ public protocol FfiDecodedMessageProtocol: AnyObject, Sendable {
     
     func id()  -> Data
     
+    func insertedAtNs()  -> Int64
+    
     func kind()  -> FfiGroupMessageKind
     
     func numReplies()  -> UInt64
@@ -2799,6 +2829,13 @@ open func hasReactions() -> Bool  {
 open func id() -> Data  {
     return try!  FfiConverterData.lift(try! rustCall() {
     uniffi_xmtpv3_fn_method_ffidecodedmessage_id(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func insertedAtNs() -> Int64  {
+    return try!  FfiConverterInt64.lift(try! rustCall() {
+    uniffi_xmtpv3_fn_method_ffidecodedmessage_inserted_at_ns(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -3477,6 +3514,179 @@ public func FfiConverterTypeFfiMessageCallback_lift(_ pointer: UnsafeMutableRawP
 #endif
 public func FfiConverterTypeFfiMessageCallback_lower(_ value: FfiMessageCallback) -> UnsafeMutableRawPointer {
     return FfiConverterTypeFfiMessageCallback.lower(value)
+}
+
+
+
+
+
+
+public protocol FfiMessageDeletionCallback: AnyObject, Sendable {
+    
+    func onMessageDeleted(messageId: Data) 
+    
+}
+open class FfiMessageDeletionCallbackImpl: FfiMessageDeletionCallback, @unchecked Sendable {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_xmtpv3_fn_clone_ffimessagedeletioncallback(self.pointer, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_xmtpv3_fn_free_ffimessagedeletioncallback(pointer, $0) }
+    }
+
+    
+
+    
+open func onMessageDeleted(messageId: Data)  {try! rustCall() {
+    uniffi_xmtpv3_fn_method_ffimessagedeletioncallback_on_message_deleted(self.uniffiClonePointer(),
+        FfiConverterData.lower(messageId),$0
+    )
+}
+}
+    
+
+}
+
+
+// Put the implementation in a struct so we don't pollute the top-level namespace
+fileprivate struct UniffiCallbackInterfaceFfiMessageDeletionCallback {
+
+    // Create the VTable using a series of closures.
+    // Swift automatically converts these into C callback functions.
+    //
+    // This creates 1-element array, since this seems to be the only way to construct a const
+    // pointer that we can pass to the Rust code.
+    static let vtable: [UniffiVTableCallbackInterfaceFfiMessageDeletionCallback] = [UniffiVTableCallbackInterfaceFfiMessageDeletionCallback(
+        onMessageDeleted: { (
+            uniffiHandle: UInt64,
+            messageId: RustBuffer,
+            uniffiOutReturn: UnsafeMutableRawPointer,
+            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
+        ) in
+            let makeCall = {
+                () throws -> () in
+                guard let uniffiObj = try? FfiConverterTypeFfiMessageDeletionCallback.handleMap.get(handle: uniffiHandle) else {
+                    throw UniffiInternalError.unexpectedStaleHandle
+                }
+                return uniffiObj.onMessageDeleted(
+                     messageId: try FfiConverterData.lift(messageId)
+                )
+            }
+
+            
+            let writeReturn = { () }
+            uniffiTraitInterfaceCall(
+                callStatus: uniffiCallStatus,
+                makeCall: makeCall,
+                writeReturn: writeReturn
+            )
+        },
+        uniffiFree: { (uniffiHandle: UInt64) -> () in
+            let result = try? FfiConverterTypeFfiMessageDeletionCallback.handleMap.remove(handle: uniffiHandle)
+            if result == nil {
+                print("Uniffi callback interface FfiMessageDeletionCallback: handle missing in uniffiFree")
+            }
+        }
+    )]
+}
+
+private func uniffiCallbackInitFfiMessageDeletionCallback() {
+    uniffi_xmtpv3_fn_init_callback_vtable_ffimessagedeletioncallback(UniffiCallbackInterfaceFfiMessageDeletionCallback.vtable)
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiMessageDeletionCallback: FfiConverter {
+    fileprivate static let handleMap = UniffiHandleMap<FfiMessageDeletionCallback>()
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = FfiMessageDeletionCallback
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> FfiMessageDeletionCallback {
+        return FfiMessageDeletionCallbackImpl(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: FfiMessageDeletionCallback) -> UnsafeMutableRawPointer {
+        guard let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: handleMap.insert(obj: value))) else {
+            fatalError("Cast to UnsafeMutableRawPointer failed")
+        }
+        return ptr
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiMessageDeletionCallback {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: FfiMessageDeletionCallback, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiMessageDeletionCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> FfiMessageDeletionCallback {
+    return try FfiConverterTypeFfiMessageDeletionCallback.lift(pointer)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiMessageDeletionCallback_lower(_ value: FfiMessageDeletionCallback) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeFfiMessageDeletionCallback.lower(value)
 }
 
 
@@ -5183,6 +5393,186 @@ public func FfiConverterTypeXmtpApiClient_lower(_ value: XmtpApiClient) -> Unsaf
 
 
 
+public struct FfiAction {
+    public var id: String
+    public var label: String
+    public var imageUrl: String?
+    public var style: FfiActionStyle?
+    public var expiresAtNs: Int64?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, label: String, imageUrl: String?, style: FfiActionStyle?, expiresAtNs: Int64?) {
+        self.id = id
+        self.label = label
+        self.imageUrl = imageUrl
+        self.style = style
+        self.expiresAtNs = expiresAtNs
+    }
+}
+
+#if compiler(>=6)
+extension FfiAction: Sendable {}
+#endif
+
+
+extension FfiAction: Equatable, Hashable {
+    public static func ==(lhs: FfiAction, rhs: FfiAction) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.label != rhs.label {
+            return false
+        }
+        if lhs.imageUrl != rhs.imageUrl {
+            return false
+        }
+        if lhs.style != rhs.style {
+            return false
+        }
+        if lhs.expiresAtNs != rhs.expiresAtNs {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(label)
+        hasher.combine(imageUrl)
+        hasher.combine(style)
+        hasher.combine(expiresAtNs)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiAction: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiAction {
+        return
+            try FfiAction(
+                id: FfiConverterString.read(from: &buf), 
+                label: FfiConverterString.read(from: &buf), 
+                imageUrl: FfiConverterOptionString.read(from: &buf), 
+                style: FfiConverterOptionTypeFfiActionStyle.read(from: &buf), 
+                expiresAtNs: FfiConverterOptionInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiAction, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.label, into: &buf)
+        FfiConverterOptionString.write(value.imageUrl, into: &buf)
+        FfiConverterOptionTypeFfiActionStyle.write(value.style, into: &buf)
+        FfiConverterOptionInt64.write(value.expiresAtNs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiAction_lift(_ buf: RustBuffer) throws -> FfiAction {
+    return try FfiConverterTypeFfiAction.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiAction_lower(_ value: FfiAction) -> RustBuffer {
+    return FfiConverterTypeFfiAction.lower(value)
+}
+
+
+public struct FfiActions {
+    public var id: String
+    public var description: String
+    public var actions: [FfiAction]
+    public var expiresAtNs: Int64?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, description: String, actions: [FfiAction], expiresAtNs: Int64?) {
+        self.id = id
+        self.description = description
+        self.actions = actions
+        self.expiresAtNs = expiresAtNs
+    }
+}
+
+#if compiler(>=6)
+extension FfiActions: Sendable {}
+#endif
+
+
+extension FfiActions: Equatable, Hashable {
+    public static func ==(lhs: FfiActions, rhs: FfiActions) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.description != rhs.description {
+            return false
+        }
+        if lhs.actions != rhs.actions {
+            return false
+        }
+        if lhs.expiresAtNs != rhs.expiresAtNs {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(description)
+        hasher.combine(actions)
+        hasher.combine(expiresAtNs)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiActions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiActions {
+        return
+            try FfiActions(
+                id: FfiConverterString.read(from: &buf), 
+                description: FfiConverterString.read(from: &buf), 
+                actions: FfiConverterSequenceTypeFfiAction.read(from: &buf), 
+                expiresAtNs: FfiConverterOptionInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiActions, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.description, into: &buf)
+        FfiConverterSequenceTypeFfiAction.write(value.actions, into: &buf)
+        FfiConverterOptionInt64.write(value.expiresAtNs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiActions_lift(_ buf: RustBuffer) throws -> FfiActions {
+    return try FfiConverterTypeFfiActions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiActions_lower(_ value: FfiActions) -> RustBuffer {
+    return FfiConverterTypeFfiActions.lower(value)
+}
+
+
 public struct FfiApiStats {
     public var uploadKeyPackage: UInt64
     public var fetchKeyPackage: UInt64
@@ -6161,10 +6551,11 @@ public struct FfiDecodedMessageMetadata {
     public var senderInboxId: String
     public var contentType: FfiContentTypeId
     public var conversationId: Data
+    public var insertedAtNs: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: Data, sentAtNs: Int64, kind: FfiGroupMessageKind, senderInstallationId: Data, senderInboxId: String, contentType: FfiContentTypeId, conversationId: Data) {
+    public init(id: Data, sentAtNs: Int64, kind: FfiGroupMessageKind, senderInstallationId: Data, senderInboxId: String, contentType: FfiContentTypeId, conversationId: Data, insertedAtNs: Int64) {
         self.id = id
         self.sentAtNs = sentAtNs
         self.kind = kind
@@ -6172,6 +6563,7 @@ public struct FfiDecodedMessageMetadata {
         self.senderInboxId = senderInboxId
         self.contentType = contentType
         self.conversationId = conversationId
+        self.insertedAtNs = insertedAtNs
     }
 }
 
@@ -6203,6 +6595,9 @@ extension FfiDecodedMessageMetadata: Equatable, Hashable {
         if lhs.conversationId != rhs.conversationId {
             return false
         }
+        if lhs.insertedAtNs != rhs.insertedAtNs {
+            return false
+        }
         return true
     }
 
@@ -6214,6 +6609,7 @@ extension FfiDecodedMessageMetadata: Equatable, Hashable {
         hasher.combine(senderInboxId)
         hasher.combine(contentType)
         hasher.combine(conversationId)
+        hasher.combine(insertedAtNs)
     }
 }
 
@@ -6232,7 +6628,8 @@ public struct FfiConverterTypeFfiDecodedMessageMetadata: FfiConverterRustBuffer 
                 senderInstallationId: FfiConverterData.read(from: &buf), 
                 senderInboxId: FfiConverterString.read(from: &buf), 
                 contentType: FfiConverterTypeFfiContentTypeId.read(from: &buf), 
-                conversationId: FfiConverterData.read(from: &buf)
+                conversationId: FfiConverterData.read(from: &buf), 
+                insertedAtNs: FfiConverterInt64.read(from: &buf)
         )
     }
 
@@ -6244,6 +6641,7 @@ public struct FfiConverterTypeFfiDecodedMessageMetadata: FfiConverterRustBuffer 
         FfiConverterString.write(value.senderInboxId, into: &buf)
         FfiConverterTypeFfiContentTypeId.write(value.contentType, into: &buf)
         FfiConverterData.write(value.conversationId, into: &buf)
+        FfiConverterInt64.write(value.insertedAtNs, into: &buf)
     }
 }
 
@@ -7115,6 +7513,84 @@ public func FfiConverterTypeFfiInstallation_lower(_ value: FfiInstallation) -> R
 }
 
 
+public struct FfiIntent {
+    public var id: String
+    public var actionId: String
+    public var metadata: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, actionId: String, metadata: String?) {
+        self.id = id
+        self.actionId = actionId
+        self.metadata = metadata
+    }
+}
+
+#if compiler(>=6)
+extension FfiIntent: Sendable {}
+#endif
+
+
+extension FfiIntent: Equatable, Hashable {
+    public static func ==(lhs: FfiIntent, rhs: FfiIntent) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.actionId != rhs.actionId {
+            return false
+        }
+        if lhs.metadata != rhs.metadata {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(actionId)
+        hasher.combine(metadata)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiIntent: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiIntent {
+        return
+            try FfiIntent(
+                id: FfiConverterString.read(from: &buf), 
+                actionId: FfiConverterString.read(from: &buf), 
+                metadata: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiIntent, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.actionId, into: &buf)
+        FfiConverterOptionString.write(value.metadata, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiIntent_lift(_ buf: RustBuffer) throws -> FfiIntent {
+    return try FfiConverterTypeFfiIntent.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiIntent_lower(_ value: FfiIntent) -> RustBuffer {
+    return FfiConverterTypeFfiIntent.lower(value)
+}
+
+
 public struct FfiKeyPackageStatus {
     public var lifetime: FfiLifetime?
     public var validationError: String?
@@ -7382,10 +7858,13 @@ public struct FfiListMessagesOptions {
     public var contentTypes: [FfiContentType]?
     public var excludeContentTypes: [FfiContentType]?
     public var excludeSenderInboxIds: [String]?
+    public var sortBy: FfiSortBy?
+    public var insertedAfterNs: Int64?
+    public var insertedBeforeNs: Int64?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(sentBeforeNs: Int64?, sentAfterNs: Int64?, limit: Int64?, deliveryStatus: FfiDeliveryStatus?, direction: FfiDirection?, contentTypes: [FfiContentType]?, excludeContentTypes: [FfiContentType]?, excludeSenderInboxIds: [String]?) {
+    public init(sentBeforeNs: Int64?, sentAfterNs: Int64?, limit: Int64?, deliveryStatus: FfiDeliveryStatus?, direction: FfiDirection?, contentTypes: [FfiContentType]?, excludeContentTypes: [FfiContentType]?, excludeSenderInboxIds: [String]?, sortBy: FfiSortBy?, insertedAfterNs: Int64?, insertedBeforeNs: Int64?) {
         self.sentBeforeNs = sentBeforeNs
         self.sentAfterNs = sentAfterNs
         self.limit = limit
@@ -7394,6 +7873,9 @@ public struct FfiListMessagesOptions {
         self.contentTypes = contentTypes
         self.excludeContentTypes = excludeContentTypes
         self.excludeSenderInboxIds = excludeSenderInboxIds
+        self.sortBy = sortBy
+        self.insertedAfterNs = insertedAfterNs
+        self.insertedBeforeNs = insertedBeforeNs
     }
 }
 
@@ -7428,6 +7910,15 @@ extension FfiListMessagesOptions: Equatable, Hashable {
         if lhs.excludeSenderInboxIds != rhs.excludeSenderInboxIds {
             return false
         }
+        if lhs.sortBy != rhs.sortBy {
+            return false
+        }
+        if lhs.insertedAfterNs != rhs.insertedAfterNs {
+            return false
+        }
+        if lhs.insertedBeforeNs != rhs.insertedBeforeNs {
+            return false
+        }
         return true
     }
 
@@ -7440,6 +7931,9 @@ extension FfiListMessagesOptions: Equatable, Hashable {
         hasher.combine(contentTypes)
         hasher.combine(excludeContentTypes)
         hasher.combine(excludeSenderInboxIds)
+        hasher.combine(sortBy)
+        hasher.combine(insertedAfterNs)
+        hasher.combine(insertedBeforeNs)
     }
 }
 
@@ -7459,7 +7953,10 @@ public struct FfiConverterTypeFfiListMessagesOptions: FfiConverterRustBuffer {
                 direction: FfiConverterOptionTypeFfiDirection.read(from: &buf), 
                 contentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf), 
                 excludeContentTypes: FfiConverterOptionSequenceTypeFfiContentType.read(from: &buf), 
-                excludeSenderInboxIds: FfiConverterOptionSequenceString.read(from: &buf)
+                excludeSenderInboxIds: FfiConverterOptionSequenceString.read(from: &buf), 
+                sortBy: FfiConverterOptionTypeFfiSortBy.read(from: &buf), 
+                insertedAfterNs: FfiConverterOptionInt64.read(from: &buf), 
+                insertedBeforeNs: FfiConverterOptionInt64.read(from: &buf)
         )
     }
 
@@ -7472,6 +7969,9 @@ public struct FfiConverterTypeFfiListMessagesOptions: FfiConverterRustBuffer {
         FfiConverterOptionSequenceTypeFfiContentType.write(value.contentTypes, into: &buf)
         FfiConverterOptionSequenceTypeFfiContentType.write(value.excludeContentTypes, into: &buf)
         FfiConverterOptionSequenceString.write(value.excludeSenderInboxIds, into: &buf)
+        FfiConverterOptionTypeFfiSortBy.write(value.sortBy, into: &buf)
+        FfiConverterOptionInt64.write(value.insertedAfterNs, into: &buf)
+        FfiConverterOptionInt64.write(value.insertedBeforeNs, into: &buf)
     }
 }
 
@@ -7501,10 +8001,11 @@ public struct FfiMessage {
     public var deliveryStatus: FfiDeliveryStatus
     public var sequenceId: UInt64
     public var originatorId: UInt32
+    public var insertedAtNs: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: Data, sentAtNs: Int64, conversationId: Data, senderInboxId: String, content: Data, kind: FfiConversationMessageKind, deliveryStatus: FfiDeliveryStatus, sequenceId: UInt64, originatorId: UInt32) {
+    public init(id: Data, sentAtNs: Int64, conversationId: Data, senderInboxId: String, content: Data, kind: FfiConversationMessageKind, deliveryStatus: FfiDeliveryStatus, sequenceId: UInt64, originatorId: UInt32, insertedAtNs: Int64) {
         self.id = id
         self.sentAtNs = sentAtNs
         self.conversationId = conversationId
@@ -7514,6 +8015,7 @@ public struct FfiMessage {
         self.deliveryStatus = deliveryStatus
         self.sequenceId = sequenceId
         self.originatorId = originatorId
+        self.insertedAtNs = insertedAtNs
     }
 }
 
@@ -7551,6 +8053,9 @@ extension FfiMessage: Equatable, Hashable {
         if lhs.originatorId != rhs.originatorId {
             return false
         }
+        if lhs.insertedAtNs != rhs.insertedAtNs {
+            return false
+        }
         return true
     }
 
@@ -7564,6 +8069,7 @@ extension FfiMessage: Equatable, Hashable {
         hasher.combine(deliveryStatus)
         hasher.combine(sequenceId)
         hasher.combine(originatorId)
+        hasher.combine(insertedAtNs)
     }
 }
 
@@ -7584,7 +8090,8 @@ public struct FfiConverterTypeFfiMessage: FfiConverterRustBuffer {
                 kind: FfiConverterTypeFfiConversationMessageKind.read(from: &buf), 
                 deliveryStatus: FfiConverterTypeFfiDeliveryStatus.read(from: &buf), 
                 sequenceId: FfiConverterUInt64.read(from: &buf), 
-                originatorId: FfiConverterUInt32.read(from: &buf)
+                originatorId: FfiConverterUInt32.read(from: &buf), 
+                insertedAtNs: FfiConverterInt64.read(from: &buf)
         )
     }
 
@@ -7598,6 +8105,7 @@ public struct FfiConverterTypeFfiMessage: FfiConverterRustBuffer {
         FfiConverterTypeFfiDeliveryStatus.write(value.deliveryStatus, into: &buf)
         FfiConverterUInt64.write(value.sequenceId, into: &buf)
         FfiConverterUInt32.write(value.originatorId, into: &buf)
+        FfiConverterInt64.write(value.insertedAtNs, into: &buf)
     }
 }
 
@@ -9228,6 +9736,83 @@ public func FfiConverterTypeFfiWalletSendCalls_lower(_ value: FfiWalletSendCalls
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
+public enum FfiActionStyle {
+    
+    case primary
+    case secondary
+    case danger
+}
+
+
+#if compiler(>=6)
+extension FfiActionStyle: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiActionStyle: FfiConverterRustBuffer {
+    typealias SwiftType = FfiActionStyle
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiActionStyle {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .primary
+        
+        case 2: return .secondary
+        
+        case 3: return .danger
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: FfiActionStyle, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .primary:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .secondary:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .danger:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiActionStyle_lift(_ buf: RustBuffer) throws -> FfiActionStyle {
+    return try FfiConverterTypeFfiActionStyle.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiActionStyle_lower(_ value: FfiActionStyle) -> RustBuffer {
+    return FfiConverterTypeFfiActionStyle.lower(value)
+}
+
+
+extension FfiActionStyle: Equatable, Hashable {}
+
+
+
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
 public enum FfiBackupElementSelection {
     
     case messages
@@ -9835,6 +10420,10 @@ public enum FfiDecodedMessageBody {
     )
     case walletSendCalls(FfiWalletSendCalls
     )
+    case intent(FfiIntent
+    )
+    case actions(FfiActions
+    )
     case custom(FfiEncodedContent
     )
 }
@@ -9881,7 +10470,13 @@ public struct FfiConverterTypeFfiDecodedMessageBody: FfiConverterRustBuffer {
         case 9: return .walletSendCalls(try FfiConverterTypeFfiWalletSendCalls.read(from: &buf)
         )
         
-        case 10: return .custom(try FfiConverterTypeFfiEncodedContent.read(from: &buf)
+        case 10: return .intent(try FfiConverterTypeFfiIntent.read(from: &buf)
+        )
+        
+        case 11: return .actions(try FfiConverterTypeFfiActions.read(from: &buf)
+        )
+        
+        case 12: return .custom(try FfiConverterTypeFfiEncodedContent.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -9937,8 +10532,18 @@ public struct FfiConverterTypeFfiDecodedMessageBody: FfiConverterRustBuffer {
             FfiConverterTypeFfiWalletSendCalls.write(v1, into: &buf)
             
         
-        case let .custom(v1):
+        case let .intent(v1):
             writeInt(&buf, Int32(10))
+            FfiConverterTypeFfiIntent.write(v1, into: &buf)
+            
+        
+        case let .actions(v1):
+            writeInt(&buf, Int32(11))
+            FfiConverterTypeFfiActions.write(v1, into: &buf)
+            
+        
+        case let .custom(v1):
+            writeInt(&buf, Int32(12))
             FfiConverterTypeFfiEncodedContent.write(v1, into: &buf)
             
         }
@@ -9993,6 +10598,10 @@ public enum FfiDecodedMessageContent {
     )
     case walletSendCalls(FfiWalletSendCalls
     )
+    case intent(FfiIntent?
+    )
+    case actions(FfiActions?
+    )
     case custom(FfiEncodedContent
     )
 }
@@ -10042,7 +10651,13 @@ public struct FfiConverterTypeFfiDecodedMessageContent: FfiConverterRustBuffer {
         case 10: return .walletSendCalls(try FfiConverterTypeFfiWalletSendCalls.read(from: &buf)
         )
         
-        case 11: return .custom(try FfiConverterTypeFfiEncodedContent.read(from: &buf)
+        case 11: return .intent(try FfiConverterOptionTypeFfiIntent.read(from: &buf)
+        )
+        
+        case 12: return .actions(try FfiConverterOptionTypeFfiActions.read(from: &buf)
+        )
+        
+        case 13: return .custom(try FfiConverterTypeFfiEncodedContent.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -10103,8 +10718,18 @@ public struct FfiConverterTypeFfiDecodedMessageContent: FfiConverterRustBuffer {
             FfiConverterTypeFfiWalletSendCalls.write(v1, into: &buf)
             
         
-        case let .custom(v1):
+        case let .intent(v1):
             writeInt(&buf, Int32(11))
+            FfiConverterOptionTypeFfiIntent.write(v1, into: &buf)
+            
+        
+        case let .actions(v1):
+            writeInt(&buf, Int32(12))
+            FfiConverterOptionTypeFfiActions.write(v1, into: &buf)
+            
+        
+        case let .custom(v1):
+            writeInt(&buf, Int32(13))
             FfiConverterTypeFfiEncodedContent.write(v1, into: &buf)
             
         }
@@ -11529,6 +12154,76 @@ extension FfiSignatureKind: Equatable, Hashable {}
 
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum FfiSortBy {
+    
+    case sentAt
+    case insertedAt
+}
+
+
+#if compiler(>=6)
+extension FfiSortBy: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiSortBy: FfiConverterRustBuffer {
+    typealias SwiftType = FfiSortBy
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiSortBy {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .sentAt
+        
+        case 2: return .insertedAt
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: FfiSortBy, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .sentAt:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .insertedAt:
+            writeInt(&buf, Int32(2))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiSortBy_lift(_ buf: RustBuffer) throws -> FfiSortBy {
+    return try FfiConverterTypeFfiSortBy.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiSortBy_lower(_ value: FfiSortBy) -> RustBuffer {
+    return FfiConverterTypeFfiSortBy.lower(value)
+}
+
+
+extension FfiSortBy: Equatable, Hashable {}
+
+
+
+
+
+
 
 public enum FfiSubscribeError: Swift.Error {
 
@@ -12480,6 +13175,30 @@ fileprivate struct FfiConverterOptionTypeFfiSignatureRequest: FfiConverterRustBu
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeFfiActions: FfiConverterRustBuffer {
+    typealias SwiftType = FfiActions?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeFfiActions.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeFfiActions.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeFfiContentTypeId: FfiConverterRustBuffer {
     typealias SwiftType = FfiContentTypeId?
 
@@ -12520,6 +13239,30 @@ fileprivate struct FfiConverterOptionTypeFfiForkRecoveryOpts: FfiConverterRustBu
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeFfiForkRecoveryOpts.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeFfiIntent: FfiConverterRustBuffer {
+    typealias SwiftType = FfiIntent?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeFfiIntent.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeFfiIntent.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -12664,6 +13407,30 @@ fileprivate struct FfiConverterOptionTypeFfiWalletCallMetadata: FfiConverterRust
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeFfiWalletCallMetadata.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeFfiActionStyle: FfiConverterRustBuffer {
+    typealias SwiftType = FfiActionStyle?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeFfiActionStyle.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeFfiActionStyle.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -12856,6 +13623,30 @@ fileprivate struct FfiConverterOptionTypeFfiSignatureKind: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeFfiSignatureKind.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeFfiSortBy: FfiConverterRustBuffer {
+    typealias SwiftType = FfiSortBy?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeFfiSortBy.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeFfiSortBy.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -13101,6 +13892,31 @@ fileprivate struct FfiConverterSequenceTypeFfiDecodedMessage: FfiConverterRustBu
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeFfiDecodedMessage.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeFfiAction: FfiConverterRustBuffer {
+    typealias SwiftType = [FfiAction]
+
+    public static func write(_ value: [FfiAction], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeFfiAction.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [FfiAction] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [FfiAction]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeFfiAction.read(from: &buf))
         }
         return seq
     }
@@ -13804,9 +14620,23 @@ public func createClient(api: XmtpApiClient, syncApi: XmtpApiClient, db: String?
             errorHandler: FfiConverterTypeGenericError_lift
         )
 }
+public func decodeActions(bytes: Data)throws  -> FfiActions  {
+    return try  FfiConverterTypeFfiActions_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_decode_actions(
+        FfiConverterData.lower(bytes),$0
+    )
+})
+}
 public func decodeAttachment(bytes: Data)throws  -> FfiAttachment  {
     return try  FfiConverterTypeFfiAttachment_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
     uniffi_xmtpv3_fn_func_decode_attachment(
+        FfiConverterData.lower(bytes),$0
+    )
+})
+}
+public func decodeIntent(bytes: Data)throws  -> FfiIntent  {
+    return try  FfiConverterTypeFfiIntent_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_decode_intent(
         FfiConverterData.lower(bytes),$0
     )
 })
@@ -13853,10 +14683,24 @@ public func decodeTransactionReference(bytes: Data)throws  -> FfiTransactionRefe
     )
 })
 }
+public func encodeActions(actions: FfiActions)throws  -> Data  {
+    return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_encode_actions(
+        FfiConverterTypeFfiActions_lower(actions),$0
+    )
+})
+}
 public func encodeAttachment(attachment: FfiAttachment)throws  -> Data  {
     return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
     uniffi_xmtpv3_fn_func_encode_attachment(
         FfiConverterTypeFfiAttachment_lower(attachment),$0
+    )
+})
+}
+public func encodeIntent(intent: FfiIntent)throws  -> Data  {
+    return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_encode_intent(
+        FfiConverterTypeFfiIntent_lower(intent),$0
     )
 })
 }
@@ -14090,7 +14934,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_create_client() != 54009) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_func_decode_actions() != 13209) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_func_decode_attachment() != 20456) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_decode_intent() != 24165) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_decode_multi_remote_attachment() != 59746) {
@@ -14111,7 +14961,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_decode_transaction_reference() != 25896) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_func_encode_actions() != 15414) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_func_encode_attachment() != 47054) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_encode_intent() != 64568) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_encode_multi_remote_attachment() != 28938) {
@@ -14408,6 +15264,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversations_stream_groups() != 11064) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_method_fficonversations_stream_message_deletions() != 61355) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_method_fficonversations_stream_messages() != 45879) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -14439,6 +15298,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffidecodedmessage_id() != 41676) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_method_ffidecodedmessage_inserted_at_ns() != 46609) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffidecodedmessage_kind() != 55657) {
@@ -14481,6 +15343,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffimessagecallback_on_close() != 9150) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_method_ffimessagedeletioncallback_on_message_deleted() != 4903) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffipreferencecallback_on_preference_update() != 19900) {
@@ -14647,6 +15512,7 @@ private let initializationResult: InitializationResult = {
     uniffiCallbackInitFfiConversationCallback()
     uniffiCallbackInitFfiInboxOwner()
     uniffiCallbackInitFfiMessageCallback()
+    uniffiCallbackInitFfiMessageDeletionCallback()
     uniffiCallbackInitFfiPreferenceCallback()
     return InitializationResult.ok
 }()

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.1-rc3"
+  spec.version      = "4.7.0-dev"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Upgrade to libxmtp 4.7.0-dev.f5bec47 and add sort and insertion-time filters to `Conversation.listMessages`, `Dm.listMessages`, and `Group.listMessages`
Add `sortBy`, `insertedAfterNs`, and `insertedBeforeNs` options to message listing APIs and expose `insertedAt`/`insertedAtNs` on decoded messages, backed by updated FFI bindings; bump package and podspec to the new binary release.

#### 📍Where to Start
Start with the new FFI options and enums in [xmtpv3.swift](https://github.com/xmtp/xmtp-ios/pull/621/files#diff-ec5124fcbfc3feda814ac7f92ee26fadffc570075abb8cc98d4a5de65a3c6df0), then review the `MessageSortBy` mapping in [DecodedMessage.swift](https://github.com/xmtp/xmtp-ios/pull/621/files#diff-96872bc3f891752324e391a9c2e014501ba307c648ebeb8b92509aaabb6bc049), and finally the updated list APIs in [Conversation.swift](https://github.com/xmtp/xmtp-ios/pull/621/files#diff-762ec7c3d6db84803270cf7dbc8426b70c8a716764921342fb61903384ee97d1), [Dm.swift](https://github.com/xmtp/xmtp-ios/pull/621/files#diff-c0f8e31a1bb57d01d49812b52b2db9459670c99095e042330e91a46b67c205c6), and [Group.swift](https://github.com/xmtp/xmtp-ios/pull/621/files#diff-1fffa18be2bf50b61ad120aae376479b48b94575bd42b97c772b8688acfe0f83).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized acd15ff. 8 files reviewed, 32 issues evaluated, 30 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Sources/XMTPiOS/Dm.swift — 0 comments posted, 6 evaluated, 6 filtered</summary>

- [line 338](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Dm.swift#L338): `limit` is accepted without validation and converted directly via `options.limit = Int64(limit)`. Negative, zero, or excessively large values are not guarded. If the FFI expects a positive bound, this can lead to undefined or incorrect runtime behavior. Add validation (e.g., clamp to a reasonable maximum and enforce `limit > 0`) and return an error for invalid values. <b>[ Out of scope ]</b>
- [line 373](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Dm.swift#L373): Messages that fail to decode are silently dropped due to `compactMap`, yielding partial results without any visibility or error. This is a data-conversion boundary and should either surface an error, return a separate list of failures, or explicitly log/flag the discarded items. As written, callers cannot distinguish between “no messages” and “messages existed but failed to decode.” A safer approach is to use `map` with explicit handling, or collect errors alongside successes. <b>[ Out of scope ]</b>
- [line 413](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Dm.swift#L413): `limit` is accepted as `Int?` and converted to `Int64` without validation in both `Dm.messagesWithReactions` and `Group.messagesWithReactions`. A negative `limit` or an extremely large value can be forwarded to FFI, potentially causing backend errors or unexpected behavior. Validate that `limit` is positive and within a sensible upper bound before assigning `options.limit`. <b>[ Low confidence ]</b>
- [line 417](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Dm.swift#L417): In `Dm.messagesWithReactions`, `options.deliveryStatus` is set via `deliveryStatus.toFfi()` while `Group.messagesWithReactions` maps `.all` to `nil` explicitly. This inconsistency can yield different filtering behavior between DMs and Groups when `deliveryStatus` is `.all` if `toFfi()` does not return `nil` for `.all`. This breaks contract parity across conversation types and can lead to unexpected result sets. <b>[ Low confidence ]</b>
- [line 419](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Dm.swift#L419): Both `Dm.messagesWithReactions` and `Group.messagesWithReactions` coerce a `nil` `direction` into `FfiDirection.descending`. If `nil` is intended to mean ‘unspecified’ (i.e., let backend default or preserve insertion order), this forces a sort and may change results ordering compared to passing `nil`. Given the parameter type is `SortDirection?`, callers can pass `nil`, but it never reaches FFI as `nil`. <b>[ Low confidence ]</b>
- [line 537](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Dm.swift#L537): Both `Dm.enrichedMessages` and `Group.enrichedMessages` return results using `compactMap` when constructing `DecodedMessageV2`, i.e., `return try await ffiConversation.findEnrichedMessages(opts: options).compactMap { ffiDecodedMessage in DecodedMessageV2(ffiMessage: ffiDecodedMessage) }` and similarly for `ffiGroup`. Using `compactMap` silently drops any messages whose decoding fails (where `DecodedMessageV2(...)` returns `nil`), causing silent data loss and potentially breaking caller expectations for message counts or completeness. If decoding can fail, this should surface an explicit error or include placeholders with status, rather than silently omitting entries. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Sources/XMTPiOS/Group.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 571](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Group.swift#L571): Using `compactMap` when mapping `ffiGroup.findMessages(opts:)` results to `DecodedMessage` silently drops any messages for which `DecodedMessage.create(ffiMessage:)` returns `nil`. This causes undetected data loss at the data-conversion boundary: callers get fewer messages without any error or indication that decoding failed for some items. If decoding can fail for legitimate inputs, you should either surface errors (e.g., return a result that includes failures), log/report them, or use a fall back to preserve contract visibility rather than silently filtering. <b>[ Low confidence ]</b>
- [line 724](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Group.swift#L724): In `Group.enrichedMessages`, the same silent data loss occurs due to `compactMap` when constructing `DecodedMessageV2`: `return try await ffiGroup.findEnrichedMessages(opts: options).compactMap { ffiDecodedMessage in DecodedMessageV2(ffiMessage: ffiDecodedMessage) }`. Any undecodable message is dropped without error or indication, potentially violating contract parity and caller expectations. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Sources/XMTPiOS/Libxmtp/DecodedMessage.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 202](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift#L202): In `public static func create(ffiMessage: FfiMessageWithReactions) -> DecodedMessage?`, a single failure while decoding any reaction causes the entire parent message to be dropped. Specifically, the `map` over `ffiMessage.reactions` at lines 216–226 throws if any `reaction` content fails to decode, which is then caught by the surrounding `do/catch` at lines 202–235, resulting in `return nil` for the whole message. This silently discards an otherwise valid `ffiMessage.message` and all successfully decoded reactions. A safer behavior would be to skip or flag only the malformed reactions and still return the parent `DecodedMessage` with the decodable subset of `childMessages`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 143](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift#L143): `mapContent(.custom)` calls `Client.codecRegistry.find(for: encoded.type)` even when `encoded.type` may be unset because `mapFfiEncodedContent(_:)` only sets `encoded.type` if `ffiContent.typeId` is non-nil. If `typeId` is nil, `encoded.type` may be a default/empty value or nil (depending on `EncodedContent`'s definition), which can cause a lookup failure or unexpected behavior (e.g., crash if `find` expects a valid type, or decoding with the wrong codec). Guard for missing `typeId` before attempting codec lookup, or provide a safe default/explicit error. <b>[ Low confidence ]</b>
- [line 230](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift#L230): `determineContentType(from:)` returns `ContentTypeText` for `.custom` when `typeId` is missing (lines 230–232). This mislabels content and creates contract mismatch: callers observing `contentType` will see `text` even though the body is `.custom`. It can lead to incorrect handling downstream and violates contract parity with `mapMessageBody(.custom)` which attempts codec-based decoding. <b>[ Low confidence ]</b>
- [line 239](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift#L239): `mapReaction(_:)` maps `action` as `reactionPayload.action == .added ? .added : .removed` (line 239). Any non-`.added` value, including potential `.unknown` or future enum cases, is coerced to `.removed`, silently misclassifying reactions. Use an explicit `switch` to preserve semantics and handle unknown values distinctly. <b>[ Low confidence ]</b>
- [line 292](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/DecodedMessageV2.swift#L292): `mapMultiRemoteAttachment(_:)` forwards `info.scheme` directly (line 292) while `mapRemoteAttachment(_:)` normalizes schemes via `mapRemoteAttachmentScheme(_:)` to ensure a valid enum with default `.https`. This inconsistency can yield invalid scheme values for multi-attachments (e.g., unknown strings), causing downstream errors or contract mismatch. Normalize `info.scheme` the same way. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Sources/XMTPiOS/Libxmtp/xmtpv3.swift — 0 comments posted, 9 evaluated, 8 filtered</summary>

- [line 2552](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L2552): `try! await uniffiRustCallAsync(...)` will crash the process if `uniffiRustCallAsync` throws (e.g., if the Rust future returns an error or `liftFunc` fails). This is a normal runtime path, not an initialization invariant, and no error handler is provided (`errorHandler: nil`). Replace `try!` with `try` and propagate/handle the error so the app does not terminate unexpectedly. <b>[ Low confidence ]</b>
- [line 2558](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L2558): Potential retain cycle/leak: the `callback` lowered via `FfiConverterTypeFfiMessageDeletionCallback_lower(callback)` may be retained by the underlying stream while the owner retains the returned `FfiStreamCloser`. If the `callback` strongly captures the owner, a reference cycle can form (`owner -> stream closer -> FFI-held callback -> owner`), preventing deallocation until the stream is explicitly closed. Document the capture guidelines or use weak/unowned captures and ensure the `FfiStreamCloser` is always closed to break the cycle. <b>[ Low confidence ]</b>
- [line 3653](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L3653): Potential resource/state leak: `lower(_:)` calls `handleMap.insert(obj:)` but this converter provides no corresponding removal/cleanup on any exit path (success or failure). Repeated calls will grow `handleMap` and retain `FfiMessageDeletionCallback` instances, with no visible lifecycle pairing. <b>[ Low confidence ]</b>
- [line 3654](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L3654): `lower(_:)` may crash via `fatalError("Cast to UnsafeMutableRawPointer failed")` if `UniffiHandleMap.insert(obj:)` returns a handle value of `0`, because `UnsafeMutableRawPointer(bitPattern: 0)` is `nil`. This occurs after the object is inserted into `handleMap`, leaving a mutated state with no paired cleanup on this path. <b>[ Low confidence ]</b>
- [line 3667](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L3667): `read(from:)` accepts any `UInt64` and converts it to a pointer, throwing only on `0`/nil. It then `lift`s the pointer without validating it corresponds to a previously inserted handle. If an invalid or stale handle value is provided (e.g., from Rust or corrupted data), subsequent use of the lifted callback may fail or crash due to missing map entries or misuse, with no graceful fallback here. <b>[ Low confidence ]</b>
- [line 6576](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L6576): `FfiDecodedMessageMetadata` declares `Hashable` conformance while providing a custom `==` that compares a specific subset of properties (`id`, `sentAtNs`, `kind`, `senderInstallationId`, `senderInboxId`, `contentType`, `conversationId`, `insertedAtNs`). If `Hashable` is synthesized (no explicit `hash(into:)` present), the synthesized hash will include all stored properties. This can violate the Hashable contract if there are stored properties not covered by `==`: two instances may be considered equal by `==` yet produce different hash values, causing incorrect behavior in hashed collections (e.g., `Set`, `Dictionary`). To fix, either ensure `==` and `hash(into:)` operate over the exact same set of properties, or allow the compiler to synthesize both Equatable and Hashable using identical properties. <b>[ Low confidence ]</b>
- [line 6622](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L6622): Parsing advances `buf.offset` incrementally via multiple `read(from: &buf)` calls. If any intermediate read fails (e.g., due to insufficient data or malformed field), the function throws but leaves `buf.offset` partially advanced, corrupting the caller’s parsing state. To preserve invariants, parsing must be transactional: either use a local copy of `offset` and commit only on success, or ensure each `read` returns decoded data without mutating `buf` until the whole decode succeeds. <b>[ Low confidence ]</b>
- [line 6632](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOS/Libxmtp/xmtpv3.swift#L6632): The newly added field `insertedAtNs: FfiConverterInt64.read(from: &buf)` changes the decode contract by requiring an additional trailing `Int64`. If older serialized payloads omit this field, decoding will attempt to read past the available data and throw, breaking backward compatibility. There is no versioning, presence flag, or default-value handling to safely decode older messages. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift — 1 comment posted, 10 evaluated, 9 filtered</summary>

- [line 101](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L101): Potential integer overflow when computing `reader.offset + count`. If the sum overflows `Int`, the program traps at runtime during the addition, prior to any guard or error handling. <b>[ Low confidence ]</b>
- [line 101](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L101): `count` is not validated to be non-negative before constructing `range = reader.offset ..< (reader.offset + count)`. If `count < 0`, creating this range will trap at runtime due to an invalid range (upperBound < lowerBound) before the guard executes. <b>[ Low confidence ]</b>
- [line 102](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L102): `reader.offset` is not validated to be within `0...reader.data.count`. If `offset` is negative, the guard `reader.data.count >= range.upperBound` can still pass, and `Data.copyBytes(to:from:)` will be invoked with a range whose lowerBound is < 0, causing a runtime precondition failure. <b>[ Low confidence ]</b>
- [line 302](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L302): In `CALL_ERROR` when an `errorHandler` is provided, the code throws the handler's error without deallocating `callStatus.errorBuf`. If the handler does not explicitly take ownership and deallocate the buffer, this causes a memory leak. To be safe, either always deallocate after the handler converts the buffer (e.g., by ensuring the handler consumes and deallocates), or deallocate here after obtaining the error value. <b>[ Low confidence ]</b>
- [line 313](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L313): In `CALL_UNEXPECTED_ERROR` when `callStatus.errorBuf.len > 0`, the code throws `UniffiInternalError.rustPanic(FfiConverterString.lift(callStatus.errorBuf))` without explicitly deallocating `errorBuf`. If `FfiConverterString.lift` does not deallocate the buffer or if it throws before deallocation, the buffer leaks. Ensure `errorBuf` is always freed exactly once on all exit paths, including when `lift` throws (e.g., by first converting safely, then deallocating in a `defer`, and falling back to a default message if conversion fails). <b>[ Low confidence ]</b>
- [line 314](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L314): In `CALL_UNEXPECTED_ERROR` when converting the panic message, `FfiConverterString.lift(callStatus.errorBuf)` may throw (e.g., invalid encoding). The current code propagates that conversion error instead of reliably surfacing a Rust panic. This changes the externally visible error contract and may hide the original panic. Provide a fallback: if conversion fails, deallocate the buffer and throw `UniffiInternalError.rustPanic("Rust panic")` or a safe-decoded message. <b>[ Low confidence ]</b>
- [line 323](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L323): In the `default` case, the code throws `UniffiInternalError.unexpectedRustCallStatusCode` without deallocating `callStatus.errorBuf`. If the buffer was populated by the callee, this results in a memory leak. Always free the buffer before throwing on unknown status codes. <b>[ Low confidence ]</b>
- [line 334](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L334): On the success path, `callStatus.pointee.code` is never set to a success value (e.g., `CALL_SUCCESS`). If the caller reuses a `RustCallStatus` instance from a prior error, the stale `code` can remain non-success, causing the FFI caller to misinterpret this call as an error even though it succeeded. <b>[ Low confidence ]</b>
- [line 334](https://github.com/xmtp/xmtp-ios/blob/acd15ff958587db284f0b66de11e060d1e6d50bb/Sources/XMTPiOSDynamic/Libxmtp/xmtpv3.swift#L334): On the success path, `callStatus.pointee.errorBuf` is not cleared/reset. If a previous error populated `errorBuf`, the stale pointer/message can persist on success, leading to incorrect error reporting and potential memory/resource leaks if the caller frees the stale buffer based on the non-success state. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->