### PR TITLE
Release v1.6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.1-rc4.294bc52/LibXMTPSwiftFFI.zip",
-			checksum: "07f632d22d6c4f08ca43c087effad4f4adddff82ee609221d68a153bf0b9deb3"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.1.4d46a4a/LibXMTPSwiftFFI.zip",
+			checksum: "a3bc53c3bfec02fb52064c0576fa0633bf3bd60fc61d8fd5f6b80355763f91d4"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.1-rc4"
+  spec.version      = "4.6.1"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 4.7.0-dev.4d46a4a.

Changes:
- Updated XMTP.podspec version to 4.7.0-dev.4d46a4a
- Updated static binary (LibXMTPSwiftFFI) URL and checksum in Package.swift
- Updated dynamic binary (LibXMTPSwiftFFIDynamic) URL and checksum in Package.swift
- Updated Swift source files (xmtpv3.swift) for both static and dynamic bindings

Base branch: main