### PR TITLE
Update to libxmtp 1.6.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
 	targets: [
 		.binaryTarget(
 			name: "LibXMTPSwiftFFI",
-			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.8.554e05e/LibXMTPSwiftFFI.zip",
-			checksum: "1aa425ee071462c79aa83c6a1287f201dcfa7cce376e9bbe39e3988694698866"
+			url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.6.9.13f093e/LibXMTPSwiftFFI.zip",
+			checksum: "3c2d4e2b9203323e5767a6054a52d471d1abf8aa04c0c68ab704b41600be2829"
 		),
 		.target(
 			name: "XMTPiOS",

--- a/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -15656,6 +15656,13 @@ public func decodeIntent(bytes: Data)throws  -> FfiIntent  {
     )
 })
 }
+public func decodeLeaveRequest(bytes: Data)throws  -> FfiLeaveRequest  {
+    return try  FfiConverterTypeFfiLeaveRequest_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_decode_leave_request(
+        FfiConverterData.lower(bytes),$0
+    )
+})
+}
 public func decodeMultiRemoteAttachment(bytes: Data)throws  -> FfiMultiRemoteAttachment  {
     return try  FfiConverterTypeFfiMultiRemoteAttachment_lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
     uniffi_xmtpv3_fn_func_decode_multi_remote_attachment(
@@ -15730,6 +15737,13 @@ public func encodeIntent(intent: FfiIntent)throws  -> Data  {
     return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
     uniffi_xmtpv3_fn_func_encode_intent(
         FfiConverterTypeFfiIntent_lower(intent),$0
+    )
+})
+}
+public func encodeLeaveRequest(request: FfiLeaveRequest)throws  -> Data  {
+    return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeGenericError_lift) {
+    uniffi_xmtpv3_fn_func_encode_leave_request(
+        FfiConverterTypeFfiLeaveRequest_lower(request),$0
     )
 })
 }
@@ -15991,6 +16005,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_decode_intent() != 24165) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xmtpv3_checksum_func_decode_leave_request() != 20951) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xmtpv3_checksum_func_decode_multi_remote_attachment() != 59746) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -16022,6 +16039,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_encode_intent() != 64568) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_encode_leave_request() != 28716) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_encode_multi_remote_attachment() != 28938) {

--- a/XMTP.podspec
+++ b/XMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "XMTP"
-  spec.version      = "4.6.8"
+  spec.version      = "4.6.9"
 
   spec.summary      = "XMTP SDK Cocoapod"
 


### PR DESCRIPTION
This PR updates the iOS bindings to libxmtp version 1.6.9.

Changes:
- Updated XMTP.podspec version to 1.6.9
- Updated binary (LibXMTPSwiftFFI) URL and checksum in Package.swift
- Updated Swift source file (xmtpv3.swift)

Base branch: main