### PR TITLE
Remove unneeded `@testable` imports

### DIFF
--- a/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -108,4 +108,15 @@
 			try await Fixtures(clientOptions: clientOptions)
 		}
 	}
+
+// INFO: - copied from Date.swift
+public extension Date {
+	var millisecondsSinceEpoch: Double {
+		timeIntervalSince1970 * 1000
+	}
+	
+	init(millisecondsSinceEpoch: Int64) {
+		self.init(timeIntervalSince1970: TimeInterval(millisecondsSinceEpoch / 1_000_000_000))
+	}
+}
 #endif

--- a/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -12,6 +12,10 @@
 		_env("XMTP_NODE_ADDRESS")
 	}
 
+	public func generateRandomBytes(count: Int) -> Data {
+		Data((0..<count).map { _ in UInt8.random(in: 0...255) })
+	}
+
 	public func getHistorySyncUrlFromEnvironment() -> String? {
 		_env("XMTP_HISTORY_SERVER_ADDRESS")
 	}
@@ -58,7 +62,7 @@
 			caro = try PrivateKey.generate()
 			davon = try PrivateKey.generate()
 
-			let key = Data((0 ..< 32).map { _ in UInt8.random(in: 0 ... 255) })
+			let key = generateRandomBytes(count: 32)
 			let clientOptions = ClientOptions(
 				api: clientOptions,
 				dbEncryptionKey: key

--- a/Tests/XMTPTests/ArchiveTests.swift
+++ b/Tests/XMTPTests/ArchiveTests.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
+import XMTPTestHelpers
 
 @available(iOS 15, *)
 class ArchiveTests: XCTestCase {
@@ -18,8 +19,8 @@ class ArchiveTests: XCTestCase {
 
 	func testClientArchives() async throws {
 		let fixtures = try await fixtures()
-		let key = try Crypto.secureRandomBytes(count: 32)
-		let encryptionKey = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
+		let encryptionKey = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 
 		let alixClient = try await Client.create(
@@ -107,8 +108,8 @@ class ArchiveTests: XCTestCase {
 
 	func testInActiveDmsStitchIfDuplicated() async throws {
 		let fixtures = try await fixtures()
-		let key = try Crypto.secureRandomBytes(count: 32)
-		let encryptionKey = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
+		let encryptionKey = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 
 		let alixClient = try await Client.create(
@@ -183,7 +184,7 @@ class ArchiveTests: XCTestCase {
 
 	func testImportArchiveWorksEvenOnFullDatabase() async throws {
 		let fixtures = try await fixtures()
-		let encryptionKey = try Crypto.secureRandomBytes(count: 32)
+		let encryptionKey = generateRandomBytes(count: 32)
 		let allPath = "xmtp_test1/testAll.zstd"
 
 		let group = try await fixtures.alixClient.conversations.newGroup(with: [

--- a/Tests/XMTPTests/AttachmentTests.swift
+++ b/Tests/XMTPTests/AttachmentTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 
 @available(iOS 15, *)
 class AttachmentsTests: XCTestCase {

--- a/Tests/XMTPTests/ClientTests.swift
+++ b/Tests/XMTPTests/ClientTests.swift
@@ -11,7 +11,7 @@ class ClientTests: XCTestCase {
 	}
 
 	func testTakesAWallet() async throws {
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let clientOptions = ClientOptions(
 			api: ClientOptions.Api(
 				env: XMTPEnvironment.local, isSecure: XMTPEnvironment.local.isSecure,
@@ -28,7 +28,7 @@ class ClientTests: XCTestCase {
 
 	func testPassingEncryptionKey() async throws {
 		let bo = try PrivateKey.generate()
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 
 		let client = try await Client.create(
 			account: bo,
@@ -92,7 +92,7 @@ class ClientTests: XCTestCase {
 	}
 
 	func testCanDeleteDatabase() async throws {
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let bo = try PrivateKey.generate()
 		let alix = try PrivateKey.generate()
 		var boClient = try await Client.create(

--- a/Tests/XMTPTests/ConversationTests.swift
+++ b/Tests/XMTPTests/ConversationTests.swift
@@ -1,6 +1,6 @@
 import CryptoKit
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)
@@ -213,7 +213,7 @@ class ConversationTests: XCTestCase {
 	}
 
 	func testReturnsAllHMACKeys() async throws {
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let opts = ClientOptions(
 			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure),
 			dbEncryptionKey: key
@@ -485,7 +485,7 @@ class ConversationTests: XCTestCase {
 	}
 
 	func testReturnsAllTopics() async throws {
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let opts = ClientOptions(
 			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure),
 			dbEncryptionKey: key

--- a/Tests/XMTPTests/DeleteMessageCodecTests.swift
+++ b/Tests/XMTPTests/DeleteMessageCodecTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)

--- a/Tests/XMTPTests/DeleteMessageTests.swift
+++ b/Tests/XMTPTests/DeleteMessageTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)

--- a/Tests/XMTPTests/DmTests.swift
+++ b/Tests/XMTPTests/DmTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)
@@ -104,14 +104,14 @@ class DmTests: XCTestCase {
 
 		do {
 			_ = try await fixtures.boClient.conversations.newConversation(
-				with: fixtures.alix.walletAddress
+				with: fixtures.alix.identity.identifier
 			)
 			XCTFail("Did not throw error")
 		} catch {
 			if case let ClientError.invalidInboxId(message) = error {
 				XCTAssertEqual(
 					message.lowercased(),
-					fixtures.alix.walletAddress.lowercased()
+					fixtures.alix.identity.identifier.lowercased()
 				)
 			} else {
 				XCTFail("Did not throw correct error")

--- a/Tests/XMTPTests/EnrichedMessagesTests.swift
+++ b/Tests/XMTPTests/EnrichedMessagesTests.swift
@@ -1,6 +1,6 @@
 import CryptoKit
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)

--- a/Tests/XMTPTests/GroupTests.swift
+++ b/Tests/XMTPTests/GroupTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 func assertThrowsAsyncError<T>(
@@ -103,7 +103,7 @@ class GroupTests: XCTestCase {
 			.newGroupWithIdentities(
 				with: [
 					PublicIdentity(
-						kind: .ethereum, identifier: fixtures.alix.walletAddress
+						kind: .ethereum, identifier: fixtures.alix.identity.identifier
 					),
 				]
 			)
@@ -390,12 +390,12 @@ class GroupTests: XCTestCase {
 
 		do {
 			_ = try await fixtures.boClient.conversations.newGroup(with: [
-				fixtures.alix.walletAddress,
+				fixtures.alix.identity.identifier,
 			])
 			XCTFail("Did not throw error")
 		} catch {
 			if case let ClientError.invalidInboxId(message) = error {
-				XCTAssertEqual(message.lowercased(), fixtures.alix.walletAddress.lowercased())
+				XCTAssertEqual(message.lowercased(), fixtures.alix.identity.identifier.lowercased())
 			} else {
 				XCTFail("Did not throw correct error")
 			}
@@ -406,22 +406,22 @@ class GroupTests: XCTestCase {
 		])
 
 		do {
-			_ = try await group.addMembers(inboxIds: [fixtures.caro.walletAddress])
+			_ = try await group.addMembers(inboxIds: [fixtures.caro.identity.identifier])
 			XCTFail("Did not throw error")
 		} catch {
 			if case let ClientError.invalidInboxId(message) = error {
-				XCTAssertEqual(message.lowercased(), fixtures.caro.walletAddress.lowercased())
+				XCTAssertEqual(message.lowercased(), fixtures.caro.identity.identifier.lowercased())
 			} else {
 				XCTFail("Did not throw correct error")
 			}
 		}
 
 		do {
-			_ = try await group.removeMembers(inboxIds: [fixtures.alix.walletAddress])
+			_ = try await group.removeMembers(inboxIds: [fixtures.alix.identity.identifier])
 			XCTFail("Did not throw error")
 		} catch {
 			if case let ClientError.invalidInboxId(message) = error {
-				XCTAssertEqual(message.lowercased(), fixtures.alix.walletAddress.lowercased())
+				XCTAssertEqual(message.lowercased(), fixtures.alix.identity.identifier.lowercased())
 			} else {
 				XCTFail("Did not throw correct error")
 			}
@@ -438,7 +438,7 @@ class GroupTests: XCTestCase {
 
 		let result = try await group.addMembersByIdentity(identities: [
 			PublicIdentity(
-				kind: .ethereum, identifier: fixtures.caro.walletAddress
+				kind: .ethereum, identifier: fixtures.caro.identity.identifier
 			),
 		])
 
@@ -557,14 +557,14 @@ class GroupTests: XCTestCase {
 		let cannotMessage = try await fixtures.alixClient.canMessage(
 			identities: [
 				PublicIdentity(
-					kind: .ethereum, identifier: notOnNetwork.walletAddress
+					kind: .ethereum, identifier: notOnNetwork.identity.identifier
 				),
 				fixtures.bo.identity,
 			]
 		)
 		XCTAssert(canMessage)
 		XCTAssert(
-			!(cannotMessage[notOnNetwork.walletAddress.lowercased()] ?? true)
+			!(cannotMessage[notOnNetwork.identity.identifier.lowercased()] ?? true)
 		)
 		try fixtures.cleanUpDatabases()
 	}
@@ -661,7 +661,7 @@ class GroupTests: XCTestCase {
 			_ = try await fixtures.alixClient.conversations
 				.newGroupWithIdentities(with: [
 					PublicIdentity(
-						kind: .ethereum, identifier: nonRegistered.walletAddress
+						kind: .ethereum, identifier: nonRegistered.identity.identifier
 					),
 				])
 

--- a/Tests/XMTPTests/HistorySyncTests.swift
+++ b/Tests/XMTPTests/HistorySyncTests.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
+import XMTPTestHelpers
 
 @available(iOS 15, *)
 class HistorySyncTests: XCTestCase {
@@ -19,7 +20,7 @@ class HistorySyncTests: XCTestCase {
 	func testSyncConsent() async throws {
 		let fixtures = try await fixtures()
 
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let alixClient = try await Client.create(
 			account: alix,
@@ -82,7 +83,7 @@ class HistorySyncTests: XCTestCase {
 	func testSyncMessages() async throws {
 		let fixtures = try await fixtures()
 
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let alixClient = try await Client.create(
 			account: alix,
@@ -134,7 +135,7 @@ class HistorySyncTests: XCTestCase {
 	func testStreamConsent() async throws {
 		let fixtures = try await fixtures()
 
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 
 		let alixClient = try await Client.create(
@@ -196,7 +197,7 @@ class HistorySyncTests: XCTestCase {
 	}
 
 	func testStreamPrivatePreferences() async throws {
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let alixClient = try await Client.create(
 			account: alix,
@@ -238,7 +239,7 @@ class HistorySyncTests: XCTestCase {
 	func testDisablingHistoryTransferStillSyncsLocalState() async throws {
 		let fixtures = try await fixtures()
 
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let alixClient = try await Client.create(
 			account: alix,
@@ -301,7 +302,7 @@ class HistorySyncTests: XCTestCase {
 	func testDisablingHistoryTransferDoesNotTransfer() async throws {
 		let fixtures = try await fixtures()
 
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let alixClient = try await Client.create(
 			account: alix,

--- a/Tests/XMTPTests/LeaveRequestTests.swift
+++ b/Tests/XMTPTests/LeaveRequestTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 16, *)

--- a/Tests/XMTPTests/PerformanceTests.swift
+++ b/Tests/XMTPTests/PerformanceTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 import XMTPTestHelpers
 
 @available(iOS 15, *)
@@ -166,7 +166,7 @@ class PerformanceTests: XCTestCase {
 	}
 
 	func testCreatesADevClientPerformance() async throws {
-		let key = try Crypto.secureRandomBytes(count: 32)
+		let key = generateRandomBytes(count: 32)
 		let fakeWallet = try PrivateKey.generate()
 
 		// Measure time to create the client

--- a/Tests/XMTPTests/ReactionTests.swift
+++ b/Tests/XMTPTests/ReactionTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 
 @available(iOS 15, *)
 class ReactionTests: XCTestCase {

--- a/Tests/XMTPTests/ReadReceiptTests.swift
+++ b/Tests/XMTPTests/ReadReceiptTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 
 @available(iOS 15, *)
 class ReadReceiptTests: XCTestCase {

--- a/Tests/XMTPTests/ReplyTests.swift
+++ b/Tests/XMTPTests/ReplyTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 
 @available(iOS 15, *)
 class ReplyTests: XCTestCase {

--- a/Tests/XMTPTests/TransactionReferencesTests.swift
+++ b/Tests/XMTPTests/TransactionReferencesTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import XMTPiOS
+import XMTPiOS
 
 @available(iOS 15, *)
 final class TransactionReferenceTests: XCTestCase {


### PR DESCRIPTION
## Introduction 📟
<!-- Brief explanation of the problem to be solved / bug to be fixed. -->
Replaces `@testable import XMTPiOS` with `import XMTPiOS` where possible; so tests are testing the public SDK API instead of internal fields/functions

## Purpose ℹ️ 
<!-- What is the goal of the proposed change? -->
Test the public API instead of internal fields/functions

## Scope 🔭
<!-- What is the technical scope of the changes? -->
Test cases

<!-- Beginning of comment block
From this point on, all the following titles are optional.
Move the ones you need out of the comment block and delete the rest of the template.
There is a table example included for screenshots

## Out of Scope ⚔️

## Testing 🧪
Modified tests have the same behavior (pass if they were passing before, fail in the same manner that they were failing before)

## TODOs ☑️
- [ ] [Change log] updated or ignored

## Discussion 🎙

End of comment block -->
